### PR TITLE
docs: refresh algolia index and re-deploy website when docs change

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,27 @@
+name: Sync Algolia
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "docs/**"
+
+jobs:
+  algolia:
+    runs-on: ubuntu-latest
+    name: Algolia Sync
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: opstrace/algolia-docs-sync@v1
+        with:
+          algoliaId: "QTVPN6XDU8"
+          algoliaKey: ${{ secrets.ALGOLIA_KEY }}
+          algoliaIndex: "opstrace-docs"
+  vercel:
+    runs-on: ubuntu-latest
+    name: Rebuild
+    steps:
+      - name: Trigger rebuild
+        run: curl -X POST https://api.vercel.com/v1/integrations/deploy/${{ secrets.VERCEL_DEPLOY_ID }}


### PR DESCRIPTION
Add a GitHub Action to re-index /docs with Algolia and re-deploy the website with the latest changes on `main`

# Have you...

* [x] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
