### PR TITLE
docs: remove aws/gcp tabs from cluster config ref

### DIFF
--- a/docs/references/cluster-configuration.md
+++ b/docs/references/cluster-configuration.md
@@ -59,7 +59,6 @@ Here be dragons: we develop with three nodes, and—for now—we rarely test wit
 
 ## Optional parameters
 
-<!--tabs-->
 ### `aws`
 
 Allows for setting configuration specific to Amazon Web Services (AWS).
@@ -99,7 +98,6 @@ gcp:
     zone_suffix: a
 ```
 
-<!--/tabs-->
 
 Note: the example above shows the defaults.
 


### PR DESCRIPTION
The tabs should be used here: both, `aws` and `gcp` are high-level optional configuration parameters that should be enumerated like all other high-level optional configuration parameters.

In addition to that, the tabbing leads to problems:
![Screenshot from 2020-12-10 22-13-00](https://user-images.githubusercontent.com/265630/101830588-05b53800-3b35-11eb-8ace-ab99c198bbcc.png)

- notes and warnings are mixed
- the tab headings don't look great because of lower case letters (but lower case letters are correct, because that's how the parameters are named)