### PR TITLE
ci: temporarily skip GCP build step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,6 +25,7 @@ steps:
     soft_fail:
       - exit_status: 42
   - label: "🔨 main test (GCP)"
+    skip: "temporarily skipping GCP builds"
     key: "maintest-gcp"
     depends_on:
       - "preamble"


### PR DESCRIPTION
Use the skip attribute to skip GCP due to temporary cloud quota issues.
See:
  - https://buildkite.com/docs/pipelines/command-step
  - https://github.com/buildkite/feedback/issues/55
