### PR TITLE
fix: duplicate sample for timestamp

### DIFF
--- a/packages/controller/src/resources/monitoring/tenants/prometheus.ts
+++ b/packages/controller/src/resources/monitoring/tenants/prometheus.ts
@@ -25,14 +25,12 @@ import {
   withPodAntiAffinityRequired
 } from "@opstrace/kubernetes";
 import {
-  getNodeCount,
   getTenantNamespace,
   getPrometheusName,
   getDomain
 } from "../../../helpers";
 import { State } from "../../../reducer";
 import { Tenant } from "@opstrace/tenants";
-import { select } from "@opstrace/utils";
 import { KubeConfig } from "@kubernetes/client-node";
 
 export function PrometheusResources(
@@ -45,13 +43,9 @@ export function PrometheusResources(
   const name = getPrometheusName(tenant);
 
   const config = {
-    replicas: select(getNodeCount(state), [
-      { "<=": 6, choose: 2 },
-      {
-        "<=": Infinity,
-        choose: 3
-      }
-    ]),
+    // TODO: set number of replicas per shard with
+    // https://github.com/opstrace/opstrace/pull/215
+    replicas: 1,
     diskSize: "10Gi",
     resources: {}
   };


### PR DESCRIPTION
Reduce the number of Prometheus scraping replicas. The proper fix will be by sharding the targets across Prometheus instances. This will be done in PR opstrace/opstrace#215.