### PR TITLE
ci: gcp: use projects bbb and ccc for #62

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ fetch-secrets:
 	--include "opstrace-ci-authtoken-secrets.yaml" \
 	--include "dns-service-login-for-ci.json" \
 	--include "gcp-svc-acc-ci-shard-aaa.json" \
+	--include "gcp-svc-acc-ci-shard-ccc.json" \
 	--include "gcp-svc-acc-ci-shard-bbb.json"
 	chmod 600 secrets/ci.id_rsa
 

--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -49,7 +49,8 @@ source secrets/aws-dev-svc-acc-env.sh
 # permutation is equally likely". Also see
 # https://github.com/opstrace/opstrace/pull/128#issuecomment-742519078 and
 # https://stackoverflow.com/q/5189913/145400.
-OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb)
+#OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
+OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-bbb ci-shard-ccc)
 echo "--- random choice for GCP project ID: ${OPSTRACE_GCP_PROJECT_ID}"
 export GOOGLE_APPLICATION_CREDENTIALS=./secrets/gcp-svc-acc-${OPSTRACE_GCP_PROJECT_ID}.json
 


### PR DESCRIPTION
For relaxing the pressure as of #62. Looks like the recent failures came from GCP project `ci-shard-aaa`. I finished setting up `ci-shard-ccc` for CI and propose to use projects ci-shard-bbb and ci-shard-ccc for the next couple of days.

We should investigate why we ran into quota issues within `ci-shard-aaa` -- I don't think an elevated build rate was responsible for that (recent days were pretty calm :christmas_tree:). 