### PR TITLE
chore: collect historical repo traffic metrics

### DIFF
--- a/.github/workflows/repo-traffic.yml
+++ b/.github/workflows/repo-traffic.yml
@@ -1,0 +1,40 @@
+# An action to collect GitHub repository traffic stats and 
+# upload them to S3 for building up a long-term history,
+# because of the 14-day limitation:
+# https://github.com/isaacs/github/issues/399
+on:
+  schedule: 
+    - cron: "0 * * * *"
+      
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    
+jobs:
+  # This workflow contains a single job called "traffic"
+  traffic:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    
+    # Calculates traffic and clones and stores in CSV file
+    - name: Repository Traffic 
+      uses: sangonzal/repository-traffic-action@v0.1.3
+      env:
+        TRAFFIC_ACTION_TOKEN: ${{ secrets.TRAFFIC_ACTION_TOKEN }} 
+     
+     # Upload to S3
+    - name: S3 Sync
+      uses: jakejarvis/s3-sync-action@v0.5.1
+      with:
+        args: --follow-symlinks --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SOURCE_DIR: 'traffic'
+        DEST_DIR: 'opstrace'
+


### PR DESCRIPTION
GitHub traffic stats are only persisted for 14 days.  Ideally we would persist the entire history of these stats for use in the future.  

This PR creates a GitHub Action that will do just that, storing the results in S3 for later processing.

Reference:  https://github.com/sangonzal/repository-traffic-action