### PR TITLE
ci: fix docs pr check regex

### DIFF
--- a/ci/check-if-docs-pr.sh
+++ b/ci/check-if-docs-pr.sh
@@ -44,11 +44,11 @@ FILES_EDITED_IN_PR=$(
 # removed.
 ALLOWLIST="\
 ^docs/|\
-.gitattributes|\
+^.gitattributes|\
 ^.github|\
 ^README.md|\
 ^.markdownlint.json|\
-ci/check-if-docs-pr.sh\
+^ci/check-if-docs-pr.sh\
 "
 
 DOCS_ONLY_CHANGES=$(echo ${FILES_EDITED_IN_PR}| egrep -v "${ALLOWLIST}" | tr -d '[:space:]')


### PR DESCRIPTION
Close #161 

Output for PR where this issue was detected:
```
> BUILDKITE_PULL_REQUEST=160 bash ./ci/check-if-docs-pr.sh
+ source ci/utils.sh
+ echo 'BUILDKITE_PULL_REQUEST: 160'
BUILDKITE_PULL_REQUEST: 160
+ '[' -z 160 ']'
+ '[' 160 = false ']'
++ curl --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/opstrace/opstrace/pulls/160/files
++ command curl --connect-timeout 10 --retry 3 --retry-delay 5 --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/opstrace/opstrace/pulls/160/files
++ curl --connect-timeout 10 --retry 3 --retry-delay 5 --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/opstrace/opstrace/pulls/160/files
++ jq -r '.[].filename'
+ FILES_EDITED_IN_PR='.buildkite/pipeline.yml
ci/check-if-docs-pr.sh'
+ ALLOWLIST='^docs/|^.gitattributes|^.github|^README.md|^.markdownlint.json|^ci/check-if-docs-pr.sh'
++ echo .buildkite/pipeline.yml ci/check-if-docs-pr.sh
++ egrep -v '^docs/|^.gitattributes|^.github|^README.md|^.markdownlint.json|^ci/check-if-docs-pr.sh'
++ tr -d '[:space:]'
+ DOCS_ONLY_CHANGES=.buildkite/pipeline.ymlci/check-if-docs-pr.sh
+ '[' -z .buildkite/pipeline.ymlci/check-if-docs-pr.sh ']'
+ echo 'docs-only PR? PR: yes, but more changed than just docs'
docs-only PR? PR: yes, but more changed than just docs
+ exit 1
```

Previous PR which only touched ` ./ci/check-if-docs-pr.sh`:
```
> BUILDKITE_PULL_REQUEST=94 bash ./ci/check-if-docs-pr.sh 
+ source ci/utils.sh
+ echo 'BUILDKITE_PULL_REQUEST: 94'
BUILDKITE_PULL_REQUEST: 94
+ '[' -z 94 ']'
+ '[' 94 = false ']'
++ curl --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/opstrace/opstrace/pulls/94/files
++ command curl --connect-timeout 10 --retry 3 --retry-delay 5 --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/opstrace/opstrace/pulls/94/files
++ curl --connect-timeout 10 --retry 3 --retry-delay 5 --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/opstrace/opstrace/pulls/94/files
++ jq -r '.[].filename'
+ FILES_EDITED_IN_PR=ci/check-if-docs-pr.sh
+ ALLOWLIST='^docs/|^.gitattributes|^.github|^README.md|^.markdownlint.json|^ci/check-if-docs-pr.sh'
++ echo ci/check-if-docs-pr.sh
++ egrep -v '^docs/|^.gitattributes|^.github|^README.md|^.markdownlint.json|^ci/check-if-docs-pr.sh'
++ tr -d '[:space:]'
+ DOCS_ONLY_CHANGES=
+ '[' -z '' ']'
+ echo '--- docs only PR (94) - skipping next steps'
--- docs only PR (94) - skipping next steps
+ exit 0
```
