### PR TITLE
fix license check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,9 @@ check-license-headers:
 	find . -not -path '*/.git/*' \
 		-not -path '*/node_modules*' \
 		-not -path '*/kubernetes/src/custom-resources*' \
+		-not -path '*/.cache/*' \
+		-not -path '*/.npm/*' \
+		-not -path './build/*' \
 		-type d -exec bash -c \
 		$$'echo "dir: {}"; shopt -s extglob \n addlicense -c "Opstrace, Inc." -l apache {}/@(*.ts|*.tsx|*.json|*.go|*.css)' \;
 	# Show the changes. This returns non-zero when there is a diff.

--- a/packages/app/src/state/branch/hooks/__tests__/useBranches.test.tsx
+++ b/packages/app/src/state/branch/hooks/__tests__/useBranches.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { CombinedState } from "redux";
 import { useDispatch, useSelector } from "react-redux";
@@ -16,7 +32,7 @@ import useBranches, {
 import { subscribe } from "../../actions";
 
 jest.mock("react-redux", () => ({
-  ...jest.requireActual("react-redux") as object,
+  ...(jest.requireActual("react-redux") as object),
   useDispatch: jest.fn(),
   useSelector: jest.fn()
 }));
@@ -77,14 +93,24 @@ test("getBranches selector", () => {
 });
 
 test("getCurrentBranchName selector", () => {
-  const subState = { branches: { branches: [{ name: "Test", id: "test-id" }], currentBranchName: "Test" } };
+  const subState = {
+    branches: {
+      branches: [{ name: "Test", id: "test-id" }],
+      currentBranchName: "Test"
+    }
+  };
   const state = mainReducer(subState as CombinedState<any>, mockAction);
   expect(getCurrentBranchName(state)).toEqual("Test");
 });
 
 describe("getCurrentBranch selector", () => {
   test("should find current branch", () => {
-    const subState = { branches: { branches: [{ name: "Test", id: "test-id" }], currentBranchName: "Test" } };
+    const subState = {
+      branches: {
+        branches: [{ name: "Test", id: "test-id" }],
+        currentBranchName: "Test"
+      }
+    };
     const state = mainReducer(subState as CombinedState<any>, mockAction);
     expect(getCurrentBranch(state)).toEqual({ name: "Test", id: "test-id" });
   });
@@ -112,4 +138,3 @@ describe("getCurrentBranch selector", () => {
     expect(getCurrentBranch(state)).toBeUndefined();
   });
 });
-

--- a/packages/app/src/state/file/hooks/__tests__/useFiles.test.tsx
+++ b/packages/app/src/state/file/hooks/__tests__/useFiles.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { CombinedState } from "redux";
 import { useDispatch, useSelector } from "react-redux";
@@ -12,7 +28,6 @@ import {
   useBranchTypescriptFiles,
   useLatestBranchTypescriptFiles,
   getCurrentBranchFiles,
-
   getOpenFileParams,
   getCurrentlySelectedFile,
   useBranchTypescriptFilesForModuleVersion,
@@ -21,7 +36,7 @@ import {
 import { subscribe } from "../../actions";
 
 jest.mock("react-redux", () => ({
-  ...jest.requireActual("react-redux") as object,
+  ...(jest.requireActual("react-redux") as object),
   useDispatch: jest.fn(),
   useSelector: jest.fn()
 }));
@@ -35,11 +50,13 @@ afterEach(() => {
 const mockAction = { type: "UNKNOWN_ACTION" } as any;
 
 test("useBranchFiles hook", () => {
-  const files = [{
-    id: "test",
-    branch_name: "test-branch",
-    path: "foo/bar/baz",
-  }];
+  const files = [
+    {
+      id: "test",
+      branch_name: "test-branch",
+      path: "foo/bar/baz"
+    }
+  ];
   const dispatchMock = jest.fn();
 
   (useSelector as jest.Mock).mockReturnValueOnce(files);
@@ -57,34 +74,45 @@ test("useBranchFiles hook", () => {
 
 test("getCurrentBranchFiles selector", () => {
   const subState = {
-    branches: { branches: [{ name: "test-branch" }], currentBranchName: "test-branch" }, files: {
-      files: [{
-        id: "test",
-        branch_name: "test-branch",
-        path: "foo/bar/baz",
-      }]
+    branches: {
+      branches: [{ name: "test-branch" }],
+      currentBranchName: "test-branch"
+    },
+    files: {
+      files: [
+        {
+          id: "test",
+          branch_name: "test-branch",
+          path: "foo/bar/baz"
+        }
+      ]
     }
   };
   const state = mainReducer(subState as CombinedState<any>, mockAction);
-  expect(getCurrentBranchFiles(state)).toEqual([{
-    id: "test",
-    branch_name: "test-branch",
-    path: "foo/bar/baz",
-  }]);
+  expect(getCurrentBranchFiles(state)).toEqual([
+    {
+      id: "test",
+      branch_name: "test-branch",
+      path: "foo/bar/baz"
+    }
+  ]);
 });
 
 test("useBranchTypescriptFiles hook", () => {
-  const subState = [{
-    id: "test-1",
-    branch_name: "test-branch-1",
-    path: "foo/bar/baz",
-    ext: ".ts"
-  }, {
-    id: "test-2",
-    branch_name: "test-branch-2",
-    path: "foo/bar/baz",
-    ext: ".js"
-  }];
+  const subState = [
+    {
+      id: "test-1",
+      branch_name: "test-branch-1",
+      path: "foo/bar/baz",
+      ext: ".ts"
+    },
+    {
+      id: "test-2",
+      branch_name: "test-branch-2",
+      path: "foo/bar/baz",
+      ext: ".js"
+    }
+  ];
 
   const dispatchMock = jest.fn();
 
@@ -95,41 +123,48 @@ test("useBranchTypescriptFiles hook", () => {
     wrapper: ({ children }: any) => <StoreProvider>{children}</StoreProvider>
   });
 
-  expect(result.current).toEqual([{
-    id: "test-1",
-    branch_name: "test-branch-1",
-    path: "foo/bar/baz",
-    ext: ".ts"
-  }]);
+  expect(result.current).toEqual([
+    {
+      id: "test-1",
+      branch_name: "test-branch-1",
+      path: "foo/bar/baz",
+      ext: ".ts"
+    }
+  ]);
 });
 
 test("useBranchTypescriptFilesForModuleVersion hook", () => {
-  const subState = [{
-    id: "test-1",
-    branch_name: "test-branch-1",
-    path: "foo/bar/baz",
-    ext: ".ts",
-    module_scope: "/foo",
-    module_name: "test",
-    module_version: "0.1",
-  }, {
-    id: "test-2",
-    branch_name: "test-branch-2",
-    path: "foo/bar/baz",
-    ext: ".ts",
-    module_scope: "/",
-    module_name: "test",
-    module_version: "0.2",
-  }];
+  const subState = [
+    {
+      id: "test-1",
+      branch_name: "test-branch-1",
+      path: "foo/bar/baz",
+      ext: ".ts",
+      module_scope: "/foo",
+      module_name: "test",
+      module_version: "0.1"
+    },
+    {
+      id: "test-2",
+      branch_name: "test-branch-2",
+      path: "foo/bar/baz",
+      ext: ".ts",
+      module_scope: "/",
+      module_name: "test",
+      module_version: "0.2"
+    }
+  ];
 
   const dispatchMock = jest.fn();
   (useSelector as jest.Mock).mockReturnValueOnce(subState);
   (useDispatch as jest.Mock).mockReturnValue(dispatchMock);
 
-  const { result } = renderHook(() =>
-    useBranchTypescriptFilesForModuleVersion("test", "/foo", "0.1"), {
-    wrapper: ({ children }: any) => <StoreProvider>{children}</StoreProvider>
-  });
+  const { result } = renderHook(
+    () => useBranchTypescriptFilesForModuleVersion("test", "/foo", "0.1"),
+    {
+      wrapper: ({ children }: any) => <StoreProvider>{children}</StoreProvider>
+    }
+  );
 
   expect(result.current).toEqual([
     {
@@ -150,17 +185,20 @@ test("useBranchTypescriptFilesForModuleVersion hook", () => {
 });
 
 test("useLatestBranchTypescriptFiles hook", () => {
-  const subState = [{
-    id: "test-1",
-    branch_name: "test-branch-1",
-    path: "foo/bar/baz",
-    ext: ".ts",
-  }, {
-    id: "test-2",
-    branch_name: "test-branch-2",
-    path: "foo/bar/baz",
-    ext: ".js",
-  }];
+  const subState = [
+    {
+      id: "test-1",
+      branch_name: "test-branch-1",
+      path: "foo/bar/baz",
+      ext: ".ts"
+    },
+    {
+      id: "test-2",
+      branch_name: "test-branch-2",
+      path: "foo/bar/baz",
+      ext: ".js"
+    }
+  ];
 
   const dispatchMock = jest.fn();
 
@@ -172,56 +210,75 @@ test("useLatestBranchTypescriptFiles hook", () => {
   });
 
   expect(result.current).toEqual({
-    files: [{
-      id: "test-1",
-      branch_name: "test-branch-1",
-      path: "foo/bar/baz",
-      ext: ".ts",
-    }], tsFileCount: 1
+    files: [
+      {
+        id: "test-1",
+        branch_name: "test-branch-1",
+        path: "foo/bar/baz",
+        ext: ".ts"
+      }
+    ],
+    tsFileCount: 1
   });
 });
 
 describe("getBranchTypescriptFiles selector", () => {
   test("should find typescript files", () => {
     const subState = {
-      branches: { branches: [{ name: "test-branch" }], currentBranchName: "test-branch" }, files: {
-        files: [{
-          id: "ts-file",
-          ext: "ts",
-          branch_name: "test-branch"
-        }, {
-          id: "tsx-file",
-          ext: "tsx",
-          branch_name: "test-branch"
-        }, {
-          id: "js-file",
-          ext: "js",
-          branch_name: "test-branch"
-        }]
+      branches: {
+        branches: [{ name: "test-branch" }],
+        currentBranchName: "test-branch"
+      },
+      files: {
+        files: [
+          {
+            id: "ts-file",
+            ext: "ts",
+            branch_name: "test-branch"
+          },
+          {
+            id: "tsx-file",
+            ext: "tsx",
+            branch_name: "test-branch"
+          },
+          {
+            id: "js-file",
+            ext: "js",
+            branch_name: "test-branch"
+          }
+        ]
       }
     };
 
     const state = mainReducer(subState as CombinedState<any>, mockAction);
-    expect(getBranchTypescriptFiles(state)).toEqual([{
+    expect(getBranchTypescriptFiles(state)).toEqual([
+      {
         id: "ts-file",
         ext: "ts",
         branch_name: "test-branch"
-      }, {
+      },
+      {
         id: "tsx-file",
         ext: "tsx",
         branch_name: "test-branch"
-      }]
-    );
+      }
+    ]);
   });
 
   test("should not find typescript files if its absent in store", () => {
     const subState = {
-      branches: { branches: [{ name: "test-branch" }], currentBranchName: "test-branch" }, files: {
-        files: [{
-          id: "js-file",
-          ext: "js",
-          branch_name: "test-branch"
-        }]
+      branches: {
+        branches: [{ name: "test-branch" }],
+        currentBranchName: "test-branch"
+      },
+      files: {
+        files: [
+          {
+            id: "js-file",
+            ext: "js",
+            branch_name: "test-branch"
+          }
+        ]
       }
     };
 
@@ -240,13 +297,14 @@ describe("getCurrentlySelectedFile selector", () => {
             file: {
               id: "file-1",
               ext: "txt",
-              module_name: "test-module",
+              module_name: "test-module"
             }
-          }, {
+          },
+          {
             file: {
               id: "file-2",
               ext: "js",
-              module_name: "test-module",
+              module_name: "test-module"
             }
           }
         ]
@@ -258,7 +316,7 @@ describe("getCurrentlySelectedFile selector", () => {
       file: {
         id: "file-1",
         ext: "txt",
-        module_name: "test-module",
+        module_name: "test-module"
       }
     });
   });
@@ -281,7 +339,7 @@ test("getOpenFileParams selector", () => {
     files: {
       files: [],
       selectedModuleName: "module-test",
-      selectedModuleScope: "/foo",
+      selectedModuleScope: "/foo"
     }
   };
 

--- a/packages/app/src/state/module/hooks/__tests__/useModules.test.tsx
+++ b/packages/app/src/state/module/hooks/__tests__/useModules.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { CombinedState } from "redux";
 import { useDispatch, useSelector } from "react-redux";
@@ -18,7 +34,7 @@ import useModules, {
 import { subscribe } from "../../actions";
 
 jest.mock("react-redux", () => ({
-  ...jest.requireActual("react-redux") as object,
+  ...(jest.requireActual("react-redux") as object),
   useDispatch: jest.fn(),
   useSelector: jest.fn()
 }));
@@ -49,9 +65,13 @@ test("useModules hook", () => {
 });
 
 test("getModules selector", () => {
-  const subState = { modules: { modules: [{ name: "test-module", branch_name: "test-branch" }] } };
+  const subState = {
+    modules: { modules: [{ name: "test-module", branch_name: "test-branch" }] }
+  };
   const state = mainReducer(subState as CombinedState<any>, mockAction);
-  expect(getModules(state)).toEqual([{ name: "test-module", branch_name: "test-branch" }]);
+  expect(getModules(state)).toEqual([
+    { name: "test-module", branch_name: "test-branch" }
+  ]);
 });
 
 describe("getCurrentBranchModules selector", () => {
@@ -65,9 +85,8 @@ describe("getCurrentBranchModules selector", () => {
         ]
       },
       branches: {
-        currentBranchName: "test-branch", branches: [
-          { name: "test-branch", id: "branch-1" }
-        ]
+        currentBranchName: "test-branch",
+        branches: [{ name: "test-branch", id: "branch-1" }]
       }
     };
     const state = mainReducer(subState as CombinedState<any>, mockAction);
@@ -83,9 +102,8 @@ describe("getCurrentBranchModules selector", () => {
         modules: [{ name: "module-1", branch_name: "test-branch" }]
       },
       branches: {
-        currentBranchName: "unknown-branch", branches: [
-          { name: "test-branch", id: "branch-1" }
-        ]
+        currentBranchName: "unknown-branch",
+        branches: [{ name: "test-branch", id: "branch-1" }]
       }
     };
     const state = mainReducer(subState as CombinedState<any>, mockAction);
@@ -133,9 +151,8 @@ describe("getCombinedModules selector", () => {
         ]
       },
       branches: {
-        currentBranchName: "test-branch", branches: [
-          { name: "test-branch", id: "branch-1" }
-        ]
+        currentBranchName: "test-branch",
+        branches: [{ name: "test-branch", id: "branch-1" }]
       }
     };
     const state = mainReducer(subState as CombinedState<any>, mockAction);
@@ -154,7 +171,8 @@ describe("getCombinedModules selector", () => {
         ]
       },
       branches: {
-        currentBranchName: "test-branch", branches: []
+        currentBranchName: "test-branch",
+        branches: []
       }
     };
     const state = mainReducer(subState as CombinedState<any>, mockAction);
@@ -180,7 +198,7 @@ describe("getCombinedModules selector", () => {
         modules: [
           { name: "test-1", branch_name: "main", scope: "/foo" },
           { name: "test-2", branch_name: "main", scope: "/foo" },
-          { name: "test-2", branch_name: "test-branch", scope: "/foo" },
+          { name: "test-2", branch_name: "test-branch", scope: "/foo" }
         ]
       }
     };
@@ -199,7 +217,7 @@ describe("getCombinedModules selector", () => {
           { name: "test-1", branch_name: "test-branch", scope: "/foo" },
           { name: "test-1", branch_name: "main", scope: "/" }
         ]
-      },
+      }
     };
     const state = mainReducer(subState as CombinedState<any>, mockAction);
     expect(getMainBranchModule("test-1", "/foo")(state)).toBeUndefined();
@@ -217,9 +235,8 @@ describe("getCurrentBranchModule selector", () => {
         ]
       },
       branches: {
-        currentBranchName: "test-branch", branches: [
-          { name: "test-branch", id: "branch-1" }
-        ]
+        currentBranchName: "test-branch",
+        branches: [{ name: "test-branch", id: "branch-1" }]
       }
     };
     const state = mainReducer(subState as CombinedState<any>, mockAction);
@@ -236,7 +253,7 @@ describe("getCurrentBranchModule selector", () => {
         modules: [
           { name: "test-1", branch_name: "test-branch", scope: "/foo" },
           { name: "test-1", branch_name: "main", scope: "/" }
-        ],
+        ]
       },
       branches: { currentBranchName: "test-branch", branches: [] }
     };

--- a/packages/app/src/state/moduleVersion/hooks/__tests__/useModuleVersions.test.tsx
+++ b/packages/app/src/state/moduleVersion/hooks/__tests__/useModuleVersions.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { CombinedState } from "redux";
 import { useDispatch, useSelector } from "react-redux";
@@ -15,7 +31,7 @@ import {
 import { subscribe } from "../../actions";
 
 jest.mock("react-redux", () => ({
-  ...jest.requireActual("react-redux") as object,
+  ...(jest.requireActual("react-redux") as object),
   useDispatch: jest.fn(),
   useSelector: jest.fn()
 }));
@@ -29,12 +45,14 @@ afterEach(() => {
 const mockAction = { type: "UNKNOWN_ACTION" } as any;
 
 test("useSortedVersionsForModule hook", () => {
-  const versions = [{
-    module_version: "0.1",
-    version: "1",
-    branch_name: "test",
-    module_name: "test-module",
-  }];
+  const versions = [
+    {
+      module_version: "0.1",
+      version: "1",
+      branch_name: "test",
+      module_name: "test-module"
+    }
+  ];
 
   const dispatchMock = jest.fn();
 
@@ -53,46 +71,59 @@ test("useSortedVersionsForModule hook", () => {
 describe("makeVersionsForModuleSelector selector", () => {
   test("should find versions", () => {
     const subState = {
-      branches: { branches: [{ name: "test-branch", scope: "/" }], currentBranchName: "test-branch" },
+      branches: {
+        branches: [{ name: "test-branch", scope: "/" }],
+        currentBranchName: "test-branch"
+      },
       moduleVersions: {
-        versions: [{
-          branch_name: "test-branch",
-          module_name: "test-1",
-          module_scope: "/",
-          version: "1",
-        }, {
-          branch_name: "test-branch",
-          module_name: "test-2",
-          module_scope: "/",
-          version: "2",
-        }]
+        versions: [
+          {
+            branch_name: "test-branch",
+            module_name: "test-1",
+            module_scope: "/",
+            version: "1"
+          },
+          {
+            branch_name: "test-branch",
+            module_name: "test-2",
+            module_scope: "/",
+            version: "2"
+          }
+        ]
       }
     };
     const state = mainReducer(subState as CombinedState<any>, mockAction);
-    expect(makeVersionsForModuleSelector("test-1", "/")(state)).toEqual([{
-      branch_name: "test-branch",
-      module_name: "test-1",
-      module_scope: "/",
-      version: "1"
-    }]);
+    expect(makeVersionsForModuleSelector("test-1", "/")(state)).toEqual([
+      {
+        branch_name: "test-branch",
+        module_name: "test-1",
+        module_scope: "/",
+        version: "1"
+      }
+    ]);
   });
-
 
   test("should not find versions if its absent in store", () => {
     const subState = {
-      branches: { branches: [{ name: "test-branch", scope: "/" }], currentBranchName: "test-branch" },
+      branches: {
+        branches: [{ name: "test-branch", scope: "/" }],
+        currentBranchName: "test-branch"
+      },
       moduleVersions: {
-        versions: [{
-          branch_name: "test-branch-1",
-          module_name: "test-1",
-          module_scope: "/",
-          version: "1",
-        }, {
-          branch_name: "test-branch-2",
-          module_name: "test-1",
-          module_scope: "/",
-          version: "2",
-        }]
+        versions: [
+          {
+            branch_name: "test-branch-1",
+            module_name: "test-1",
+            module_scope: "/",
+            version: "1"
+          },
+          {
+            branch_name: "test-branch-2",
+            module_name: "test-1",
+            module_scope: "/",
+            version: "2"
+          }
+        ]
       }
     };
     const state = mainReducer(subState as CombinedState<any>, mockAction);
@@ -100,17 +131,19 @@ describe("makeVersionsForModuleSelector selector", () => {
   });
 });
 
-
 test("useLatestMainVersionForModule hook", () => {
-  const versions = [{
-    version: "10",
-    branch_name: "main",
-    module_name: "test-module-1",
-  }, {
-    version: "5",
-    branch_name: "branch-1",
-    module_name: "test-module-2",
-  }];
+  const versions = [
+    {
+      version: "10",
+      branch_name: "main",
+      module_name: "test-module-1"
+    },
+    {
+      version: "5",
+      branch_name: "branch-1",
+      module_name: "test-module-2"
+    }
+  ];
 
   const dispatchMock = jest.fn();
 
@@ -126,6 +159,6 @@ test("useLatestMainVersionForModule hook", () => {
   expect(result.current).toEqual({
     version: "10",
     branch_name: "main",
-    module_name: "test-module-1",
+    module_name: "test-module-1"
   });
 });

--- a/packages/app/src/state/user/hooks/__tests__/useCurrentUser.test.tsx
+++ b/packages/app/src/state/user/hooks/__tests__/useCurrentUser.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -18,7 +34,7 @@ import { mainReducer } from "state/reducer";
 import { CombinedState } from "redux";
 
 jest.mock("react-redux", () => ({
-  ...jest.requireActual("react-redux") as object,
+  ...(jest.requireActual("react-redux") as object),
   useDispatch: jest.fn(),
   useSelector: jest.fn()
 }));
@@ -115,13 +131,15 @@ test("getCurrentUserIdLoaded selector", () => {
       currentUserId: "test2",
       loading: true,
       currentUserIdLoaded: false,
-      users: [{
-        email: "test2@test.com",
-        username: "test2",
-        role: "",
-        opaque_id: "test2",
-        created_at: "20202-11-12"
-      }]
+      users: [
+        {
+          email: "test2@test.com",
+          username: "test2",
+          role: "",
+          opaque_id: "test2",
+          created_at: "20202-11-12"
+        }
+      ]
     }
   };
 


### PR DESCRIPTION
Fix #139

* Adds missing license headers in source code files.
* Skips `.npm`, `.cache` and `build/` folders in license check to fix these kind of errors:
```
2020/12/09 10:47:53 ./.cache/yarn/v6/npm-is-accessor-descriptor-0.1.6-a9e12cb3ae8d876727eeef3843f8a0897b5c98d6-integrity/@(*.ts|*.tsx|*.json|*.go|*.css)
error: lstat ./.cache/yarn/v6/npm-is-accessor-descriptor-0.1.6-a9e12cb3ae8d876727eeef3843f8a0897b5c98d6-integrity/@(*.ts|*.tsx|*.json|*.go|*.css): no such file or directory
```