### PR TITLE
chore: remove root go.mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ prometheus.yml
 opstrace
 
 ./go.sum
+./go.mod
 
 tsconfig.tsbuildinfo
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,0 @@
-module github.com/opstrace/opstrace
-
-go 1.15
-
-require (
-	github.com/google/addlicense v0.0.0-20200906110928-a0294312aa76 // indirect
-	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
-)


### PR DESCRIPTION
Let's remove go mod to avoid having it overwritten unnecessarily, for example, https://github.com/opstrace/opstrace/pull/251/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R4-R8

