### PR TITLE
Fix lib lint

### DIFF
--- a/lib/aws/package.json
+++ b/lib/aws/package.json
@@ -13,7 +13,7 @@
     "watch": "tsc -b -w",
     "clean": "rimraf build .cache tsconfig.tsbuildinfo",
     "prebuild": "yarn clean",
-    "lint": "echo done"
+    "lint": "eslint --ext .ts src/"
   },
   "dependencies": {
     "@opstrace/utils": "^0.0.0",

--- a/lib/aws/src/NATGateway.ts
+++ b/lib/aws/src/NATGateway.ts
@@ -41,7 +41,7 @@ export class NatGatewayRes extends AWSResource<
     const ngws = result.NatGateways;
 
     for (const ng of ngws) {
-      log.debug("NG %s: state %s", ng.NatGatewayId!, ng.State!);
+      log.debug("NG %s: state %s", ng.NatGatewayId, ng.State);
     }
 
     if (ngws.length == 1) {
@@ -56,7 +56,7 @@ export class NatGatewayRes extends AWSResource<
     const notDeleted = ngws.filter(ng => ng.State !== "deleted");
     const failed = ngws.filter(ng => ng.State === "failed");
     const ongoing = ngws.filter(
-      ng => !["failed", "deleted"].includes(ng.State!)
+      ng => !ng.State || !["failed", "deleted"].includes(ng.State)
     );
 
     // If state management is done 'right' then there should never be more

--- a/lib/aws/src/autoScalingGroup.ts
+++ b/lib/aws/src/autoScalingGroup.ts
@@ -143,7 +143,7 @@ class ASGRes extends AWSResource<
     log.info(
       "%s setup: last scaling activity has status `%s`%s",
       this.rname,
-      lastActivity.StatusCode!,
+      lastActivity.StatusCode,
       msgsuffix
     );
 
@@ -156,7 +156,7 @@ class ASGRes extends AWSResource<
       log.warning(
         "%s setup: last scaling activity has status FAILED: %s",
         this.rname,
-        lastActivity.StatusMessage!
+        lastActivity.StatusMessage
       );
       log.warning(
         "The Auto Scaling group shows a `failed`' scaling event (see above " +

--- a/lib/aws/src/bucket.ts
+++ b/lib/aws/src/bucket.ts
@@ -33,7 +33,7 @@ export class S3BucketRes extends AWSResource<true> {
   constructor(
     opstraceClusterName: string,
     bucketName: string,
-    retentionPeriod: number = 0,
+    retentionPeriod = 0,
     tenants: string[] = []
   ) {
     super(opstraceClusterName);
@@ -137,7 +137,9 @@ export class S3BucketRes extends AWSResource<true> {
         }
       }
       // Check if the bucket rules contains all the necessary rule ids.
-      return this.lifecycleRules.every(r => ids.includes(r.ID!));
+      return this.lifecycleRules.every(
+        r => r.ID !== undefined && ids.includes(r.ID)
+      );
     } catch (e) {
       if (e instanceof AWSApiError) {
         if (e.statusCode == 404 || e.statusCode == 403) {
@@ -165,7 +167,7 @@ export class S3BucketRes extends AWSResource<true> {
               // "Specifies the Region where the bucket will be created. If you
               // don't specify a Region, the bucket is created in the US East (N.
               // Virginia) Region (us-east-1)."
-              LocationConstraint: s3Client().config.region!
+              LocationConstraint: s3Client().config.region
             }
           })
           .promise()
@@ -210,7 +212,7 @@ export class S3BucketRes extends AWSResource<true> {
 
     // Chek if the `opstrace-uninstall-auto-delete-after-one-day` lifecycle
     // config has been set (name-based convention).
-    const result: AWS.S3.BucketLifecycleConfiguration = await awsPromErrFilter(
+    const result = await awsPromErrFilter(
       s3Client()
         .getBucketLifecycleConfiguration({
           Bucket: this.bname
@@ -218,7 +220,7 @@ export class S3BucketRes extends AWSResource<true> {
         .promise()
     );
 
-    for (const rule of result.Rules) {
+    for (const rule of result?.Rules ?? []) {
       if (rule.ID === "opstrace-uninstall-auto-delete-after-one-day")
         return true;
     }

--- a/lib/aws/src/eks.ts
+++ b/lib/aws/src/eks.ts
@@ -139,7 +139,7 @@ export async function doesEKSClusterExist({
 
   // now see if the unambigious resource tag also matches.
   if (cluster) {
-    const ocn = cluster.tags!.opstrace_cluster_name;
+    const ocn = cluster.tags?.opstrace_cluster_name;
     if (ocn !== undefined && ocn == opstraceClusterName) {
       return cluster;
     }
@@ -190,6 +190,6 @@ export async function ensureEKSExists({
   return await new EKSRes(opstraceClusterName).setup(eksCreateParams);
 }
 
-export async function destroyEKS(opstraceClusterName: string) {
+export async function destroyEKS(opstraceClusterName: string): Promise<void> {
   return await new EKSRes(opstraceClusterName).teardown();
 }

--- a/lib/aws/src/iam.ts
+++ b/lib/aws/src/iam.ts
@@ -59,7 +59,7 @@ export class ServiceLinkedRoleRes extends AWSResource<true> {
     return false;
   }
 
-  protected async tryDestroy() {
+  protected async tryDestroy(): Promise<void> {
     log.warning("not cleaning up: %s", this.rname);
   }
 

--- a/lib/aws/src/iamRole.ts
+++ b/lib/aws/src/iamRole.ts
@@ -62,7 +62,7 @@ export const attachPolicy = ({
 }: {
   RoleName: string;
   PolicyArn: string;
-}) => {
+}): Promise<void> => {
   return new Promise((resolve, reject) => {
     iamClient().attachRolePolicy({ RoleName, PolicyArn }, err => {
       if (err) {
@@ -79,7 +79,7 @@ export const detachPolicy = ({
 }: {
   RoleName: string;
   PolicyArn: string;
-}) => {
+}): Promise<void> => {
   return new Promise((resolve, reject) => {
     iamClient().detachRolePolicy({ RoleName, PolicyArn }, err => {
       if (err) {
@@ -100,7 +100,7 @@ export function* ensureRoleExists({
 }: {
   RoleName: string;
   AssumeRolePolicyDocument: string;
-}) {
+}): Generator<unknown, IAM.Role, IAM.Role> {
   while (true) {
     const existingRole: IAM.Role = yield call(getRole, {
       RoleName
@@ -131,7 +131,11 @@ export function* ensureRoleExists({
   }
 }
 
-export function* ensureRoleDoesNotExist({ RoleName }: { RoleName: string }) {
+export function* ensureRoleDoesNotExist({
+  RoleName
+}: {
+  RoleName: string;
+}): Generator<unknown, void, IAM.Role> {
   log.info(`Ensuring IAM role ${RoleName} does not exist`);
 
   while (true) {

--- a/lib/aws/src/instanceProfile.ts
+++ b/lib/aws/src/instanceProfile.ts
@@ -116,7 +116,9 @@ export async function createInstanceProfile(
   return ipres.getIpName();
 }
 
-export async function destroyInstanceProfile(opstraceClusterName: string) {
+export async function destroyInstanceProfile(
+  opstraceClusterName: string
+): Promise<void> {
   await new InstanceProfileRes(opstraceClusterName).teardown();
 }
 
@@ -126,7 +128,7 @@ export const addRole = ({
 }: {
   RoleName: string;
   InstanceProfileName: string;
-}) => {
+}): Promise<void> => {
   return new Promise((resolve, reject) => {
     iamClient().addRoleToInstanceProfile(
       { RoleName, InstanceProfileName },
@@ -151,7 +153,7 @@ export const removeRole = ({
 }: {
   RoleName: string;
   InstanceProfileName: string;
-}) => {
+}): Promise<void> => {
   log.info(
     `Ensuring InstanceProfile ${InstanceProfileName} has ${RoleName} role removed`
   );

--- a/lib/aws/src/internetGateway.ts
+++ b/lib/aws/src/internetGateway.ts
@@ -122,12 +122,16 @@ class InternetGatewayRes extends AWSResource<EC2.InternetGateway> {
 /**
  * Expected to yield `EC2.InternetGateway` upon success.
  */
-export async function ensureInternetGatewayExists(clusterName: string) {
+export async function ensureInternetGatewayExists(
+  clusterName: string
+): Promise<EC2.InternetGateway> {
   const igr = new InternetGatewayRes(clusterName);
   return await igr.setup();
 }
 
-export async function ensureInternetGatewayDoesNotExist(clusterName: string) {
+export async function ensureInternetGatewayDoesNotExist(
+  clusterName: string
+): Promise<void> {
   const igr = new InternetGatewayRes(clusterName);
   return await igr.teardown();
 }
@@ -144,7 +148,7 @@ export const attachInternetGateway = ({
 }: {
   InternetGatewayId: string;
   VpcId: string;
-}): Promise<any> => {
+}): Promise<void> => {
   log.info("attaching Internet Gateway to Vpc %s", VpcId);
   return new Promise((resolve, reject) => {
     ec2c().attachInternetGateway({ VpcId, InternetGatewayId }, err => {

--- a/lib/aws/src/launchConfiguration.ts
+++ b/lib/aws/src/launchConfiguration.ts
@@ -54,9 +54,9 @@ const getLaunchConfiguration = async ({
  */
 async function createLaunchConfiguration(
   launchConfigParams: AutoScaling.CreateLaunchConfigurationType
-): Promise<any> {
+): Promise<unknown> {
   // result not well-typed in library,
-  const result: any = await awsPromErrFilter(
+  const result: unknown = await awsPromErrFilter(
     autoScalingClient().createLaunchConfiguration(launchConfigParams).promise()
   );
   if (result) {
@@ -99,7 +99,11 @@ export function* ensureLaunchConfigurationExists({
   imageId: string;
   instanceType: string;
   keyName?: string;
-}) {
+}): Generator<
+  unknown,
+  AutoScaling.LaunchConfiguration,
+  AutoScaling.LaunchConfiguration | undefined
+> {
   log.info(`Ensuring LaunchConfiguration ${LaunchConfigurationName} exists`);
   // Note(JP): assume cluster is ready, and then make it so that this
   // assumption is fulfilled.
@@ -159,7 +163,7 @@ export function* ensureLaunchConfigurationDoesNotExist({
   LaunchConfigurationName
 }: {
   LaunchConfigurationName: string;
-}) {
+}): Generator<unknown, void, AutoScaling.LaunchConfiguration> {
   log.info(
     `Ensuring LaunchConfiguration ${LaunchConfigurationName} does not exist`
   );

--- a/lib/aws/src/policy.ts
+++ b/lib/aws/src/policy.ts
@@ -76,7 +76,7 @@ export function* ensurePolicyExists({
 }: {
   PolicyName: string;
   PolicyDocument: string;
-}) {
+}): Generator<unknown, IAM.Policy, IAM.Policy> {
   while (true) {
     const existingPolicy: IAM.Policy = yield call(getPolicy, {
       PolicyName
@@ -109,7 +109,7 @@ export function* ensurePolicyDoesNotExist({
   PolicyName
 }: {
   PolicyName: string;
-}) {
+}): Generator<unknown, void, IAM.Policy> {
   while (true) {
     const existingPolicy: IAM.Policy = yield call(getPolicy, {
       PolicyName

--- a/lib/aws/src/rdsCluster.ts
+++ b/lib/aws/src/rdsCluster.ts
@@ -190,6 +190,8 @@ export async function ensureRDSClusterExists({
   return await new RDSClusterRes(opstraceDBClusterName).setup(dbCreateParams);
 }
 
-export async function destroyRDSCluster(opstraceDBClusterName: string) {
+export async function destroyRDSCluster(
+  opstraceDBClusterName: string
+): Promise<void> {
   return await new RDSClusterRes(opstraceDBClusterName).teardown();
 }

--- a/lib/aws/src/rdsInstance.ts
+++ b/lib/aws/src/rdsInstance.ts
@@ -169,6 +169,8 @@ export async function ensureRDSInstanceExists({
   return await new RDSInstanceRes(opstraceDBInstanceName).setup(dbCreateParams);
 }
 
-export async function destroyRDSInstance(opstraceDBInstanceName: string) {
+export async function destroyRDSInstance(
+  opstraceDBInstanceName: string
+): Promise<void> {
   return await new RDSInstanceRes(opstraceDBInstanceName).teardown();
 }

--- a/lib/aws/src/route53.ts
+++ b/lib/aws/src/route53.ts
@@ -47,7 +47,9 @@ import { AWSApiError } from "./types";
  *
  * Return after all matching zones have been deleted in the described fashion.
  */
-export async function route53PurgeZonesForDnsName(dnsName: string) {
+export async function route53PurgeZonesForDnsName(
+  dnsName: string
+): Promise<void> {
   log.info("Purge Route53 hosted zone(s) for DNS name: %s", dnsName);
 
   while (true) {
@@ -178,7 +180,7 @@ export async function getRecordsForZone(
       log.debug(
         "route53: got truncated resource record sets response, fetching next batch"
       );
-      params.StartRecordName = result.NextRecordName!;
+      params.StartRecordName = result.NextRecordName;
       params.StartRecordType = result.NextRecordType;
     }
   } while (result.IsTruncated);
@@ -227,7 +229,9 @@ export async function sendChangeRequest(
  * submitted as a "change request" and can then be followed with a so-called
  * change ID. Do this, wait for the task to complete.
  */
-export async function waitForChangeToComplete(change: Route53.ChangeInfo) {
+export async function waitForChangeToComplete(
+  change: Route53.ChangeInfo
+): Promise<void> {
   log.info("route53: wait for submitted change request to complete");
 
   while (true) {

--- a/lib/aws/src/routeTable.ts
+++ b/lib/aws/src/routeTable.ts
@@ -111,9 +111,11 @@ abstract class RouteTableRes extends AWSResource<EC2.RouteTable, string> {
     }
 
     log.info("try to delete route table: %s", rt.RouteTableId);
-    await deleteRouteTable({
-      RouteTableId: rt.RouteTableId!
-    });
+    if (rt.RouteTableId) {
+      await deleteRouteTable({
+        RouteTableId: rt.RouteTableId
+      });
+    }
   }
 
   protected async checkDestroySuccess(): Promise<true | string> {

--- a/lib/aws/src/securityGroup.ts
+++ b/lib/aws/src/securityGroup.ts
@@ -105,7 +105,7 @@ export const authorizeSecurityGroupEgress = ({
   Rule
 }: {
   Rule: EC2.AuthorizeSecurityGroupEgressRequest;
-}) => {
+}): Promise<void> => {
   return new Promise((resolve, reject) => {
     ec2c().authorizeSecurityGroupEgress(Rule, err => {
       if (err) {
@@ -125,7 +125,7 @@ export const revokeSecurityGroupEgress = ({
 }: {
   GroupId: string;
   IpPermissions: EC2.IpPermissionList;
-}) => {
+}): Promise<void> => {
   return new Promise((resolve, reject) => {
     ec2c().revokeSecurityGroupEgress(
       {
@@ -146,7 +146,7 @@ export const authorizeSecurityGroupIngress = ({
   Rule
 }: {
   Rule: EC2.AuthorizeSecurityGroupIngressRequest;
-}) => {
+}): Promise<void> => {
   return new Promise((resolve, reject) => {
     ec2c().authorizeSecurityGroupIngress(Rule, err => {
       if (err) {
@@ -166,7 +166,7 @@ export const revokeSecurityGroupIngress = ({
 }: {
   GroupId: string;
   IpPermissions: EC2.IpPermissionList;
-}) => {
+}): Promise<void> => {
   return new Promise((resolve, reject) => {
     ec2c().revokeSecurityGroupIngress(
       {
@@ -193,7 +193,7 @@ export function* ensureSecurityGroupExists({
   GroupName: string;
   name: string;
   Description: string;
-}) {
+}): Generator<unknown, EC2.SecurityGroup, EC2.SecurityGroup> {
   // Note(JP): towards making clear what name that is.
   const clusterName = name;
 
@@ -239,7 +239,7 @@ export function* ensureSecurityGroupPermissionsDoNotExist({
   GroupName
 }: {
   GroupName: string;
-}) {
+}): Generator<unknown, void, EC2.SecurityGroup> {
   log.info(
     "Ensuring Security Group Permissions do not exist for %s",
     GroupName
@@ -295,7 +295,7 @@ export function* ensureSecurityGroupDoesNotExist({
   GroupName
 }: {
   GroupName: string;
-}) {
+}): Generator<unknown, void, EC2.SecurityGroup> {
   log.info("Delete security group: %s", GroupName);
 
   while (true) {

--- a/lib/aws/src/sts.ts
+++ b/lib/aws/src/sts.ts
@@ -61,7 +61,7 @@ export class STSRegionCheck extends AWSResource<true> {
     return false;
   }
 
-  protected async tryDestroy() {
+  protected async tryDestroy(): Promise<void> {
     log.warning("tryDestroy() should never be called: %s", this.rname);
   }
 
@@ -91,7 +91,7 @@ export class STSAccountIDRes extends AWSResource<string> {
     return false;
   }
 
-  protected async tryDestroy() {
+  protected async tryDestroy(): Promise<void> {
     log.warning("tryDestroy() should never be called: %s", this.rname);
   }
 

--- a/lib/aws/src/types.ts
+++ b/lib/aws/src/types.ts
@@ -17,9 +17,12 @@
 import * as yup from "yup";
 import { EC2 } from "aws-sdk";
 
-export declare interface Dict<T = any> {
+export declare interface Dict<T = unknown> {
   [key: string]: T;
 }
+
+export type PickRequired<T, K extends keyof T> = Omit<T, K> &
+  Required<Pick<T, K>>;
 
 export const awsConfigSchema = yup.object({
   certManagerRoleArn: yup.string()

--- a/lib/aws/src/vpcEndpoint.ts
+++ b/lib/aws/src/vpcEndpoint.ts
@@ -63,7 +63,7 @@ export class VpcEndpointRes extends AWSResource<
     return await this.lookup();
   }
 
-  protected async tryDestroy() {
+  protected async tryDestroy(): Promise<void> {
     const vpe = await this.lookup();
     if (vpe === false) {
       return;

--- a/lib/dns/package.json
+++ b/lib/dns/package.json
@@ -13,7 +13,7 @@
     "watch": "tsc -b -w",
     "clean": "rimraf build .cache tsconfig.tsbuildinfo",
     "prebuild": "yarn clean",
-    "lint": "echo done"
+    "lint": "eslint --ext .ts src/"
   },
   "dependencies": {
     "@google-cloud/dns": "^2.0.2",

--- a/lib/dns/src/aws.ts
+++ b/lib/dns/src/aws.ts
@@ -51,7 +51,7 @@ export const getZone = async ({
             name: r.Name,
             type: r.Type,
             ttl: r.TTL,
-            rrdatas: r.ResourceRecords!.map(r => r.Value)
+            rrdatas: r.ResourceRecords?.map(r => r.Value)
           }));
           resolve({ zone: { name: Id, dnsName: Name }, records });
         });
@@ -69,7 +69,7 @@ export const createZone = async ({
 }: {
   dnsName: string;
   dns: Route53;
-}): Promise<any> => {
+}): Promise<void> => {
   return new Promise((resolve, reject) =>
     dns.createHostedZone(
       {
@@ -99,7 +99,7 @@ export const addNSRecord = async ({
   dns: Route53;
   zone: DNSZone;
   record: ReturnType<typeof constructNSRecordOptions>;
-}): Promise<any> => {
+}): Promise<void> => {
   return new Promise((resolve, reject) =>
     dns.changeResourceRecordSets(
       {
@@ -108,7 +108,7 @@ export const addNSRecord = async ({
             {
               Action: "CREATE",
               ResourceRecordSet: {
-                Name: record.name!,
+                Name: record.name,
                 ResourceRecords: record.data.map(d => ({ Value: d })),
                 TTL: record.ttl,
                 Type: "NS"
@@ -117,7 +117,8 @@ export const addNSRecord = async ({
           ],
           Comment: `Managed by Opstrace`
         },
-        HostedZoneId: zone.name!
+        // FIXME: What if our zone.name is indeed undefined?
+        HostedZoneId: zone.name ?? ""
       },
       err => {
         if (err) {

--- a/lib/dns/src/opstrace.ts
+++ b/lib/dns/src/opstrace.ts
@@ -72,7 +72,7 @@ export class DNSClient {
     return Promise.resolve(DNSClient.instance);
   }
 
-  public async Login() {
+  public async Login(): Promise<void> {
     if (this.accessToken !== "") {
       return;
     }
@@ -99,6 +99,7 @@ export class DNSClient {
     log.info("Verification code: %s", res.data["user_code"]);
 
     // visualzie the countdown before trying to open the browser.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const _ in [1, 2, 3, 4, 5]) {
       await delay(1000);
       process.stderr.write(".");

--- a/lib/dns/src/types.ts
+++ b/lib/dns/src/types.ts
@@ -30,3 +30,6 @@ export type DNSZone = {
 
 // Denotes support for these 2 providers
 export type Provider = "aws" | "gcp";
+
+export type PartialRequired<T, K extends keyof T> = Omit<T, K> &
+  Required<Pick<T, K>>;

--- a/lib/dns/src/util.ts
+++ b/lib/dns/src/util.ts
@@ -20,7 +20,11 @@ export const constructNSRecordOptions = ({
 }: {
   name: string;
   nameservers: string[];
-}) => ({
+}): {
+  name: string;
+  data: string[];
+  ttl: number;
+} => ({
   name,
   data: nameservers,
   ttl: 30
@@ -32,4 +36,4 @@ export const getSubdomain = ({
 }: {
   stackName: string;
   dnsName: string;
-}) => `${stackName}.${dnsName}`;
+}): string => `${stackName}.${dnsName}`;

--- a/lib/gcp/package.json
+++ b/lib/gcp/package.json
@@ -13,7 +13,7 @@
     "watch": "tsc -b -w",
     "clean": "rimraf build .cache tsconfig.tsbuildinfo",
     "prebuild": "yarn clean",
-    "lint": "eslint . --ext .ts --quiet"
+    "lint": "eslint --ext .ts src"
   },
   "dependencies": {
     "@google-cloud/common": "^3.4.1",

--- a/lib/gcp/src/NATGateway.ts
+++ b/lib/gcp/src/NATGateway.ts
@@ -29,7 +29,7 @@ class Router extends Compute {
     region: string,
     network: string,
     project: string,
-    callback: (err: Error, data: any) => Record<string, unknown>
+    callback: (err: Error, data: unknown) => Record<string, unknown> | void
   ) {
     //@ts-ignore : don't know the reason but have to add one now for ESLint :-).
     this.request(
@@ -54,7 +54,7 @@ class Router extends Compute {
   destroyGateway(
     name: string,
     region: string,
-    callback: (err: Error, data: any) => Record<string, unknown>
+    callback: (err: Error, data: unknown) => Record<string, unknown> | void
   ) {
     //@ts-ignore: don't know the reason but have to add one now for ESLint :-).
     this.request(
@@ -68,7 +68,7 @@ class Router extends Compute {
   getGateway(
     name: string,
     region: string,
-    callback: (err: Error, data: any) => void
+    callback: (err: Error, data: unknown) => void
   ) {
     //@ts-ignore: don't know the reason but have to add one now for ESLint :-).
     this.request(
@@ -90,7 +90,7 @@ const doesGatewayExist = async (
   new Promise(async res => {
     try {
       await new Promise((resolve, reject) => {
-        client.getGateway(name, region, (err: Error, data: any) => {
+        client.getGateway(name, region, (err: Error) => {
           if (err) {
             reject(err);
           } else {
@@ -105,7 +105,7 @@ const doesGatewayExist = async (
   });
 
 const createGateway = (
-  client: any,
+  client: Router,
   {
     name,
     region,
@@ -119,23 +119,17 @@ const createGateway = (
   }
 ) =>
   new Promise((resolve, reject) => {
-    client.createGateway(
-      name,
-      region,
-      network,
-      project,
-      (err: Error, _: any) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(true);
-        }
+    client.createGateway(name, region, network, project, (err: Error) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(true);
       }
-    );
+    });
   });
 
 const destroyGateway = (
-  client: any,
+  client: Router,
   {
     name,
     region
@@ -145,7 +139,7 @@ const destroyGateway = (
   }
 ) =>
   new Promise((resolve, reject) => {
-    client.destroyGateway(name, region, (err: Error, _: any) => {
+    client.destroyGateway(name, region, (err: Error) => {
       if (err) {
         reject(err);
       } else {

--- a/lib/gcp/src/bucket.ts
+++ b/lib/gcp/src/bucket.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { delay, call } from "redux-saga/effects";
+import { delay, call, CallEffect } from "redux-saga/effects";
 import * as gcs from "@google-cloud/storage";
 
 import { SECOND, log } from "@opstrace/utils";
@@ -98,7 +98,7 @@ export function* ensureBucketExists({
   bucketName: string;
   retentionDays: number;
   region: string;
-}) {
+}): Generator<CallEffect, unknown, unknown> {
   const storage = new gcs.Storage();
 
   log.info("create GCS bucket: %s", bucketName);
@@ -133,7 +133,11 @@ export function* ensureBucketExists({
   }
 }
 
-export function* emptyBucket({ bucketName }: { bucketName: string }) {
+export function* emptyBucket({
+  bucketName
+}: {
+  bucketName: string;
+}): Generator<CallEffect, void, unknown> {
   const storage = new gcs.Storage();
 
   const bucket = yield call(getBucket, { name: bucketName, storage });

--- a/lib/gcp/src/bucket.ts
+++ b/lib/gcp/src/bucket.ts
@@ -47,7 +47,7 @@ const createBucket = async ({
   name: string;
   location: string;
   storage: gcs.Storage;
-}): Promise<[gcs.Bucket, any] | null> => {
+}): Promise<gcs.CreateBucketResponse | null> => {
   return storage.createBucket(name, {
     location
   });
@@ -61,7 +61,7 @@ export const setBucketLifecycle = async ({
   name: string;
   days: number;
   storage: gcs.Storage;
-}): Promise<[gcs.Bucket, any] | null> =>
+}): Promise<gcs.CreateBucketResponse | null> =>
   new Promise((resolve, reject) => {
     const bucket = storage.bucket(name);
     //-

--- a/lib/gcp/src/cloudSQL.ts
+++ b/lib/gcp/src/cloudSQL.ts
@@ -76,7 +76,7 @@ export function* ensureCloudSQLExists({
   region: string;
   ipCidrRange: string;
   opstraceClusterName: string;
-  instance: sql_v1beta4.Schema$DatabaseInstance;
+  instance: sql_v1beta4.Schema$DatabaseInstance; // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }): Generator<CallEffect, sql_v1beta4.Schema$DatabaseInstance, any> {
   log.info(`Ensuring CloudSQL exists`);
 

--- a/lib/gcp/src/cloudSQL.ts
+++ b/lib/gcp/src/cloudSQL.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { call, delay } from "redux-saga/effects";
+import { call, delay, CallEffect } from "redux-saga/effects";
 import { google, sql_v1beta4 } from "googleapis";
 import { log, SECOND } from "@opstrace/utils";
 import {
@@ -77,7 +77,7 @@ export function* ensureCloudSQLExists({
   ipCidrRange: string;
   opstraceClusterName: string;
   instance: sql_v1beta4.Schema$DatabaseInstance;
-}): Generator<any, sql_v1beta4.Schema$DatabaseInstance, any> {
+}): Generator<CallEffect, sql_v1beta4.Schema$DatabaseInstance, any> {
   log.info(`Ensuring CloudSQL exists`);
 
   const auth = new google.auth.GoogleAuth({
@@ -131,7 +131,7 @@ export function* ensureCloudSQLDoesNotExist({
 }: {
   opstraceClusterName: string;
   addressName: string;
-}): Generator<any, any, any> {
+}): Generator<CallEffect, void, unknown> {
   const auth = new google.auth.GoogleAuth({
     scopes: [
       "https://www.googleapis.com/auth/cloud-platform",

--- a/lib/gcp/src/cloudSQLDatabase.ts
+++ b/lib/gcp/src/cloudSQLDatabase.ts
@@ -90,7 +90,7 @@ async function destroySQLDatabase(name: string) {
 export function* ensureSQLDatabaseExists({
   opstraceClusterName
 }: {
-  opstraceClusterName: string;
+  opstraceClusterName: string; // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }): Generator<any, sql_v1beta4.Schema$Database, any> {
   while (true) {
     const existingSQLDatabase: sql_v1beta4.Schema$Database = yield call(
@@ -104,7 +104,7 @@ export function* ensureSQLDatabaseExists({
       } catch (e) {
         /**
          Google api returns a 400 (not the expected 409) if the database already exists...
-         
+
          "data": {
           "error": {
             "code": 400,
@@ -138,7 +138,9 @@ export function* ensureSQLDatabaseExists({
   }
 }
 
-export function* ensureSQLDatabaseDoesNotExist(opstraceClusterName: string) {
+export function* ensureSQLDatabaseDoesNotExist(
+  opstraceClusterName: string // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Generator<any, void, any> {
   log.info("SQLDatabase teardown: start");
 
   while (true) {

--- a/lib/gcp/src/cloudSQLInstance.ts
+++ b/lib/gcp/src/cloudSQLInstance.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { strict as assert } from "assert";
 import { delay, call, CallEffect } from "redux-saga/effects";
 import { google, sql_v1beta4 } from "googleapis";
 
@@ -53,7 +54,7 @@ export async function getSQLInstance(
  */
 export async function getRunnableSQLInstanceName(
   opstraceClusterName: string
-): Promise<string | boolean> {
+): Promise<string | false> {
   const instance = await getSQLInstance(opstraceClusterName);
   if (!instance || instance.state !== "RUNNABLE" || !instance.name) {
     return false;
@@ -85,11 +86,12 @@ export function* ensureSQLInstanceExists({
   instance
 }: {
   opstraceClusterName: string;
-  instance: sql_v1beta4.Schema$DatabaseInstance;
+  instance: sql_v1beta4.Schema$DatabaseInstance; // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }): Generator<CallEffect, sql_v1beta4.Schema$DatabaseInstance, any> {
   // Ensure instance has the correct label - this is the primary method for
   // correlating an instance with an Opstrace cluster.
-  instance.settings!.userLabels!.opstrace_cluster_name = opstraceClusterName;
+  assert(instance.settings?.userLabels);
+  instance.settings.userLabels.opstrace_cluster_name = opstraceClusterName;
   // Create a random name for the instance to avoid the following constraint:
   // When you delete an instance, you cannot reuse the name of the deleted instance until one week from the deletion date.
   // There is an 82 char limit for instance names - we are fine using ~13 chars for the unix time suffix
@@ -125,7 +127,7 @@ export function* ensureSQLInstanceExists({
 }
 
 export function* ensureSQLInstanceDoesNotExist(
-  opstraceClusterName: string
+  opstraceClusterName: string // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Generator<CallEffect, void, any> {
   log.info("SQLInstance teardown: start");
 

--- a/lib/gcp/src/cloudSQLInstance.ts
+++ b/lib/gcp/src/cloudSQLInstance.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { delay, call } from "redux-saga/effects";
+import { delay, call, CallEffect } from "redux-saga/effects";
 import { google, sql_v1beta4 } from "googleapis";
 
 import { getGcpProjectId } from "./cluster";
@@ -51,7 +51,9 @@ export async function getSQLInstance(
  * Get the CloudSQL instance NAME in RUNNABLE state associated with this Opstrace cluster, or false.
  * @param opstraceClusterName
  */
-export async function getRunnableSQLInstanceName(opstraceClusterName: string) {
+export async function getRunnableSQLInstanceName(
+  opstraceClusterName: string
+): Promise<string | boolean> {
   const instance = await getSQLInstance(opstraceClusterName);
   if (!instance || instance.state !== "RUNNABLE" || !instance.name) {
     return false;
@@ -84,7 +86,7 @@ export function* ensureSQLInstanceExists({
 }: {
   opstraceClusterName: string;
   instance: sql_v1beta4.Schema$DatabaseInstance;
-}): Generator<any, sql_v1beta4.Schema$DatabaseInstance, any> {
+}): Generator<CallEffect, sql_v1beta4.Schema$DatabaseInstance, any> {
   // Ensure instance has the correct label - this is the primary method for
   // correlating an instance with an Opstrace cluster.
   instance.settings!.userLabels!.opstrace_cluster_name = opstraceClusterName;
@@ -122,7 +124,9 @@ export function* ensureSQLInstanceExists({
   }
 }
 
-export function* ensureSQLInstanceDoesNotExist(opstraceClusterName: string) {
+export function* ensureSQLInstanceDoesNotExist(
+  opstraceClusterName: string
+): Generator<CallEffect, void, any> {
   log.info("SQLInstance teardown: start");
 
   while (true) {

--- a/lib/gcp/src/cluster.ts
+++ b/lib/gcp/src/cluster.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { delay, call } from "redux-saga/effects";
+import { delay, call, CallEffect } from "redux-saga/effects";
 
 import { ApiError as GCPApiError } from "@google-cloud/common";
 import { google } from "googleapis";
@@ -25,6 +25,7 @@ import {
 
 import { SECOND, log } from "@opstrace/utils";
 import { GKECluster, RUNNING, ERROR } from "./types";
+import { ClusterManagerClient } from "@google-cloud/container/build/src/v1";
 
 const container = google.container("v1");
 
@@ -102,7 +103,7 @@ export async function getAllGKEClusters(): Promise<
 }
 
 const createGKECluster = async (
-  client: any,
+  client: ClusterManagerClient,
   {
     name,
     cluster,
@@ -168,7 +169,7 @@ export function* ensureGKEExists({
   cluster,
   gcpProjectID
 }: GKEExistsRequest): Generator<
-  any,
+  CallEffect,
   gkeProtos.google.container.v1.ICluster,
   any
 > {

--- a/lib/gcp/src/globalAddress.ts
+++ b/lib/gcp/src/globalAddress.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { delay, call } from "redux-saga/effects";
+import { delay, call, CallEffect } from "redux-saga/effects";
 import { google, compute_v1 } from "googleapis";
 import { SECOND, log } from "@opstrace/utils";
 import { getGcpProjectId } from "./cluster";
@@ -88,7 +88,11 @@ export function* ensureAddressExists({
   network: string;
   region: string;
   ipCidrRange: string;
-}) {
+}): Generator<
+  CallEffect,
+  compute_v1.Schema$Address,
+  compute_v1.Schema$Address
+> {
   log.info("create global Address: %s", addressName);
   while (true) {
     const address: compute_v1.Schema$Address = yield call(getAddress, {
@@ -128,7 +132,7 @@ export function* ensureAddressDoesNotExist({
   addressName
 }: {
   addressName: string;
-}) {
+}): Generator<CallEffect, void, compute_v1.Schema$Address> {
   while (true) {
     const address: compute_v1.Schema$Address = yield call(getAddress, {
       name: addressName

--- a/lib/gcp/src/iam.ts
+++ b/lib/gcp/src/iam.ts
@@ -16,7 +16,7 @@
 
 import { log, SECOND } from "@opstrace/utils";
 import { google, iam_v1 } from "googleapis";
-import { delay, call } from "redux-saga/effects";
+import { delay, call, CallEffect } from "redux-saga/effects";
 
 const iam = google.iam("v1");
 const resourcemanager = google.cloudresourcemanager("v1");
@@ -202,7 +202,7 @@ export function* ensureServiceAccountExists({
   projectId: string;
   role: string;
   kubernetesServiceAccount: string;
-}): Generator<any, string, any> {
+}): Generator<CallEffect, string, any> {
   while (true) {
     try {
       const sa =

--- a/lib/gcp/src/network.ts
+++ b/lib/gcp/src/network.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { delay, call } from "redux-saga/effects";
+import { delay, call, CallEffect } from "redux-saga/effects";
 //@ts-ignore: don't know the reason but have to add one now for ESLint :-).
 import Compute from "@google-cloud/compute";
 import { log, SECOND } from "@opstrace/utils";
@@ -25,7 +25,7 @@ class Routes extends Compute {
   }
   destroy(
     name: string,
-    callback: (err: any, data: any) => Record<string, unknown>
+    callback: (err: Error, data: any) => Record<string, unknown>
   ) {
     //@ts-ignore: don't know the reason but have to add one now for ESLint :-).
     this.request(
@@ -36,7 +36,7 @@ class Routes extends Compute {
       callback
     );
   }
-  list(callback: (err: any, data: any) => void) {
+  list(callback: (err: Error, data: any) => void) {
     //@ts-ignore: don't know the reason but have to add one now for ESLint :-).
     this.request(
       {
@@ -50,7 +50,7 @@ class Routes extends Compute {
 
 const getRoutes = (client: any, networkName: string) =>
   new Promise((resolve, reject) => {
-    client.list((err: any, data: any) => {
+    client.list((err: Error, data: any) => {
       if (err) {
         reject(err);
       } else {
@@ -73,7 +73,7 @@ const getRoutes = (client: any, networkName: string) =>
 
 const destroyRoute = (client: any, name: string) =>
   new Promise((resolve, reject) => {
-    client.destroy(name, (err: any, _: any) => {
+    client.destroy(name, (err: Error, _: any) => {
       if (err) {
         reject(err);
       } else {
@@ -118,7 +118,9 @@ export interface NetworkRequest {
   name: string;
 }
 
-export function* ensureNetworkExists(networkName: string) {
+export function* ensureNetworkExists(
+  networkName: string
+): Generator<CallEffect, boolean, boolean> {
   const client = new Compute();
 
   while (true) {
@@ -151,7 +153,9 @@ export function* ensureNetworkExists(networkName: string) {
   }
 }
 
-export function* ensureNetworkDoesNotExist({ name }: NetworkRequest) {
+export function* ensureNetworkDoesNotExist({
+  name
+}: NetworkRequest): Generator<CallEffect, void, any> {
   const client = new Compute();
 
   const routesClient = new Routes();

--- a/lib/gcp/src/network.ts
+++ b/lib/gcp/src/network.ts
@@ -19,6 +19,9 @@ import { delay, call, CallEffect } from "redux-saga/effects";
 import Compute from "@google-cloud/compute";
 import { log, SECOND } from "@opstrace/utils";
 
+// Currently as @google-cloud/compute does not provide typings - it doesn't
+// make much sense to fix all lint errors for any
+/* eslint-disable @typescript-eslint/no-explicit-any */
 class Routes extends Compute {
   constructor(options = {}) {
     super(options);
@@ -73,7 +76,7 @@ const getRoutes = (client: any, networkName: string) =>
 
 const destroyRoute = (client: any, name: string) =>
   new Promise((resolve, reject) => {
-    client.destroy(name, (err: Error, _: any) => {
+    client.destroy(name, (err: Error) => {
       if (err) {
         reject(err);
       } else {

--- a/lib/gcp/src/subnetworks.ts
+++ b/lib/gcp/src/subnetworks.ts
@@ -26,7 +26,7 @@ import { log, SECOND } from "@opstrace/utils";
 const doesSubNetworkExist = async (
   client: any,
   { name }: { name: string }
-): Promise<any> => {
+): Promise<unknown> => {
   return new Promise((resolve, reject) => {
     client
       .getSubnetworks()
@@ -61,7 +61,11 @@ const createSubNetwork = (
   });
 };
 
-const deleteSubNetwork = (client: any, region: string, name: string) => {
+const deleteSubNetwork = (
+  client: any,
+  region: string,
+  name: string
+): Promise<unknown> => {
   return new Promise((resolve, reject) => {
     client
       .region(region)

--- a/lib/gcp/src/subnetworks.ts
+++ b/lib/gcp/src/subnetworks.ts
@@ -22,6 +22,10 @@ import { ApiError as GCPApiError } from "@google-cloud/common";
 import Compute from "@google-cloud/compute";
 import { log, SECOND } from "@opstrace/utils";
 
+// Currently as @google-cloud/compute does not provide typings - it doesn't
+// make much sense to fix all lint errors for any
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 // assume one subnet with that name,  not multiple
 const doesSubNetworkExist = async (
   client: any,
@@ -91,7 +95,7 @@ export function* ensureSubNetworkExists({
   gcpRegion,
   gcpProjectID,
   ipCidrRange
-}: SubnetRequest) {
+}: SubnetRequest): Generator<unknown, void, unknown> {
   const client = new Compute();
 
   const snetname = opstraceClusterName;
@@ -152,7 +156,7 @@ export function* ensureSubNetworkExists({
 export function* ensureSubNetworkDoesNotExist(
   opstraceClusterName: string,
   gcpRegion: string
-) {
+): Generator<unknown, void, unknown> {
   const client = new Compute();
 
   let operation: any;

--- a/lib/gcp/src/types.ts
+++ b/lib/gcp/src/types.ts
@@ -249,7 +249,7 @@ export const gkeCluster = t.partial(
     nodePools: t.array(partialNodePool),
     locations: t.array(t.string),
     enableKubernetesAlpha: t.boolean,
-    resourceLabels: t.any,
+    resourceLabels: t.unknown,
     labelFingerprint: t.string,
     legacyAbac: t.partial(
       t.interface({

--- a/lib/gcp/src/util.ts
+++ b/lib/gcp/src/util.ts
@@ -28,7 +28,7 @@ export function generateKubeconfigStringForGkeCluster(
   return `apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: ${cluster.masterAuth!.clusterCaCertificate}
+    certificate-authority-data: ${cluster.masterAuth?.clusterCaCertificate}
     server: https://${cluster.endpoint}
   name: ${context}
 contexts:

--- a/lib/gcp/src/util.ts
+++ b/lib/gcp/src/util.ts
@@ -23,7 +23,7 @@ import { GCPAuthOptions, serviceAccountSchema } from "./types";
 export function generateKubeconfigStringForGkeCluster(
   projectid: string,
   cluster: gkeProtos.google.container.v1.ICluster
-) {
+): string {
   const context = `${projectid}_${cluster.name}`;
   return `apiVersion: v1
 clusters:
@@ -70,11 +70,11 @@ export const getValidatedGCPAuthOptionsFromFile = (
 
 let certManagerSA: string | undefined;
 
-export function setCertManagerServiceAccount(sa: string) {
+export function setCertManagerServiceAccount(sa: string): void {
   certManagerSA = sa;
 }
 
-export function getCertManagerServiceAccount() {
+export function getCertManagerServiceAccount(): string {
   if (certManagerSA === undefined) {
     throw new Error("call setCertManagerServiceAccount() first");
   }
@@ -83,11 +83,11 @@ export function getCertManagerServiceAccount() {
 
 let externalDNSSA: string | undefined;
 
-export function setExternalDNSServiceAccount(sa: string) {
+export function setExternalDNSServiceAccount(sa: string): void {
   externalDNSSA = sa;
 }
 
-export function getExternalDNSServiceAccount() {
+export function getExternalDNSServiceAccount(): string {
   if (externalDNSSA === undefined) {
     throw new Error("call setExternalDNSServiceAccount() first");
   }
@@ -96,11 +96,11 @@ export function getExternalDNSServiceAccount() {
 
 let cortexSA: string | undefined;
 
-export function setCortexServiceAccount(sa: string) {
+export function setCortexServiceAccount(sa: string): void {
   cortexSA = sa;
 }
 
-export function getCortexServiceAccount() {
+export function getCortexServiceAccount(): string {
   if (cortexSA === undefined) {
     throw new Error("call setCortexServiceAccount() first");
   }
@@ -109,11 +109,11 @@ export function getCortexServiceAccount() {
 
 let lokiSA: string | undefined;
 
-export function setLokiServiceAccount(sa: string) {
+export function setLokiServiceAccount(sa: string): void {
   lokiSA = sa;
 }
 
-export function getLokiServiceAccount() {
+export function getLokiServiceAccount(): string {
   if (lokiSA === undefined) {
     throw new Error("call setLokiServiceAccount() first");
   }

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -469,6 +469,7 @@ export async function waitUntilGrafanaIsReachable(
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async function wait(probeUrl: string, tenantName: string) {
     let attempt = 0;
     while (true) {


### PR DESCRIPTION
Part #51

- `dns/aws.ts` HostedZoneId was used as `zone.name` what will happen if its undefined or empty string like it was before? Or is it possbile at all?
- `dns/index.ts` Is it actually safe to assume that if we have no name-servers we can skip AddNameservers call?
- Ignore `lib/gcp/network` and `lib/gcp/subnetworks` there are a lot of warnings with any type. Because we use library without types
- `lib/kubernetes` will be fixed in another PR (there are too much errors and warnings)