### PR TITLE
ci: upgrade collection cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ fetch-secrets:
 	--include "saas-secrets-token.json" \
 	--include "ci.id_rsa" \
 	--include "ci.id_rsa.pub" \
-	--include "opstrace-ci-authtoken-secrets.yaml" \
+	--include "opstrace-collection-cluster-authtoken-secrets.yaml" \
 	--include "dns-service-login-for-ci.json" \
 	--include "gcp-svc-acc-ci-shard-aaa.json" \
 	--include "gcp-svc-acc-ci-shard-ccc.json" \

--- a/ci/data-collection-deployment-loop.sh
+++ b/ci/data-collection-deployment-loop.sh
@@ -48,7 +48,7 @@ do
     # Rely on the pipefail option.
     kubectl apply \
         -f ci/metrics/ \
-        -f secrets/opstrace-ci-authtoken-secrets.yaml \
+        -f secrets/opstrace-collection-cluster-authtoken-secrets.yaml \
         --kubeconfig "${KUBECONFIG_FILEPATH}" |& tee -a "${LOG_OUTERR_FILEPATH}"
     kexitcode=$?
     set -e

--- a/ci/metrics/prometheus.yaml.template
+++ b/ci/metrics/prometheus.yaml.template
@@ -13,7 +13,7 @@ data:
         opstrace_cloud_provider: ${OPSTRACE_CLOUD_PROVIDER}
 
     remote_write:
-    - url: https://cortex-external.builds.ci.aws.opstrace.io:8443/api/v1/push
+    - url: https://cortex.builds.collection.opstrace.io/api/v1/push
       bearer_token_file: /var/run/builds-tenant/authToken
 
     scrape_configs:

--- a/ci/metrics/promtail.yaml.template
+++ b/ci/metrics/promtail.yaml.template
@@ -6,7 +6,7 @@ metadata:
 data:
   promtail.yml: |
     client:
-      url: https://loki-external.builds.ci.aws.opstrace.io:8443/loki/api/v1/push
+      url: https://loki.builds.collection.opstrace.io/loki/api/v1/push
       bearer_token_file: /var/run/builds-tenant/authToken
       external_labels:
         opstrace_cluster_name: ${OPSTRACE_CLUSTER_NAME}


### PR DESCRIPTION
* Deployed a new cluster from the latest main branch
* Deployed using a new AWS account to track costs
* Changed the name to `collection.opstrace.io`
* To save costs, changed instance type to t3a.xlarge
