### PR TITLE
fix: update certificate resource when changes are made

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,11 +24,19 @@ steps:
       - ci/check-docs-fastpath-helper.sh fastpath-stdout FASTPATHEXIT
     soft_fail:
       - exit_status: 42
+  - label: "🔨 unit tests"
+    key: "unit-tests"
+    depends_on:
+      - "preamble"
+      - "check-docs"
+    command:
+      - cd "${OPSTRACE_PREBUILD_DIR}" && make ci-unit-tests
   - label: "🔨 main test (GCP)"
     key: "maintest-gcp"
     depends_on:
       - "preamble"
       - "check-docs"
+      - "unit-tests"
     env:
       OPSTRACE_CLUSTER_NAME: "bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-g"
       OPSTRACE_BUILD_DIR: "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-gcp"
@@ -42,6 +50,7 @@ steps:
     depends_on:
       - "preamble"
       - "check-docs"
+      - "unit-tests"
     env:
       OPSTRACE_CLUSTER_NAME: "bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-a"
       OPSTRACE_BUILD_DIR: "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-aws"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ tsconfig.tsbuildinfo
 **/lib/utils/lib
 **/module_cache
 **/modules/**/lib
+# jest coverage directory
+coverage/
 
 pkg/cortex-push/cortex-push
 pkg/datadog/datadog

--- a/Makefile
+++ b/Makefile
@@ -530,7 +530,7 @@ node_modules:
 
 .PHONY: unit-tests
 unit-tests: yarn-frozen-lockfile
-	cd lib/kubernetes && yarn test
+	cd lib/kubernetes && CI=true yarn test
 
 .PHONY: preamble
 preamble:

--- a/Makefile
+++ b/Makefile
@@ -528,6 +528,10 @@ yarn.lock: package.json $(PACKAGE_JSON) node_modules
 node_modules:
 	mkdir -p node_modules
 
+.PHONY: unit-tests
+unit-tests: yarn-frozen-lockfile
+	cd lib/kubernetes && yarn test
+
 .PHONY: preamble
 preamble:
 	bash "ci/preamble.sh"

--- a/lib/kubernetes/jest.config.js
+++ b/lib/kubernetes/jest.config.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  roots: ["<rootDir>/src"],
+  testMatch: [
+    "**/__tests__/**/*.+(ts|tsx|js)",
+    "**/?(*.)+(spec|test).+(ts|tsx|js)"
+  ],
+  transform: {
+    "^.+\\.(ts|tsx)$": "ts-jest"
+  }
+};

--- a/lib/kubernetes/package.json
+++ b/lib/kubernetes/package.json
@@ -14,7 +14,8 @@
     "watch": "tsc -p . -w",
     "clean": "rimraf build .cache tsconfig.tsbuildinfo",
     "prebuild": "yarn clean",
-    "lint": "echo done"
+    "lint": "echo done",
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@kubernetes/client-node": "0.13.0",
@@ -26,6 +27,10 @@
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",
-    "@types/request": "^2.48.4"
+    "@types/jest": "^26.0.16",
+    "@types/request": "^2.48.4",
+    "jest": "^26.6.3",
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.1.2"
   }
 }

--- a/lib/kubernetes/package.json
+++ b/lib/kubernetes/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf build .cache tsconfig.tsbuildinfo",
     "prebuild": "yarn clean",
     "lint": "echo done",
-    "test": "jest --coverage"
+    "test": "node scripts/test.js --coverage"
   },
   "dependencies": {
     "@kubernetes/client-node": "0.13.0",

--- a/lib/kubernetes/scripts/test.js
+++ b/lib/kubernetes/scripts/test.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+// Do this as the first thing so that any code reading it knows the right env.
+process.env.BABEL_ENV = "test";
+process.env.NODE_ENV = "test";
+process.env.PUBLIC_URL = "";
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on("unhandledRejection", err => {
+  throw err;
+});
+
+const jest = require("jest");
+const execSync = require("child_process").execSync;
+let argv = process.argv.slice(2);
+
+function isInGitRepository() {
+  try {
+    execSync("git rev-parse --is-inside-work-tree", { stdio: "ignore" });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function isInMercurialRepository() {
+  try {
+    execSync("hg --cwd . root", { stdio: "ignore" });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+// Watch unless on CI or explicitly running all tests
+if (
+  !process.env.CI &&
+  argv.indexOf("--watchAll") === -1 &&
+  argv.indexOf("--watchAll=false") === -1
+) {
+  // https://github.com/facebook/create-react-app/issues/5210
+  const hasSourceControl = isInGitRepository() || isInMercurialRepository();
+  argv.push(hasSourceControl ? "--watch" : "--watchAll");
+}
+
+jest.run(argv);

--- a/lib/kubernetes/src/equality/Certificate.spec.ts
+++ b/lib/kubernetes/src/equality/Certificate.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1Certificate } from "../custom-resources";
+import { isCertificateEqual } from "./Certificate";
+
+// mock logger
+jest.mock("@opstrace/utils", () => ({
+  log: {
+    debug: jest.fn
+  }
+}));
+
+// return an empty certificate for testing
+function genCert(): V1Certificate {
+  return {
+    metadata: {
+      annotations: {}
+    },
+    spec: {
+      issuerRef: {
+        name: "test"
+      },
+      secretName: "test"
+    }
+  };
+}
+
+test("should return true when certificates are empty", () => {
+  const desired = genCert();
+  const existing = genCert();
+
+  expect(isCertificateEqual(desired, existing)).toBe(true);
+});
+
+test("should not be equal when certificate annotations do not match", () => {
+  const desired = genCert();
+  const existing = genCert();
+
+  desired.metadata = {
+    annotations: {
+      foo: "bar"
+    }
+  };
+  existing.metadata = {
+    annotations: {
+      bar: "foo"
+    }
+  };
+
+  expect(isCertificateEqual(desired, existing)).toBe(false);
+});
+
+test("should not be equal when certificate commonName does not match", () => {
+  const desired = genCert();
+  const existing = genCert();
+
+  desired.spec.commonName = "bar";
+  existing.spec.commonName = "foo";
+
+  expect(isCertificateEqual(desired, existing)).toBe(false);
+});
+
+test("should not be equal when certificate dnsNames does not match", () => {
+  const desired = genCert();
+  const existing = genCert();
+
+  desired.spec.dnsNames = ["bar"];
+  existing.spec.dnsNames = ["foo"];
+
+  expect(isCertificateEqual(desired, existing)).toBe(false);
+});
+
+test("should not be equal when certificate isCa does not match", () => {
+  const desired = genCert();
+  const existing = genCert();
+
+  desired.spec.isCA = false;
+  existing.spec.isCA = true;
+
+  expect(isCertificateEqual(desired, existing)).toBe(false);
+});
+
+test("should not be equal when certificate issuerRef does not match", () => {
+  const desired = genCert();
+  const existing = genCert();
+
+  desired.spec.issuerRef = {
+    name: "foo"
+  };
+  existing.spec.issuerRef = {
+    name: "bar"
+  };
+  expect(isCertificateEqual(desired, existing)).toBe(false);
+
+  desired.spec.issuerRef = {
+    name: "test",
+    kind: "foo"
+  };
+  existing.spec.issuerRef = {
+    name: "test",
+    kind: "bar"
+  };
+  expect(isCertificateEqual(desired, existing)).toBe(false);
+});
+
+test("should not be equal when certificate secretName does not match", () => {
+  const desired = genCert();
+  const existing = genCert();
+
+  desired.spec.secretName = "foo";
+  existing.spec.secretName = "bar";
+  expect(isCertificateEqual(desired, existing)).toBe(false);
+});

--- a/lib/kubernetes/src/equality/Certificate.ts
+++ b/lib/kubernetes/src/equality/Certificate.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { log } from "@opstrace/utils";
+import { isDeepStrictEqual } from "util";
+import { V1Certificate } from "../custom-resources";
+
+export const isCertificateEqual = (
+  desired: V1Certificate,
+  existing: V1Certificate
+): boolean => {
+  if (typeof desired.spec !== typeof existing.spec) {
+    return false;
+  }
+
+  if (
+    !isDeepStrictEqual(
+      desired.metadata!.annotations,
+      existing.metadata!.annotations
+    )
+  ) {
+    log.debug(
+      `annotations mismatch: ${JSON.stringify(
+        desired.metadata!.annotations
+      )} vs ${existing.metadata!.annotations}`
+    );
+    return false;
+  }
+
+  if (desired.spec.commonName !== existing.spec.commonName) {
+    log.debug(
+      `commonName mismatch:  ${desired.spec.commonName} vs ${existing.spec.commonName}`
+    );
+    return false;
+  }
+
+  if (!isDeepStrictEqual(desired.spec.dnsNames, existing.spec.dnsNames)) {
+    log.debug(
+      `dnsNames mismatch:  ${desired.spec.dnsNames} vs ${existing.spec.dnsNames}`
+    );
+    return false;
+  }
+
+  if (desired.spec.isCA !== existing.spec.isCA) {
+    log.debug(`isCA mismatch:  ${desired.spec.isCA} vs ${existing.spec.isCA}`);
+    return false;
+  }
+
+  if (!isDeepStrictEqual(desired.spec.issuerRef, existing.spec.issuerRef)) {
+    log.debug(
+      `issuerRef mismatch:  ${desired.spec.issuerRef} vs ${existing.spec.issuerRef}`
+    );
+    return false;
+  }
+
+  if (desired.spec.secretName !== existing.spec.secretName) {
+    log.debug(
+      `secretName mismatch:  ${desired.spec.secretName} vs ${existing.spec.secretName}`
+    );
+    return false;
+  }
+
+  return true;
+};

--- a/lib/kubernetes/src/equality/index.ts
+++ b/lib/kubernetes/src/equality/index.ts
@@ -37,6 +37,8 @@ import {
 
 import { logDifference } from "./general";
 import { NetworkingV1beta1IngressTLS } from "@kubernetes/client-node";
+import { V1CertificateResource } from "../custom-resources";
+import { isCertificateEqual } from "./Certificate";
 
 export * from "./general";
 export * from "./Pod";
@@ -137,6 +139,22 @@ export const hasStatefulSetChanged = (
   ) {
     logDifference(
       `${desired.spec.metadata?.namespace}/${desired.spec.metadata?.name}`,
+      desired.spec,
+      existing.spec
+    );
+    return true;
+  }
+
+  return false;
+};
+
+export const hasCertificateChanged = (
+  desired: V1CertificateResource,
+  existing: V1CertificateResource
+) => {
+  if (!isCertificateEqual(desired.spec, existing.spec)) {
+    logDifference(
+      `${desired.spec}/${desired.spec}`,
       desired.spec,
       existing.spec
     );

--- a/lib/kubernetes/src/reconciliation/reconcile.ts
+++ b/lib/kubernetes/src/reconciliation/reconcile.ts
@@ -73,7 +73,8 @@ import {
   hasServiceMonitorChanged,
   hasIngressChanged,
   hasAlertManagerChanged,
-  hasPrometheusChanged
+  hasPrometheusChanged,
+  hasCertificateChanged
 } from "../equality";
 
 import { entries } from "@opstrace/utils";
@@ -763,7 +764,10 @@ export function* reconcile(
         return;
       }
       if (!r.isImmutable()) {
-        if (haveLabelsChanged(r, existing)) {
+        if (
+          haveLabelsChanged(r, existing) ||
+          hasCertificateChanged(r, existing)
+        ) {
           updateCollection.push(r);
         }
       }


### PR DESCRIPTION
Fix #43

When we add a new tenant, we need to check if the Certificate spec changed to trigger an update of the certificate resource in kubernetes. This will make cert-manager reconcile the resource and issue a new certificate with Let's Encrypt.