### PR TITLE
fix: set liveness and readiness probes

### DIFF
--- a/lib/kubernetes/src/equality/Pod.ts
+++ b/lib/kubernetes/src/equality/Pod.ts
@@ -136,7 +136,6 @@ const isContainerProbeEqual = (
   desired: V1Probe | undefined,
   existing: V1Probe | undefined
 ): boolean => {
-  //const res = (
   return (
     isDeepStrictEqual(desired?.exec, existing?.exec) &&
     desired?.failureThreshold === existing?.failureThreshold &&
@@ -147,12 +146,6 @@ const isContainerProbeEqual = (
     isDeepStrictEqual(desired?.tcpSocket, existing?.tcpSocket) &&
     desired?.timeoutSeconds === existing?.timeoutSeconds
   );
-  // log.info(`probes match? ${res}`)
-  // if (!res) {
-  //   log.info(`desired=${JSON.stringify(desired)}`)
-  //   log.info(`existing=${JSON.stringify(existing)}`)
-  // }
-  // return res
 };
 
 const areContainerPortsEqual = (

--- a/lib/kubernetes/src/equality/Pod.ts
+++ b/lib/kubernetes/src/equality/Pod.ts
@@ -22,8 +22,11 @@ import {
   V1ContainerPort,
   V1VolumeMount,
   V1KeyToPath,
-  V1EnvVar
+  V1EnvVar,
+  V1Probe
 } from "@kubernetes/client-node";
+
+import { isDeepStrictEqual } from "util";
 
 export const ENV_HASH_NAME = "OPSTRACE_CONTROLLER_VERSION";
 
@@ -98,7 +101,9 @@ const isContainerEqual = (
     !areContainerPortsEqual(desired, existing) ||
     !areVolumeMountsEqual(desired, existing) ||
     !areEnvVariablesEqual(desired, existing) ||
-    !areContainerArgsEqual(desired, existing)
+    !areContainerArgsEqual(desired, existing) ||
+    !areContainerReadinessProbesEqual(desired, existing) ||
+    !areContainerLivenessProbesEqual(desired, existing)
   ) {
     return false;
   }
@@ -108,6 +113,46 @@ const isContainerEqual = (
   }
 
   return true;
+};
+
+const areContainerReadinessProbesEqual = (
+  desired: V1Container,
+  existing: V1Container
+): boolean => {
+  return isContainerProbeEqual(
+    desired?.readinessProbe,
+    existing?.readinessProbe
+  );
+};
+
+const areContainerLivenessProbesEqual = (
+  desired: V1Container,
+  existing: V1Container
+): boolean => {
+  return isContainerProbeEqual(desired?.livenessProbe, existing?.livenessProbe);
+};
+
+const isContainerProbeEqual = (
+  desired: V1Probe | undefined,
+  existing: V1Probe | undefined
+): boolean => {
+  //const res = (
+  return (
+    isDeepStrictEqual(desired?.exec, existing?.exec) &&
+    desired?.failureThreshold === existing?.failureThreshold &&
+    isDeepStrictEqual(desired?.httpGet, existing?.httpGet) &&
+    desired?.initialDelaySeconds === existing?.initialDelaySeconds &&
+    desired?.periodSeconds === existing?.periodSeconds &&
+    desired?.successThreshold === existing?.successThreshold &&
+    isDeepStrictEqual(desired?.tcpSocket, existing?.tcpSocket) &&
+    desired?.timeoutSeconds === existing?.timeoutSeconds
+  );
+  // log.info(`probes match? ${res}`)
+  // if (!res) {
+  //   log.info(`desired=${JSON.stringify(desired)}`)
+  //   log.info(`existing=${JSON.stringify(existing)}`)
+  // }
+  // return res
 };
 
 const areContainerPortsEqual = (

--- a/packages/controller/src/resources/apis/cortex.ts
+++ b/packages/controller/src/resources/apis/cortex.ts
@@ -139,14 +139,24 @@ export function CortexAPIResources(
                   readinessProbe: {
                     httpGet: {
                       path: "/metrics",
-                      port: 8080 as any
-                    }
+                      port: 8080 as any,
+                      scheme: "HTTP"
+                    },
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   livenessProbe: {
                     httpGet: {
                       path: "/metrics",
-                      port: 8080 as any
-                    }
+                      port: 8080 as any,
+                      scheme: "HTTP"
+                    },
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   resources: config.resources,
                   env: cortexApiProxyEnv

--- a/packages/controller/src/resources/apis/loki.ts
+++ b/packages/controller/src/resources/apis/loki.ts
@@ -131,14 +131,24 @@ export function LokiAPIResources(
                   readinessProbe: {
                     httpGet: {
                       path: "/metrics",
-                      port: 8080 as any
-                    }
+                      port: 8080 as any,
+                      scheme: "HTTP"
+                    },
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   livenessProbe: {
                     httpGet: {
                       path: "/metrics",
-                      port: 8080 as any
-                    }
+                      port: 8080 as any,
+                      scheme: "HTTP"
+                    },
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   resources: config.resources,
                   env: lokiApiProxyEnv

--- a/packages/controller/src/resources/app/index.ts
+++ b/packages/controller/src/resources/app/index.ts
@@ -313,7 +313,8 @@ export function OpstraceApplicationResources(
                   readinessProbe: {
                     httpGet: {
                       path: "/ready",
-                      port: 9000 as any
+                      port: 9000 as any,
+                      scheme: "HTTP"
                     },
                     failureThreshold: 1,
                     initialDelaySeconds: 5,
@@ -324,7 +325,8 @@ export function OpstraceApplicationResources(
                   livenessProbe: {
                     httpGet: {
                       path: "/live",
-                      port: 9000 as any
+                      port: 9000 as any,
+                      scheme: "HTTP"
                     },
                     failureThreshold: 3,
                     initialDelaySeconds: 5,

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -1049,13 +1049,31 @@ export function CortexResources(
                       name: "grpc"
                     }
                   ],
+                  // https://github.com/cortexproject/cortex-helm-chart/blob/14ee59e7b3e8772f19a12ab16979e5143f51ae92/values.yaml#L250-L254
                   readinessProbe: {
                     httpGet: {
                       path: "/ready",
-                      port: 80 as any
+                      port: 80 as any,
+                      scheme: "HTTP"
                     },
-                    initialDelaySeconds: 15,
-                    timeoutSeconds: 1
+                    initialDelaySeconds: 45,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
+                  },
+                  // https://github.com/cortexproject/cortex-helm-chart/blob/14ee59e7b3e8772f19a12ab16979e5143f51ae92/values.yaml#L245-L249
+                  livenessProbe: {
+                    httpGet: {
+                      path: "/ready",
+                      port: 80 as any,
+                      scheme: "HTTP"
+                    },
+                    initialDelaySeconds: 45,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   resources: config.ingester.resources,
                   volumeMounts: [

--- a/packages/controller/src/resources/loki/index.ts
+++ b/packages/controller/src/resources/loki/index.ts
@@ -649,13 +649,31 @@ export function LokiResources(
                       name: "grpc"
                     }
                   ],
+                  // https://github.com/grafana/loki/blob/6d85c7c212f95c7fbf902b467edc46a5ec3555fd/production/helm/loki/values.yaml#L167-L171
                   readinessProbe: {
                     httpGet: {
                       path: "/ready",
-                      port: 1080 as any
+                      port: 1080 as any,
+                      scheme: "HTTP"
                     },
-                    initialDelaySeconds: 15,
-                    timeoutSeconds: 1
+                    initialDelaySeconds: 45,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
+                  },
+                  // https://github.com/grafana/loki/blob/6d85c7c212f95c7fbf902b467edc46a5ec3555fd/production/helm/loki/values.yaml#L117-L121
+                  livenessProbe: {
+                    httpGet: {
+                      path: "/ready",
+                      port: 1080 as any,
+                      scheme: "HTTP"
+                    },
+                    initialDelaySeconds: 45,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   resources: deploymentConfig.distributor.resources,
                   volumeMounts: [
@@ -736,10 +754,26 @@ export function LokiResources(
                   readinessProbe: {
                     httpGet: {
                       path: "/ready",
-                      port: 1080 as any
+                      port: 1080 as any,
+                      scheme: "HTTP"
                     },
-                    initialDelaySeconds: 15,
-                    timeoutSeconds: 1
+                    initialDelaySeconds: 45,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
+                  },
+                  livenessProbe: {
+                    httpGet: {
+                      path: "/ready",
+                      port: 1080 as any,
+                      scheme: "HTTP"
+                    },
+                    initialDelaySeconds: 45,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   resources: deploymentConfig.ingester.resources,
                   volumeMounts: [
@@ -871,10 +905,26 @@ export function LokiResources(
                   readinessProbe: {
                     httpGet: {
                       path: "/ready",
-                      port: 1080 as any
+                      port: 1080 as any,
+                      scheme: "HTTP"
                     },
                     initialDelaySeconds: 15,
-                    timeoutSeconds: 1
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
+                  },
+                  livenessProbe: {
+                    httpGet: {
+                      path: "/ready",
+                      port: 1080 as any,
+                      scheme: "HTTP"
+                    },
+                    initialDelaySeconds: 15,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   resources: deploymentConfig.querier.resources,
                   volumeMounts: [
@@ -969,10 +1019,26 @@ export function LokiResources(
                   readinessProbe: {
                     httpGet: {
                       path: "/ready",
-                      port: 1080 as any
+                      port: 1080 as any,
+                      scheme: "HTTP"
                     },
                     initialDelaySeconds: 15,
-                    timeoutSeconds: 1
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
+                  },
+                  livenessProbe: {
+                    httpGet: {
+                      path: "/ready",
+                      port: 1080 as any,
+                      scheme: "HTTP"
+                    },
+                    initialDelaySeconds: 15,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   resources: deploymentConfig.querier.resources,
                   volumeMounts: [

--- a/packages/controller/src/resources/monitoring/tenants/grafana.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafana.ts
@@ -185,8 +185,24 @@ export function GrafanaResources(
                   readinessProbe: {
                     httpGet: {
                       path: "/api/health",
-                      port: "http" as any
-                    }
+                      port: "http" as any,
+                      scheme: "HTTP"
+                    },
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
+                  },
+                  livenessProbe: {
+                    httpGet: {
+                      path: "/api/health",
+                      port: "http" as any,
+                      scheme: "HTTP"
+                    },
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
                   },
                   resources: {},
                   env: [


### PR DESCRIPTION
Fix #131 

* Adds equality check for pod readiness and liveness probes. This required also setting the Kubernetes default values otherwise the desired spec and existing spec equality check would always fail.
* Adds liveness probes to the deployments/statefulsets/daemonsets that didn't have them.
* Changed `initialDelaySeconds` in cortex and loki deployments following the official helm chart values (for example, [cortex](https://github.com/cortexproject/cortex-helm-chart/blob/14ee59e7b3e8772f19a12ab16979e5143f51ae92/values.yaml#L250-L254)).