### PR TITLE
chore: deploy loki query-frontend

### DIFF
--- a/packages/controller/src/resources/apis/loki.ts
+++ b/packages/controller/src/resources/apis/loki.ts
@@ -63,7 +63,7 @@ export function LokiAPIResources(
   const namespace = getTenantNamespace(tenant);
   const api = "loki";
   const name = `${api}-api`;
-  const lokiQuerierUrl = "http://querier.loki.svc.cluster.local:1080";
+  const lokiQuerierUrl = "http://query-frontend.loki.svc.cluster.local:1080";
   const lokiDistributorUrl = "http://distributor.loki.svc.cluster.local:1080";
 
   const lokiApiProxyCliArgs = [

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -211,7 +211,8 @@ export function CortexResources(
       store_gateway_addresses: `store-gateway.${namespace}.svc.cluster.local:9095`
     },
     query_range: {
-      split_queries_by_day: true,
+      // https://cortexmetrics.io/docs/configuration/configuration-file/#query_range_config
+      split_queries_by_interval: "24h",
       align_queries_with_step: true,
       cache_results: true,
       results_cache: {

--- a/packages/controller/src/resources/loki/index.ts
+++ b/packages/controller/src/resources/loki/index.ts
@@ -1330,10 +1330,34 @@ export function LokiResources(
                       name: "grpc"
                     },
                     {
-                      containerPort: 80,
+                      containerPort: 1080,
                       name: "http"
                     }
                   ],
+                  readinessProbe: {
+                    httpGet: {
+                      path: "/ready",
+                      port: 1080 as any,
+                      scheme: "HTTP"
+                    },
+                    initialDelaySeconds: 45,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
+                  },
+                  livenessProbe: {
+                    httpGet: {
+                      path: "/ready",
+                      port: 1080 as any,
+                      scheme: "HTTP"
+                    },
+                    initialDelaySeconds: 45,
+                    timeoutSeconds: 1,
+                    periodSeconds: 10,
+                    successThreshold: 1,
+                    failureThreshold: 3
+                  },
                   volumeMounts: [
                     {
                       mountPath: "/etc/loki",

--- a/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
@@ -60,7 +60,7 @@ export function GrafanaDatasourceResources(
         editable: false,
         type: "loki",
         orgId: 1,
-        url: "http://querier.loki.svc.cluster.local:1080",
+        url: "http://query-frontend.loki.svc.cluster.local:1080",
         access: "proxy",
         version: 1,
         jsonData: {
@@ -106,7 +106,7 @@ export function GrafanaDatasourceResources(
             editable: false,
             type: "loki",
             orgId: 1,
-            url: "http://querier.loki.svc.cluster.local:1080",
+            url: "http://query-frontend.loki.svc.cluster.local:1080",
             access: "proxy",
             version: 1,
             jsonData: {

--- a/test/test-remote/logstream-gen/index.ts
+++ b/test/test-remote/logstream-gen/index.ts
@@ -327,7 +327,7 @@ function parseCmdlineArgs() {
       "Maximum number of log entries to fetch per query during read/validation phase",
 
     type: "int",
-    defaultValue: 60000
+    defaultValue: 5000
   });
 
   parser.addArgument("--bearer-token-file", {

--- a/test/test-remote/loki-node-client-tools/dummystream.ts
+++ b/test/test-remote/loki-node-client-tools/dummystream.ts
@@ -380,7 +380,7 @@ export class DummyStream {
 
   public async fetchAndValidate(opts: FetchAndValidateOpts): Promise<number> {
     const lokiQuerierBaseURL = opts.querierBaseUrl;
-    const chunkSize = opts.chunkSize || 20000;
+    const chunkSize = opts.chunkSize || 5000;
     const inspectEveryNthEntry = opts.inspectEveryNthEntry || 0;
     const customQueryFunc = opts.customQueryFunc;
     // not yet built in

--- a/test/test-remote/test_loki_log_ingest_api.ts
+++ b/test/test-remote/test_loki_log_ingest_api.ts
@@ -18,6 +18,7 @@ import { strict as assert } from "assert";
 
 import { ZonedDateTime } from "@js-joda/core";
 import got from "got";
+import { performance } from "perf_hooks";
 
 import {
   log,
@@ -263,6 +264,9 @@ suite("Loki API test suite", function () {
   test("insert log records with equivalent timestamps", async function () {
     // @ts-ignore: TS2532: Object is possibly 'undefined'.
     const testname = testName(this);
+    // https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_timeorigin
+    // get current time in nanoseconds from epoch
+    const now = performance.timeOrigin + performance.now();
 
     const payload = {
       streams: [
@@ -272,8 +276,8 @@ suite("Loki API test suite", function () {
             uniq: rndstring().slice(0, 5)
           },
           values: [
-            ["1286705401123456789", "aaa"],
-            ["1286705401123456789", "aaa"]
+            [now, "aaa"],
+            [now, "aaa"]
           ]
         }
       ]

--- a/test/test-remote/test_loki_log_ingest_api.ts
+++ b/test/test-remote/test_loki_log_ingest_api.ts
@@ -388,7 +388,7 @@ suite("Loki API test suite", function () {
     const queryParams = {
       query: `{searchcrit="${searchcrit}"}`,
       direction: "FORWARD",
-      limit: "10000",
+      limit: "5000",
       start: timestampToNanoSinceEpoch(starttime.minusHours(1)),
       end: timestampToNanoSinceEpoch(starttime.plusHours(1))
     };
@@ -493,7 +493,7 @@ suite("Loki API test suite", function () {
       const queryParams = {
         query: `{searchcrit="${searchcrit}"}`,
         direction: "FORWARD",
-        limit: "20000",
+        limit: "5000",
         start: timestampToNanoSinceEpoch(starttime.minusHours(1)),
         end: timestampToNanoSinceEpoch(starttime.plusHours(1))
       };

--- a/test/test-remote/test_loki_log_ingest_api.ts
+++ b/test/test-remote/test_loki_log_ingest_api.ts
@@ -376,7 +376,7 @@ suite("Loki API test suite", function () {
         testname: testname,
         searchcrit: searchcrit
       },
-      10 ** 3,
+      5000,
       textgen
     );
     await postProtobufToLoki(

--- a/test/test-remote/test_loki_log_ingest_api.ts
+++ b/test/test-remote/test_loki_log_ingest_api.ts
@@ -146,7 +146,7 @@ suite("Loki API test suite", function () {
   });
 
   test("insert w/ cntnrzd FluentD(loki plugin), then query", async function () {
-    const sampleTimeRFC3339nano = "2010-10-10T10:10:01.123456789Z";
+    const sampleTimeRFC3339nano = "2020-10-10T10:10:01.123456789Z";
 
     // Objects in this array are examples for what the Docker JSON file logging
     // writes. In particylar, the `log` key and the `time` key are what said
@@ -202,7 +202,7 @@ suite("Loki API test suite", function () {
     const testname = testName(this);
 
     // `sampletsns` is for example: "1286705401123456789"
-    const sampleTimeRFC3339nano = "2010-10-10T10:10:01.123456789Z";
+    const sampleTimeRFC3339nano = "2020-10-10T10:10:01.123456789Z";
     const ts = ZonedDateTime.parse(sampleTimeRFC3339nano);
     const sampletsns = timestampToNanoSinceEpoch(ts);
     const samplemsg = "aaa\nwith newline";
@@ -370,7 +370,7 @@ suite("Loki API test suite", function () {
     }
 
     const searchcrit = rndstring(5);
-    const starttime = ZonedDateTime.parse("2015-01-01T00:01:00.000000000Z");
+    const starttime = ZonedDateTime.parse("2020-01-01T00:01:00.000000000Z");
     const pushrequest = createDummyPushRequest(
       starttime,
       {
@@ -416,7 +416,7 @@ suite("Loki API test suite", function () {
   test("log push load with pbuf, multi stream fragments", async function () {
     // @ts-ignore: TS2532: Object is possibly 'undefined'.
     const testname = testName(this);
-    const starttime = ZonedDateTime.parse("2015-01-01T00:01:00.000000000Z");
+    const starttime = ZonedDateTime.parse("2020-01-01T00:01:00.000000000Z");
 
     // N_streams determines the number of HTTP POST requests made. Each
     // insertion request has in its body a protobuf message containing a push

--- a/test/test-remote/testutils/index.ts
+++ b/test/test-remote/testutils/index.ts
@@ -803,33 +803,3 @@ export async function sendAlertToAlertmanager(
     }
   }
 }
-
-export function toRFC3339(d: Date): string {
-  function pad(n: any) {
-    return n < 10 ? "0" + n : n;
-  }
-
-  function timezoneOffset(offset: any) {
-    if (offset === 0) {
-      return "Z";
-    }
-    const sign = offset > 0 ? "-" : "+";
-    offset = Math.abs(offset);
-    return sign + pad(Math.floor(offset / 60)) + ":" + pad(offset % 60);
-  }
-
-  return (
-    d.getFullYear() +
-    "-" +
-    pad(d.getMonth() + 1) +
-    "-" +
-    pad(d.getDate()) +
-    "T" +
-    pad(d.getHours()) +
-    ":" +
-    pad(d.getMinutes()) +
-    ":" +
-    pad(d.getSeconds()) +
-    timezoneOffset(d.getTimezoneOffset())
-  );
-}

--- a/test/test-remote/testutils/index.ts
+++ b/test/test-remote/testutils/index.ts
@@ -803,3 +803,33 @@ export async function sendAlertToAlertmanager(
     }
   }
 }
+
+export function toRFC3339(d: Date): string {
+  function pad(n: any) {
+    return n < 10 ? "0" + n : n;
+  }
+
+  function timezoneOffset(offset: any) {
+    if (offset === 0) {
+      return "Z";
+    }
+    const sign = offset > 0 ? "-" : "+";
+    offset = Math.abs(offset);
+    return sign + pad(Math.floor(offset / 60)) + ":" + pad(offset % 60);
+  }
+
+  return (
+    d.getFullYear() +
+    "-" +
+    pad(d.getMonth() + 1) +
+    "-" +
+    pad(d.getDate()) +
+    "T" +
+    pad(d.getHours()) +
+    ":" +
+    pad(d.getMinutes()) +
+    ":" +
+    pad(d.getSeconds()) +
+    timezoneOffset(d.getTimezoneOffset())
+  );
+}


### PR DESCRIPTION
https://grafana.com/docs/loki/latest/configuration/query-frontend/#frontend-service

> (...) A common bottleneck (in Loki) is on the read path: queries that executed effortlessly on small data sets may churn to a halt on larger ones. Sometimes we can solve this with more queriers. However, that doesn’t help when our queries are too large for a single querier to execute. Then we need the query frontend

> One of the most important functions of the query frontend is the ability to split larger queries into smaller ones, execute them in parallel, and stitch the results back together.