### PR TITLE
fix: broken links, adjust Fluentd name

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -18,7 +18,6 @@
       "Auth0",
       "Grafana",
       "VS Code",
-      "FluentD",
       "Opstrace",
       "Prometheus",
       "Promtail"

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ It consists of an installer that runs as a CLI to use your cloud credentials to 
 ## How does it work?
 
 Opstrace clusters expose a horizontally scalable [Prometheus](https://prometheus.io) API, backed by [Cortex](https://github.com/cortexproject/cortex), and a [Loki](https://github.com/grafana/loki) API for logs collection.
-You can point your existing Prometheus or [FluentD](https://fluentd.org)/[Promtail](https://github.com/grafana/loki/blob/master/docs/sources/clients/promtail/_index.md) instances to it.
+You can point your existing Prometheus or [Fluentd](https://www.fluentd.org)/[Promtail](https://github.com/grafana/loki/blob/master/docs/sources/clients/promtail/_index.md) instances to it.
 We also plan to support a wide variety of other APIs, such as the Datadog agent.
 
 Creating an Opstrace Cluster requires our [command-line interface](./references/cli.md), which talks directly to your cloud provider.

--- a/docs/guides/contributor/workflows.md
+++ b/docs/guides/contributor/workflows.md
@@ -113,7 +113,7 @@ For controller development it can be helpful to create an Opstrace cluster and h
 
 ### Documentation: `make lint-docs`
 
-For linting our documentation, we use [Markdownlint](./docs/contributing/writing-docs.md#get-on-your-marks), with rules defined in `.markdownlint.json` in the project root.
+For linting our documentation, we use [Markdownlint](./docs/contributor/writing-docs.md#get-on-your-marks), with rules defined in `.markdownlint.json` in the project root.
 
 Here is an example of executing the command and a resulting error thrown from Markdownlint:
 

--- a/docs/guides/contributor/writing-docs.md
+++ b/docs/guides/contributor/writing-docs.md
@@ -40,7 +40,7 @@ Hey, even professional technical writers need another set of eyes.
 
 ## When to update docs
 
-Ideally, docs is updated in the same pull request that also contains the corresponding code changes. Of course, some documents may not require updating. See our [pull request template](https://github.com/opstrace/opstrace/blob/main/.github/pull_request_temlate.md) to better assess what may or may not need updates.
+Ideally, docs is updated in the same pull request that also contains the corresponding code changes. Of course, some documents may not require updating. See our [pull request template](https://github.com/opstrace/opstrace/blob/main/.github/pull_request_template.md) to better assess what may or may not need updates.
 
 
 ## The doc creation possibilities

--- a/docs/guides/user/sending-logs-with-promtail.md
+++ b/docs/guides/user/sending-logs-with-promtail.md
@@ -65,5 +65,5 @@ This is required for example when using `letsencrypt-staging` as `cert_issuer`.
 
 ## Further references
 
-* [Configuring Promtail: reference](https://github.com/grafana/loki/blob/master/docs/sources/clients/promtail/configuration)
-* [Troubleshooting Promtail](https://github.com/grafana/loki/blob/master/docs/sources/clients/promtail/troubleshooting)
+* [Configuring Promtail: reference](https://github.com/grafana/loki/blob/master/docs/sources/clients/promtail/configuration.md)
+* [Troubleshooting Promtail](https://github.com/grafana/loki/blob/master/docs/sources/clients/promtail/troubleshooting.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -274,7 +274,7 @@ You now have dummy (random) metrics and logs being sent to the Opstrace cluster,
 
 ## Step 4: Validate the data
 
-You can view this ingested data in the `myteam` [tenant](./references/concepts.md#tenant), which we specified in the configuration file, using the Grafana "explore" view:
+You can view this ingested data in the `myteam` [tenant](./references/concepts.md#tenants), which we specified in the configuration file, using the Grafana "explore" view:
 
 ```text
 https://myteam.$OPSTRACE_CLUSTER_NAME.opstrace.io/grafana/explore?orgId=1&left=%5B%22now-30m%22,%22now%22,%22metrics%22,%7B%7D%5D

--- a/docs/references/faq.md
+++ b/docs/references/faq.md
@@ -7,7 +7,7 @@ description: The answers to some of the most common questions we hear.
 ## How does this work with—or replace—my existing Prometheus?
 
 If you're already using Prometheus, it's very easy to get started with Opstrace.
-As shown in our [docs](./sending-metrics-with-prometheus.md#remote_write-configuration-block-the-basics), all you need to do is add a couple of lines to your Prometheus configuration and your data will also be sent securely to the Opstrace cluster.
+As shown in our [docs](../guides/user/sending-metrics-with-prometheus.md#remote_write-configuration-block-the-basics), all you need to do is add a couple of lines to your Prometheus configuration and your data will also be sent securely to the Opstrace cluster.
 One great advantage is that you may be able to reduce the footprint of your Prometheus instance, as all long-term storage is now safely done by a [Cortex](https://github.com/cortexproject/cortex/) instance in your S3 buckets.
 
 ## Can I run this on my own Kubernetes cluster?

--- a/docs/references/roadmap.md
+++ b/docs/references/roadmap.md
@@ -11,7 +11,7 @@ This high-level roadmap highlights major guideposts along our path toward that g
 * Today's observability tools are disjoint from the day-to-day development process.
 For example, dashboards can break easily with a deploy and sharing analyses is hard (screenshots anyone?).
 By integrating your data with code we can solve these existing problems and create new capabilities (think VScode meets Python notebooks).
-Stay tuned to our blog and/or sign up for our [newsletter](https://next-website-sigma.vercel.app/#newsletter-headline).
+Stay tuned to our blog and/or sign up for our [newsletter](https://opstrace.com/#newsletter).
 
 **First-class Alerts**
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/opstrace/opstrace
 
 go 1.15
+
+require (
+	github.com/google/addlicense v0.0.0-20200906110928-a0294312aa76 // indirect
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7099,15 +7099,7 @@ bintrees@1.0.1:
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
   integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
 
-bl@^1.0.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.3.tgz#1e8dd80142eac80d7158c9dccc047fb620e035e7"
-  integrity sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==
-  dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
-
-bl@^4.0.3:
+bl@^1.0.0, bl@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
   integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
@@ -9409,7 +9401,7 @@ dot-object@^2.1.4:
     commander "^4.0.0"
     glob "^7.1.5"
 
-dot-prop@^5.1.0, dot-prop@^5.2.0:
+dot-prop@^5.1.0, dot-prop@^5.1.1, dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
@@ -15848,10 +15840,10 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-path@0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
-  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
+object-path@0.11.4, object-path@^0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.5.tgz#d4e3cf19601a5140a55a16ad712019a9c50b577a"
+  integrity sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -18330,7 +18322,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -19337,22 +19329,10 @@ serialize-error@^5.0.0:
   dependencies:
     type-fest "^0.8.0"
 
-serialize-javascript@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
-  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
-
-serialize-javascript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+serialize-javascript@5.0.1, serialize-javascript@^2.1.2, serialize-javascript@^3.1.0, serialize-javascript@^4.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
+  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
   dependencies:
     randombytes "^2.1.0"
 
@@ -22448,23 +22428,10 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@13.1.2, yargs-parser@^13.1.2:
+yargs-parser@13.1.2, yargs-parser@20.x, yargs-parser@^13.1.2, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@20.x:
-  version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
-
-yargs-parser@^18.1.2, yargs-parser@^18.1.3:
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
-  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
Fixes several broken links that were detected by a link check.

According to [the fluentd website](https://www.fluentd.org), it's `Fluentd`, not `FluentD`, which has been adjusted in the markdown linter config.

# Have you...

* [x] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [x] Thought about which docs need updating?
