### PR TITLE
fix: no need to set/unset bash errexit

### DIFF
--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -191,7 +191,6 @@ export OPSTRACE_KUBE_CONFIG_HOST="${OPSTRACE_BUILD_DIR}/.kube"
 # TODO: remove when we add GCP managed certificates and remove the
 # use of insecure_skip_verify in the tests
 echo "--- checking cluster is using certificate issued by LetsEncrypt"
-set -e
 
 check_certificate() {
     # Timeout the command after 10 seconds in case it's stuck. Redirect stderr
@@ -218,7 +217,6 @@ do
         exit ${retcode}
     fi
 done
-set +e
 
 echo "+++ run test-remote"
 


### PR DESCRIPTION
From https://linux.die.net/man/1/bash

"The shell does not exit if the command that fails is part of the command list immediately following a while or until keyword..."

Fix #115 