### PR TITLE
chore: ignore .js files in language breakdown (it's misleading)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+packages/app/src/client/components/Editor/lib/workers/modulescript/lib/typescriptServices.js linguist-vendored


### PR DESCRIPTION
See #2.