### PR TITLE
makefile: move all unit tests under a single target

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,8 +34,6 @@ steps:
   - label: "🔨 main test (GCP)"
     key: "maintest-gcp"
     depends_on:
-      - "preamble"
-      - "check-docs"
       - "unit-tests"
     env:
       OPSTRACE_CLUSTER_NAME: "bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-g"
@@ -48,8 +46,6 @@ steps:
   - label: "🔨 main test (AWS)"
     key: "maintest-aws"
     depends_on:
-      - "preamble"
-      - "check-docs"
       - "unit-tests"
     env:
       OPSTRACE_CLUSTER_NAME: "bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-a"


### PR DESCRIPTION
Close #135

*  Move all unit tests under a single makefile target
* Cleanup pipeline dependencies since unit-tests already depends on docs and preamble steps.