### PR TITLE
docs(roadmap): add missing manifest entry

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -81,6 +81,10 @@
           "path": "/docs/references/faq.md"
         },
         {
+          "title": "Roadmap",
+          "path": "/docs/references/roadmap.md"
+        },
+        {
           "title": "Cluster Configuration",
           "path": "/docs/references/cluster-configuration.md"
         },


### PR DESCRIPTION
Silly oversight.

In the future, we should automate updating or at least checking the manifest.