### PR TITLE
chore: enable GKE workload identity

### DIFF
--- a/lib/gcp/src/iam.ts
+++ b/lib/gcp/src/iam.ts
@@ -54,7 +54,7 @@ async function getServiceAccount({
   } catch (e) {
     // a 404 is expected if the resource does not exist,
     // otherwise throw the error back
-    if (e.code === undefined || e.code !== "404") {
+    if (e.code === undefined || e.code !== 404) {
       throw e;
     }
   }
@@ -94,7 +94,7 @@ async function getIAMPolicy({
     });
     return resp.data;
   } catch (e) {
-    if (e.code === undefined || e.code !== "404") {
+    if (e.code === undefined || e.code !== 404) {
       throw e;
     }
   }

--- a/lib/gcp/src/iam.ts
+++ b/lib/gcp/src/iam.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { SECOND } from "@opstrace/utils";
+import { log, SECOND } from "@opstrace/utils";
 import { google, iam_v1 } from "googleapis";
 import { delay, call } from "redux-saga/effects";
 
 const iam = google.iam("v1");
+const resourcemanager = google.cloudresourcemanager("v1");
 
 async function authorize() {
   // ensure we google sdk authorization is setup
@@ -35,7 +36,7 @@ async function getServiceAccount({
 }: {
   projectId: string;
   name: string;
-}): Promise<iam_v1.Schema$ServiceAccount | false> {
+}): Promise<iam_v1.Schema$ServiceAccount | undefined> {
   // https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts/get
   // Required. The resource name of the service account in the following
   // format: projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}. Using - as a
@@ -46,7 +47,6 @@ async function getServiceAccount({
   // We use the email address because we don't know the uniqueId ahead of
   // time.
   const resource = `projects/${projectId}/serviceAccounts/${name}@${projectId}.iam.gserviceaccount.com`;
-
   try {
     await authorize();
     const resp = await iam.projects.serviceAccounts.get({ name: resource });
@@ -54,12 +54,12 @@ async function getServiceAccount({
   } catch (e) {
     // a 404 is expected if the resource does not exist,
     // otherwise throw the error back
-    if (!e.code || (e.code && e.code !== "404")) {
+    if (e.code === undefined || e.code !== "404") {
       throw e;
     }
   }
 
-  return false;
+  return undefined;
 }
 
 async function createServiceAccount({
@@ -68,14 +68,138 @@ async function createServiceAccount({
 }: {
   accountId: string;
   projectId: string;
-}) {
+}): Promise<iam_v1.Schema$ServiceAccount> {
   try {
     await authorize();
     const params = {
       name: `projects/${projectId}`,
       accountId: accountId
     };
-    iam.projects.serviceAccounts.create(params);
+    const sa = await iam.projects.serviceAccounts.create(params);
+    return sa.data;
+  } catch (e) {
+    throw e;
+  }
+}
+
+async function getIAMPolicy({
+  sa
+}: {
+  sa: iam_v1.Schema$ServiceAccount;
+}): Promise<iam_v1.Schema$Policy | undefined> {
+  try {
+    await authorize();
+    const resp = await resourcemanager.projects.getIamPolicy({
+      resource: sa.projectId!
+    });
+    return resp.data;
+  } catch (e) {
+    if (e.code === undefined || e.code !== "404") {
+      throw e;
+    }
+  }
+  return undefined;
+}
+
+// We can't add a policy binding. We have to fetch the project iam policy
+// bindings and add the one we want and send the full policy again.
+//
+// https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy
+//
+// https://stackoverflow.com/questions/42564112/adding-roles-to-service-accounts-on-google-cloud-platform-using-rest-api
+// https://github.com/hashicorp/terraform-provider-google/issues/1225
+//
+async function ensurePolicyBindingExists({
+  sa,
+  role
+}: {
+  sa: iam_v1.Schema$ServiceAccount;
+  role: string;
+}) {
+  try {
+    await authorize();
+
+    log.debug(`apply policy to sa: ${JSON.stringify(sa, null, 2)}`);
+
+    let policy = (await getIAMPolicy({ sa })) ?? {};
+
+    // handle empty policy bindings
+    if (policy.bindings === undefined) {
+      policy.bindings = [];
+    }
+
+    const member = `serviceAccount:${sa.email!}`;
+
+    let done = false;
+    for (const b of policy.bindings!) {
+      if (b.role! === role) {
+        for (const m of b.members!) {
+          if (m === member) {
+            log.debug("policy is already set, nothing to do");
+            done = true;
+          }
+        }
+        if (!done) {
+          log.debug("adding member to existing role");
+          done = true;
+          if (b.members === undefined) {
+            b.members = [];
+          }
+          b.members!.push(member);
+        }
+      }
+    }
+
+    // role does not exist in policy so add it now
+    if (!done) {
+      log.debug("adding new policy binding");
+      policy.bindings!.push({ members: [member], role: role });
+    }
+
+    //
+    // https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy
+    //
+    const request: iam_v1.Params$Resource$Projects$Serviceaccounts$Setiampolicy = {
+      resource: sa.projectId!,
+      requestBody: {
+        policy: policy
+      }
+    };
+    log.debug(`policy request: ${JSON.stringify(request, null, 2)}`);
+
+    await resourcemanager.projects.setIamPolicy(request);
+  } catch (e) {
+    log.debug(`failed to apply policy: ${JSON.stringify(e, null, 2)}`);
+    throw e;
+  }
+}
+
+// We manage this service account so just go ahead and set the required policy.
+// Otherwise we have to fetch the policies, update it (if necessary) and send it
+// back again.
+async function ensureGSAKSALinkExists({
+  kubernetesServiceAccount,
+  sa
+}: {
+  kubernetesServiceAccount: string;
+  sa: iam_v1.Schema$ServiceAccount;
+}) {
+  try {
+    await authorize();
+
+    const role = "roles/iam.workloadIdentityUser";
+    const member = `serviceAccount:${sa.projectId!}.svc.id.goog[${kubernetesServiceAccount}]`;
+
+    const policy = {
+      bindings: [{ members: [member], role: role }]
+    };
+
+    await iam.projects.serviceAccounts.setIamPolicy({
+      resource: sa.name!,
+      requestBody: {
+        policy: policy
+      }
+    });
   } catch (e) {
     throw e;
   }
@@ -83,22 +207,28 @@ async function createServiceAccount({
 
 export function* ensureServiceAccountExists({
   name,
-  projectId
+  projectId,
+  role,
+  kubernetesServiceAccount
 }: {
   name: string;
   projectId: string;
+  role: string;
+  kubernetesServiceAccount: string;
 }): Generator<any, string, any> {
   while (true) {
-    let sa = yield call(getServiceAccount, { projectId, name });
-    if (sa.email !== undefined) {
-      return sa.email;
-    }
     try {
-      sa = yield call(createServiceAccount, { projectId, accountId: name });
-      if (sa.email !== undefined) {
-        return sa.email;
-      }
+      let sa =
+        (yield call(getServiceAccount, { projectId, name })) ??
+        (yield call(createServiceAccount, { projectId, accountId: name }));
+
+      yield call(ensurePolicyBindingExists, { sa, role });
+      yield call(ensureGSAKSALinkExists, { kubernetesServiceAccount, sa });
+      return sa.email;
     } catch (e) {
+      log.error(
+        `caught error and will retry later: ${JSON.stringify(e, null, 2)}`
+      );
       yield delay(5 * SECOND);
     }
   }

--- a/lib/gcp/src/iam.ts
+++ b/lib/gcp/src/iam.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SECOND } from "@opstrace/utils";
+import { google, iam_v1 } from "googleapis";
+import { delay, call } from "redux-saga/effects";
+
+const iam = google.iam("v1");
+
+async function authorize() {
+  // ensure we google sdk authorization is setup
+  const auth = new google.auth.GoogleAuth({
+    scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+  });
+  const authClient = await auth.getClient();
+  google.options({ auth: authClient });
+}
+
+async function getServiceAccount({
+  projectId,
+  name
+}: {
+  projectId: string;
+  name: string;
+}): Promise<iam_v1.Schema$ServiceAccount | false> {
+  // https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts/get
+  // Required. The resource name of the service account in the following
+  // format: projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}. Using - as a
+  // wildcard for the PROJECT_ID will infer the project from the account. The
+  // ACCOUNT value can be the email address or the uniqueId of the service
+  // account.
+  //
+  // We use the email address because we don't know the uniqueId ahead of
+  // time.
+  const resource = `projects/${projectId}/serviceAccounts/${name}@${projectId}.iam.gserviceaccount.com`;
+
+  try {
+    await authorize();
+    const resp = await iam.projects.serviceAccounts.get({ name: resource });
+    return resp.data;
+  } catch (e) {
+    // a 404 is expected if the resource does not exist,
+    // otherwise throw the error back
+    if (!e.code || (e.code && e.code !== "404")) {
+      throw e;
+    }
+  }
+
+  return false;
+}
+
+async function createServiceAccount({
+  accountId,
+  projectId
+}: {
+  accountId: string;
+  projectId: string;
+}) {
+  try {
+    await authorize();
+    const params = {
+      name: `projects/${projectId}`,
+      accountId: accountId
+    };
+    iam.projects.serviceAccounts.create(params);
+  } catch (e) {
+    throw e;
+  }
+}
+
+export function* ensureServiceAccountExists({
+  name,
+  projectId
+}: {
+  name: string;
+  projectId: string;
+}): Generator<any, string, any> {
+  while (true) {
+    let sa = yield call(getServiceAccount, { projectId, name });
+    if (sa.email !== undefined) {
+      return sa.email;
+    }
+    try {
+      sa = yield call(createServiceAccount, { projectId, accountId: name });
+      if (sa.email !== undefined) {
+        return sa.email;
+      }
+    } catch (e) {
+      yield delay(5 * SECOND);
+    }
+  }
+}

--- a/lib/gcp/src/index.ts
+++ b/lib/gcp/src/index.ts
@@ -16,6 +16,7 @@
 
 export * from "./bucket";
 export * from "./cluster";
+export * from "./iam";
 export * from "./NATGateway";
 export * from "./network";
 export * from "./subnetworks";

--- a/lib/gcp/src/types.ts
+++ b/lib/gcp/src/types.ts
@@ -21,7 +21,8 @@ import { CredentialBody } from "google-auth-library";
 export const gcpConfigSchema = yup.object({
   projectId: yup.string(),
   certManagerServiceAccount: yup.string(),
-  externalDNSServiceAccount: yup.string()
+  externalDNSServiceAccount: yup.string(),
+  cortexServiceAccount: yup.string()
 });
 
 export type GCPConfig = yup.InferType<typeof gcpConfigSchema>;

--- a/lib/gcp/src/types.ts
+++ b/lib/gcp/src/types.ts
@@ -371,6 +371,12 @@ export const gkeCluster = t.partial(
         enabled: t.boolean
       }).props
     ),
+    // https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters
+    workloadIdentityConfig: t.partial(
+      t.interface({
+        workloadPool: t.string
+      }).props
+    ),
     selfLink: t.string,
     endpoint: t.string,
     initialClusterVersion: t.string,

--- a/lib/gcp/src/types.ts
+++ b/lib/gcp/src/types.ts
@@ -22,7 +22,8 @@ export const gcpConfigSchema = yup.object({
   projectId: yup.string(),
   certManagerServiceAccount: yup.string(),
   externalDNSServiceAccount: yup.string(),
-  cortexServiceAccount: yup.string()
+  cortexServiceAccount: yup.string(),
+  lokiServiceAccount: yup.string()
 });
 
 export type GCPConfig = yup.InferType<typeof gcpConfigSchema>;

--- a/lib/gcp/src/types.ts
+++ b/lib/gcp/src/types.ts
@@ -20,7 +20,8 @@ import { CredentialBody } from "google-auth-library";
 
 export const gcpConfigSchema = yup.object({
   projectId: yup.string(),
-  certManagerServiceAccount: yup.string()
+  certManagerServiceAccount: yup.string(),
+  externalDNSServiceAccount: yup.string()
 });
 
 export type GCPConfig = yup.InferType<typeof gcpConfigSchema>;

--- a/lib/gcp/src/types.ts
+++ b/lib/gcp/src/types.ts
@@ -18,6 +18,13 @@ import * as yup from "yup";
 import * as t from "io-ts";
 import { CredentialBody } from "google-auth-library";
 
+export const gcpConfigSchema = yup.object({
+  projectId: yup.string(),
+  certManagerServiceAccount: yup.string()
+});
+
+export type GCPConfig = yup.InferType<typeof gcpConfigSchema>;
+
 export const serviceAccountSchema = yup
   .object({
     auth_uri: yup.string().required(),

--- a/lib/gcp/src/util.ts
+++ b/lib/gcp/src/util.ts
@@ -67,3 +67,16 @@ export const getValidatedGCPAuthOptionsFromFile = (
   };
   return gcpAuthOptions;
 };
+
+let certManagerSA: string | undefined;
+
+export function setCertManagerServiceAccount(sa: string) {
+  certManagerSA = sa;
+}
+
+export function getCertManagerServiceAccount() {
+  if (certManagerSA === undefined) {
+    throw new Error("call setCertManagerServiceAccount() first");
+  }
+  return certManagerSA;
+}

--- a/lib/gcp/src/util.ts
+++ b/lib/gcp/src/util.ts
@@ -93,3 +93,16 @@ export function getExternalDNSServiceAccount() {
   }
   return externalDNSSA;
 }
+
+let cortexSA: string | undefined;
+
+export function setCortexServiceAccount(sa: string) {
+  cortexSA = sa;
+}
+
+export function getCortexServiceAccount() {
+  if (cortexSA === undefined) {
+    throw new Error("call setCortexServiceAccount() first");
+  }
+  return cortexSA;
+}

--- a/lib/gcp/src/util.ts
+++ b/lib/gcp/src/util.ts
@@ -80,3 +80,16 @@ export function getCertManagerServiceAccount() {
   }
   return certManagerSA;
 }
+
+let externalDNSSA: string | undefined;
+
+export function setExternalDNSServiceAccount(sa: string) {
+  externalDNSSA = sa;
+}
+
+export function getExternalDNSServiceAccount() {
+  if (externalDNSSA === undefined) {
+    throw new Error("call setExternalDNSServiceAccount() first");
+  }
+  return externalDNSSA;
+}

--- a/lib/gcp/src/util.ts
+++ b/lib/gcp/src/util.ts
@@ -106,3 +106,16 @@ export function getCortexServiceAccount() {
   }
   return cortexSA;
 }
+
+let lokiSA: string | undefined;
+
+export function setLokiServiceAccount(sa: string) {
+  lokiSA = sa;
+}
+
+export function getLokiServiceAccount() {
+  if (lokiSA === undefined) {
+    throw new Error("call setLokiServiceAccount() first");
+  }
+  return lokiSA;
+}

--- a/packages/config/src/gke.ts
+++ b/packages/config/src/gke.ts
@@ -38,8 +38,6 @@ export function getGKEClusterConfig(
     }
   ];
   const oauthScopes = [
-    "https://www.googleapis.com/auth/bigtable.admin.table",
-    "https://www.googleapis.com/auth/bigtable.data",
     "https://www.googleapis.com/auth/logging.write",
     "https://www.googleapis.com/auth/monitoring",
     "https://www.googleapis.com/auth/devstorage.read_write",

--- a/packages/config/src/gke.ts
+++ b/packages/config/src/gke.ts
@@ -99,6 +99,13 @@ export function getGKEClusterConfig(
           oauthScopes
         }
       }
-    ]
+    ],
+    //
+    // Enable workload identity
+    // https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+    //
+    workloadIdentityConfig: {
+      workloadPool: `${gcpAuthOptions.projectId}.svc.id.goog`
+    }
   };
 }

--- a/packages/controller-config/src/types.ts
+++ b/packages/controller-config/src/types.ts
@@ -15,7 +15,7 @@
  */
 
 import * as yup from "yup";
-import { gcpAuthOptionsSchema, GCPAuthOptions } from "@opstrace/gcp";
+import { GCPConfig } from "@opstrace/gcp";
 import { AWSConfig } from "@opstrace/aws";
 
 export const controllerConfigSchema = yup
@@ -68,20 +68,15 @@ export const controllerConfigSchema = yup
         "must be less than 30 characters to be reliably used for cloud infrastructure naming (bigtable has a 30 char limit)"
       ),
 
-    gcpAuthOptions: yup
-      .mixed<GCPAuthOptions | undefined>()
-      .when(["target", "dnsProvider"], {
-        // if target or dnsProvider is gcp, then make this required, otherwise it's not required
-        is: (target: string, dnsProvider: string) =>
-          target === "gcp" || dnsProvider === "gcp",
-        then: () =>
-          gcpAuthOptionsSchema.required(
-            "[internal] must specify gcpAuthOptions"
-          ),
-        otherwise: () => yup.mixed().strip(true)
-      }),
+    mode: yup
+      .mixed<"development" | "production">()
+      .oneOf(["development", "production"])
+      .required("[internal] must specify mode (development | production)"),
+
     // AWS configuration
     aws: yup.mixed<AWSConfig | undefined>(),
+    // GCP configuration
+    gcp: yup.mixed<GCPConfig | undefined>(),
 
     controllerTerminated: yup.bool().default(false)
   })

--- a/packages/controller-config/src/types.ts
+++ b/packages/controller-config/src/types.ts
@@ -37,10 +37,7 @@ export const controllerConfigSchema = yup
     dnsName: yup.string().required(),
     terminate: yup.bool().default(false),
     // https://stackoverflow.com/a/63944333/145400
-    data_api_authn_pubkey_pem: yup
-      .string()
-      .typeError()
-      .strict(true),
+    data_api_authn_pubkey_pem: yup.string().typeError().strict(true),
     disable_data_api_authentication: yup.bool().required(),
     uiSourceIpFirewallRules: yup.array(yup.string()).ensure(),
     apiSourceIpFirewallRules: yup.array(yup.string()).ensure(),
@@ -67,12 +64,6 @@ export const controllerConfigSchema = yup
         30,
         "must be less than 30 characters to be reliably used for cloud infrastructure naming (bigtable has a 30 char limit)"
       ),
-
-    mode: yup
-      .mixed<"development" | "production">()
-      .oneOf(["development", "production"])
-      .required("[internal] must specify mode (development | production)"),
-
     // AWS configuration
     aws: yup.mixed<AWSConfig | undefined>(),
     // GCP configuration

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -26,6 +26,7 @@ import {
   Namespace,
   ResourceCollection,
   Service,
+  ServiceAccount,
   StatefulSet,
   V1PrometheusruleResource,
   V1ServicemonitorResource,
@@ -316,6 +317,31 @@ export function CortexResources(
         kind: "Namespace",
         metadata: {
           name: namespace
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  let annotations = {};
+  let serviceAccountName: string | undefined = undefined;
+  if (target == "gcp") {
+    annotations = {
+      "iam.gke.io/gcp-service-account": state.config.config!.gcp!
+        .cortexServiceAccount
+    };
+    serviceAccountName = "cortex";
+  }
+
+  collection.add(
+    new ServiceAccount(
+      {
+        apiVersion: "v1",
+        kind: "ServiceAccount",
+        metadata: {
+          name: "cortex",
+          namespace,
+          annotations: annotations
         }
       },
       kubeConfig
@@ -1215,6 +1241,7 @@ export function CortexResources(
                   ]
                 }
               ],
+              serviceAccountName: serviceAccountName,
               volumes: [
                 {
                   configMap: {
@@ -1516,6 +1543,7 @@ export function CortexResources(
                   ]
                 }
               ],
+              serviceAccountName: serviceAccountName,
               volumes: [
                 {
                   configMap: {

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -40,7 +40,7 @@ export function CortexResources(
   namespace: string
 ): ResourceCollection {
   const collection = new ResourceCollection();
-  const { name, infrastructureName, target, region } = getControllerConfig(
+  const { name, infrastructureName, target, region, gcp } = getControllerConfig(
     state
   );
   const bucketName = getBucketName({
@@ -325,10 +325,9 @@ export function CortexResources(
 
   let annotations = {};
   let serviceAccountName: string | undefined = undefined;
-  if (target == "gcp") {
+  if (target === "gcp") {
     annotations = {
-      "iam.gke.io/gcp-service-account": state.config.config!.gcp!
-        .cortexServiceAccount
+      "iam.gke.io/gcp-service-account": gcp!.cortexServiceAccount
     };
     serviceAccountName = "cortex";
   }
@@ -1071,6 +1070,7 @@ export function CortexResources(
                   ]
                 }
               ],
+              serviceAccountName: serviceAccountName,
               volumes: [
                 {
                   configMap: {
@@ -1412,6 +1412,7 @@ export function CortexResources(
                   ]
                 }
               ],
+              serviceAccountName: serviceAccountName,
               volumes: [
                 {
                   configMap: {

--- a/packages/controller/src/resources/ingress/externalDns.ts
+++ b/packages/controller/src/resources/ingress/externalDns.ts
@@ -44,6 +44,14 @@ export function ExternalDnsResources(
     platformProvider = "aws";
   }
 
+  let annotations = {};
+  if (target == "gcp") {
+    annotations = {
+      "iam.gke.io/gcp-service-account": state.config.config!.gcp!
+        .externalDNSServiceAccount
+    };
+  }
+
   collection.add(
     new ServiceAccount(
       {
@@ -51,7 +59,8 @@ export function ExternalDnsResources(
         kind: "ServiceAccount",
         metadata: {
           name: "external-dns",
-          namespace
+          namespace,
+          annotations: annotations
         }
       },
       kubeConfig

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -27,7 +27,8 @@ import {
   ensureCloudSQLExists,
   sql_v1beta4,
   ensureServiceAccountExists,
-  setCertManagerServiceAccount
+  setCertManagerServiceAccount,
+  setExternalDNSServiceAccount
 } from "@opstrace/gcp";
 import { ensureDNSExists } from "@opstrace/dns";
 import {
@@ -162,6 +163,16 @@ export function* ensureGCPInfraExists(
   });
 
   setCertManagerServiceAccount(certManagerSA);
+
+  // Create a Google service account to be used by external-dns.
+  log.info(`Ensuring external-dns service account exists`);
+  const externalDNSSA = yield call(ensureServiceAccountExists, {
+    name: `${ccfg.cluster_name}-external-dns`,
+    projectId: gcpProjectID,
+    role: "roles/dns.admin",
+    kubernetesServiceAccount: "ingress/external-dns"
+  });
+  setExternalDNSServiceAccount(externalDNSSA);
 
   return {
     kubeconfigString: gkeKubeconfigString,

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -156,7 +156,9 @@ export function* ensureGCPInfraExists(
   log.info(`Ensuring cert-manager service account exists`);
   const certManagerSA = yield call(ensureServiceAccountExists, {
     name: `${ccfg.cluster_name}-cert-manager`,
-    projectId: gcpProjectID
+    projectId: gcpProjectID,
+    role: "roles/dns.admin",
+    kubernetesServiceAccount: "ingress/cert-manager"
   });
 
   setCertManagerServiceAccount(certManagerSA);

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -25,7 +25,8 @@ import {
   ensureGKEExists,
   generateKubeconfigStringForGkeCluster,
   ensureCloudSQLExists,
-  sql_v1beta4
+  sql_v1beta4,
+  ensureServiceAccountExists,
 } from "@opstrace/gcp";
 import { ensureDNSExists } from "@opstrace/dns";
 import {
@@ -150,6 +151,13 @@ export function* ensureGCPInfraExists(
     gkecluster
   );
 
+  // Create a Google service account to be used by cert-manager.
+  log.info(`Ensuring cert-manager service account exists`);
+  const certManagerSA = yield call(ensureServiceAccountExists, {
+    name: `${ccfg.cluster_name}-cert-manager`,
+    projectId: gcpProjectID
+  });
+
   return {
     kubeconfigString: gkeKubeconfigString,
     // We've hardcoded the password here for now (and in the @opstrace/config package) to keep the installer
@@ -163,4 +171,5 @@ export function* ensureGCPInfraExists(
     // The default user created when standing up a CloudSQL instance is "postgres".
     postgreSQLEndpoint: `postgres://postgres:2020WasQuiteTheYear@${privateAddress.ipAddress}:5432/opstrace`
   };
+
 }

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -27,6 +27,7 @@ import {
   ensureCloudSQLExists,
   sql_v1beta4,
   ensureServiceAccountExists,
+  setCertManagerServiceAccount
 } from "@opstrace/gcp";
 import { ensureDNSExists } from "@opstrace/dns";
 import {
@@ -158,6 +159,8 @@ export function* ensureGCPInfraExists(
     projectId: gcpProjectID
   });
 
+  setCertManagerServiceAccount(certManagerSA);
+
   return {
     kubeconfigString: gkeKubeconfigString,
     // We've hardcoded the password here for now (and in the @opstrace/config package) to keep the installer
@@ -171,5 +174,4 @@ export function* ensureGCPInfraExists(
     // The default user created when standing up a CloudSQL instance is "postgres".
     postgreSQLEndpoint: `postgres://postgres:2020WasQuiteTheYear@${privateAddress.ipAddress}:5432/opstrace`
   };
-
 }

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -28,7 +28,8 @@ import {
   sql_v1beta4,
   ensureServiceAccountExists,
   setCertManagerServiceAccount,
-  setExternalDNSServiceAccount
+  setExternalDNSServiceAccount,
+  setCortexServiceAccount
 } from "@opstrace/gcp";
 import { ensureDNSExists } from "@opstrace/dns";
 import {
@@ -173,6 +174,16 @@ export function* ensureGCPInfraExists(
     kubernetesServiceAccount: "ingress/external-dns"
   });
   setExternalDNSServiceAccount(externalDNSSA);
+
+  // Create a Google service account to be used by cortex.
+  log.info(`Ensuring external-dns service account exists`);
+  const cortexSA = yield call(ensureServiceAccountExists, {
+    name: `${ccfg.cluster_name}-cortex`,
+    projectId: gcpProjectID,
+    role: "roles/storage.admin",
+    kubernetesServiceAccount: "cortex/cortex"
+  });
+  setCortexServiceAccount(cortexSA);
 
   return {
     kubeconfigString: gkeKubeconfigString,

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -29,7 +29,8 @@ import {
   ensureServiceAccountExists,
   setCertManagerServiceAccount,
   setExternalDNSServiceAccount,
-  setCortexServiceAccount
+  setCortexServiceAccount,
+  setLokiServiceAccount
 } from "@opstrace/gcp";
 import { ensureDNSExists } from "@opstrace/dns";
 import {
@@ -176,7 +177,7 @@ export function* ensureGCPInfraExists(
   setExternalDNSServiceAccount(externalDNSSA);
 
   // Create a Google service account to be used by cortex.
-  log.info(`Ensuring external-dns service account exists`);
+  log.info(`Ensuring cortex service account exists`);
   const cortexSA = yield call(ensureServiceAccountExists, {
     name: `${ccfg.cluster_name}-cortex`,
     projectId: gcpProjectID,
@@ -184,6 +185,16 @@ export function* ensureGCPInfraExists(
     kubernetesServiceAccount: "cortex/cortex"
   });
   setCortexServiceAccount(cortexSA);
+
+  // Create a Google service account to be used by loki.
+  log.info(`Ensuring loki service account exists`);
+  const lokiSA = yield call(ensureServiceAccountExists, {
+    name: `${ccfg.cluster_name}-loki`,
+    projectId: gcpProjectID,
+    role: "roles/storage.admin",
+    kubernetesServiceAccount: "loki/loki"
+  });
+  setLokiServiceAccount(lokiSA);
 
   return {
     kubeconfigString: gkeKubeconfigString,

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -44,7 +44,8 @@ import {
   GCPAuthOptions,
   getCertManagerServiceAccount,
   getExternalDNSServiceAccount,
-  getCortexServiceAccount
+  getCortexServiceAccount,
+  getLokiServiceAccount
 } from "@opstrace/gcp";
 import { set as updateTenantsConfig } from "@opstrace/tenants";
 import {
@@ -197,7 +198,8 @@ function* createClusterCore() {
       projectId: gcpAuthOptions!.projectId,
       certManagerServiceAccount: getCertManagerServiceAccount(),
       externalDNSServiceAccount: getExternalDNSServiceAccount(),
-      cortexServiceAccount: getCortexServiceAccount()
+      cortexServiceAccount: getCortexServiceAccount(),
+      lokiServiceAccount: getLokiServiceAccount()
     };
   }
   if (ccfg.cloud_provider === "aws") {

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -43,7 +43,8 @@ import {
   getValidatedGCPAuthOptionsFromFile,
   GCPAuthOptions,
   getCertManagerServiceAccount,
-  getExternalDNSServiceAccount
+  getExternalDNSServiceAccount,
+  getCortexServiceAccount
 } from "@opstrace/gcp";
 import { set as updateTenantsConfig } from "@opstrace/tenants";
 import {
@@ -195,7 +196,8 @@ function* createClusterCore() {
     controllerConfig.gcp = {
       projectId: gcpAuthOptions!.projectId,
       certManagerServiceAccount: getCertManagerServiceAccount(),
-      externalDNSServiceAccount: getExternalDNSServiceAccount()
+      externalDNSServiceAccount: getExternalDNSServiceAccount(),
+      cortexServiceAccount: getCortexServiceAccount()
     };
   }
   if (ccfg.cloud_provider === "aws") {

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -42,7 +42,8 @@ import { getKubeConfig, k8sListNamespacesOrError } from "@opstrace/kubernetes";
 import {
   getValidatedGCPAuthOptionsFromFile,
   GCPAuthOptions,
-  getCertManagerServiceAccount
+  getCertManagerServiceAccount,
+  getExternalDNSServiceAccount
 } from "@opstrace/gcp";
 import { set as updateTenantsConfig } from "@opstrace/tenants";
 import {
@@ -193,7 +194,8 @@ function* createClusterCore() {
 
     controllerConfig.gcp = {
       projectId: gcpAuthOptions!.projectId,
-      certManagerServiceAccount: getCertManagerServiceAccount()
+      certManagerServiceAccount: getCertManagerServiceAccount(),
+      externalDNSServiceAccount: getExternalDNSServiceAccount()
     };
   }
   if (ccfg.cloud_provider === "aws") {

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -41,7 +41,8 @@ import { getKubeConfig, k8sListNamespacesOrError } from "@opstrace/kubernetes";
 
 import {
   getValidatedGCPAuthOptionsFromFile,
-  GCPAuthOptions
+  GCPAuthOptions,
+  getCertManagerServiceAccount
 } from "@opstrace/gcp";
 import { set as updateTenantsConfig } from "@opstrace/tenants";
 import {
@@ -150,7 +151,6 @@ function* createClusterCore() {
     target: ccfg.cloud_provider,
     region: region, // not sure why that's needed
     cert_issuer: ccfg.cert_issuer,
-    gcpAuthOptions,
     infrastructureName: ccfg.cluster_name,
     logRetention: retentionConf.logs,
     metricRetention: retentionConf.metrics,
@@ -190,6 +190,11 @@ function* createClusterCore() {
     );
     kubeconfigString = res.kubeconfigString;
     postgreSQLEndpoint = res.postgreSQLEndpoint;
+
+    controllerConfig.gcp = {
+      projectId: gcpAuthOptions!.projectId,
+      certManagerServiceAccount: getCertManagerServiceAccount()
+    };
   }
   if (ccfg.cloud_provider === "aws") {
     const res: EnsureInfraExistsResponse = yield call(ensureAWSInfraExists);

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -44,6 +44,13 @@ export function* destroyGCPInfra() {
     role: "roles/dns.admin"
   });
 
+  log.info(`Ensure cortex service account deletion`);
+  yield call(ensureServiceAccountDoesNotExist, {
+    name: `${destroyConfig.clusterName}-cortex`,
+    projectId: destroyConfig.gcpProjectID!,
+    role: "roles/storage.admin"
+  });
+
   const lokiBucketName = getBucketName({
     clusterName: destroyConfig.clusterName,
     suffix: "loki"

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -21,7 +21,8 @@ import {
   ensureNetworkDoesNotExist,
   ensureSubNetworkDoesNotExist,
   ensureCloudSQLDoesNotExist,
-  emptyBucket
+  emptyBucket,
+  ensureServiceAccountDoesNotExist
 } from "@opstrace/gcp";
 import { destroyDNS } from "@opstrace/dns";
 import { log, getBucketName } from "@opstrace/utils";
@@ -29,6 +30,13 @@ import { log, getBucketName } from "@opstrace/utils";
 import { destroyConfig } from "./index";
 
 export function* destroyGCPInfra() {
+  log.info(`Ensure cert-manager service account deletion`);
+  yield call(ensureServiceAccountDoesNotExist, {
+    name: `${destroyConfig.clusterName}-cert-manager`,
+    projectId: destroyConfig.gcpProjectID!,
+    role: "roles/dns.admin"
+  });
+
   const lokiBucketName = getBucketName({
     clusterName: destroyConfig.clusterName,
     suffix: "loki"

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -37,6 +37,13 @@ export function* destroyGCPInfra() {
     role: "roles/dns.admin"
   });
 
+  log.info(`Ensure external-dns service account deletion`);
+  yield call(ensureServiceAccountDoesNotExist, {
+    name: `${destroyConfig.clusterName}-external-dns`,
+    projectId: destroyConfig.gcpProjectID!,
+    role: "roles/dns.admin"
+  });
+
   const lokiBucketName = getBucketName({
     clusterName: destroyConfig.clusterName,
     suffix: "loki"

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -51,6 +51,13 @@ export function* destroyGCPInfra() {
     role: "roles/storage.admin"
   });
 
+  log.info(`Ensure loki service account deletion`);
+  yield call(ensureServiceAccountDoesNotExist, {
+    name: `${destroyConfig.clusterName}-loki`,
+    projectId: destroyConfig.gcpProjectID!,
+    role: "roles/storage.admin"
+  });
+
   const lokiBucketName = getBucketName({
     clusterName: destroyConfig.clusterName,
     suffix: "loki"


### PR DESCRIPTION
The goal of this PR is to remove GCP credentials from the controller config map. 

In this PR we introduce functions that handle the creation and configuration of a GCP service account. We are using the `dns.admin` and `storage.admin` roles but we can follow up by reducing service account permissions to only the required roles.

To enable workload identity we need to provide [an additional parameter to the GKE cluster configuration](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters).

Since we remove the GCP credentials we need to use a service account in the cert-manager, external-dns, cortex and loki deployments that access GCP cloud resources.

### Useful documentation links

https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/gke.md
https://cert-manager.io/docs/configuration/acme/dns01/google/
https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity

https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts/get