### PR TITLE
ci: publish-artifacts: remove maintest-gcp dep

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,6 @@ steps:
     soft_fail:
       - exit_status: 42
   - label: "🔨 main test (GCP)"
-    skip: "temporarily skipping GCP builds"
     key: "maintest-gcp"
     depends_on:
       - "preamble"
@@ -60,7 +59,6 @@ steps:
   - label: "🔨 publish artifacts"
     key: "publish-artifacts"
     depends_on:
-      - "maintest-gcp"
       - "maintest-aws"
       - "check-docs"
     allow_dependency_failure: false


### PR DESCRIPTION
From the commit message:
```
GCP CI is currently affected by #62. For successful maintest-aws runs, we
still want to publish artifacts. Previously, we decided to skip
maintest-gcp for achieving that. However, explicitly removing the
maintest-gcp dependency on publish-artifacts is tidier, and explicitly
exposes the maintest-gcp breakage on all CI runs.
```
