### PR TITLE
feat(aws): cortex/loki bucket lifecycle rule for data retention

### DIFF
--- a/packages/installer/src/aws.ts
+++ b/packages/installer/src/aws.ts
@@ -144,10 +144,26 @@ export function* ensureAWSInfraExists(): Generator<
   // create s3 buckets and vpc concurrently
   const tasks = [];
   tasks.push(
-    yield fork([new S3BucketRes(ccfg.cluster_name, lokiBucketName), "setup"])
+    yield fork([
+      new S3BucketRes(
+        ccfg.cluster_name,
+        lokiBucketName,
+        ccfg.log_retention_days,
+        ccfg.tenants
+      ),
+      "setup"
+    ])
   );
   tasks.push(
-    yield fork([new S3BucketRes(ccfg.cluster_name, cortexBucketName), "setup"])
+    yield fork([
+      new S3BucketRes(
+        ccfg.cluster_name,
+        cortexBucketName,
+        ccfg.metric_retention_days,
+        ccfg.tenants
+      ),
+      "setup"
+    ])
   );
 
   const vpctask = yield fork(createVPC, {


### PR DESCRIPTION
Adds a lifecycle rule to the S3 buckets used by loki and cortex to ensure data
is deleted periodically.

Things to know about when S3 data is deleted:

"Amazon S3 rounds the transition or expiration date of an object to midnight
UTC the next day. For example, if you created an object on 1/1/2020 10:30 UTC,
and you set the lifecycle rule to transition the object after 3 days, then the
transition date of the object is 1/5/2020 00:00 UTC. Before you check whether a
lifecycle rule has been satisfied, be sure to verify that enough time has
elapsed."

