### PR TITLE
Auth0 device code login (for DNS service authentication): consolidate (no axios, clearer polling loop, credential refresh, ...)

### DIFF
--- a/lib/dns/src/opstrace.ts
+++ b/lib/dns/src/opstrace.ts
@@ -35,9 +35,8 @@ import {
   Dict
 } from "@opstrace/utils";
 
-const accessTokenFile = "./access.jwt";
-const idTokenFile = "./id.jwt";
-
+const ACCESS_TOKEN_FILE_PATH = "./access.jwt";
+const ID_TOKEN_FILE_PATH = "./id.jwt";
 const DNS_SERVICE_URL = "https://dns-api.opstrace.net/dns/";
 const OIDC_ISSUER = "https://opstrace-dev.us.auth0.com";
 const OIDC_CLIENT_ID = "fT9EPILybLT44hQl2xE7hK0eTuH1sb21";
@@ -212,19 +211,19 @@ export class DNSClient {
 
   private constructor() {
     this.additionalHeaders = {};
-
     this.accessToken = "";
-    if (fs.existsSync(accessTokenFile)) {
-      this.accessToken = fs.readFileSync(accessTokenFile, {
+    this.idToken = "";
+
+    if (fs.existsSync(ACCESS_TOKEN_FILE_PATH)) {
+      this.accessToken = fs.readFileSync(ACCESS_TOKEN_FILE_PATH, {
         encoding: "utf8",
         flag: "r"
       });
       this.additionalHeaders["authorization"] = `Bearer ${this.accessToken}`;
     }
 
-    this.idToken = "";
-    if (fs.existsSync(idTokenFile)) {
-      this.idToken = fs.readFileSync(idTokenFile, {
+    if (fs.existsSync(ID_TOKEN_FILE_PATH)) {
+      this.idToken = fs.readFileSync(ID_TOKEN_FILE_PATH, {
         encoding: "utf8",
         flag: "r"
       });
@@ -257,10 +256,10 @@ export class DNSClient {
     this.additionalHeaders["x-opstrace-id-token"] = this.idToken;
 
     log.info("write authentication state to current working directory");
-    fs.writeFileSync(accessTokenFile, this.accessToken, {
+    fs.writeFileSync(ACCESS_TOKEN_FILE_PATH, this.accessToken, {
       encoding: "utf-8"
     });
-    fs.writeFileSync(idTokenFile, this.idToken, { encoding: "utf-8" });
+    fs.writeFileSync(ID_TOKEN_FILE_PATH, this.idToken, { encoding: "utf-8" });
   }
 
   /**

--- a/lib/dns/src/opstrace.ts
+++ b/lib/dns/src/opstrace.ts
@@ -276,7 +276,9 @@ export class DNSClient {
     this.additionalHeaders["authorization"] = `Bearer ${accessToken}`;
     this.additionalHeaders["x-opstrace-id-token"] = this.idToken;
 
-    log.info("write authentication state to current working directory");
+    log.info(
+      "login successful, write authentication state to current working directory"
+    );
     fs.writeFileSync(ACCESS_TOKEN_FILE_PATH, this.accessToken, {
       encoding: "utf-8"
     });
@@ -333,9 +335,7 @@ export class DNSClient {
           }
 
           if (e.response?.statusCode === 401) {
-            log.info(
-              "got a 401 response: need to refresh authentication state"
-            );
+            log.info("perform another login to refresh authentication state");
             this.clearAuthnState();
             await this.login();
 

--- a/lib/utils/src/httpclient.ts
+++ b/lib/utils/src/httpclient.ts
@@ -116,14 +116,14 @@ function retryfunc(ro: GotRetryObject): number {
   const req = ro.error.request;
   if (req === undefined) {
     log.debug(
-      "got retryfunc() called w/o request context. attempt; %s, error: %s",
+      "retryfunc() called w/o request context. attempt; %s, error: %s",
       ro.attemptCount,
       ro.error
     );
     return 1000;
   }
 
-  // About got.RequestError "When a request fails. Contains a code property
+  // About got.RequestError: "When a request fails. Contains a code property
   // with error class code, like ECONNREFUSED. All the errors below inherit
   // this one."
 


### PR DESCRIPTION
Among others, this resolves issue #53.

```
When the DNS service responds to an HTTP
request with a 401 HTTP response then
this means that the authentication proof
(set of credentials) presented in the request
was invalid.

A common reason for that is authentication
proof / credential expiry. Therefore, a valuable
course of action is to obtain a fresh set of
credentials, by going through another login
process.
```

This also removes the last bits of usage of the Axios HTTP client in the installer/uninstaller (replaced with got) -- and therefore allows for closing #29.