### PR TITLE
chore: prevent yarn install from running twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out
 .cache
 .build
 yarn-error.log
+yarn.lock.md5
 
 opstrace-config.yaml
 prometheus.yml

--- a/Makefile
+++ b/Makefile
@@ -522,8 +522,11 @@ yarn.lock.md5: yarn.lock
 # a yarn install.
 PACKAGE_JSON = $(wildcard lib/**/*package.json packages/**/*package.json)
 
-yarn.lock: package.json $(PACKAGE_JSON)
+yarn.lock: package.json $(PACKAGE_JSON) node_modules
 	yarn --frozen-lockfile && touch yarn.lock
+
+node_modules:
+	mkdir -p node_modules
 
 .PHONY: preamble
 preamble:


### PR DESCRIPTION
This improves developer productivity (slightly) by reducing the compile time since we only need to run `yarn install` when a `package.json` or `yarn.lock` changed.  

