### PR TITLE
ci(gcp): use brand new projects -ddd, -eee, -fff for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,11 @@ fetch-secrets:
 	--include "opstrace-collection-cluster-authtoken-secrets.yaml" \
 	--include "dns-service-login-for-ci.json" \
 	--include "gcp-svc-acc-ci-shard-aaa.json" \
+	--include "gcp-svc-acc-ci-shard-bbb.json" \
 	--include "gcp-svc-acc-ci-shard-ccc.json" \
-	--include "gcp-svc-acc-ci-shard-bbb.json"
+	--include "gcp-svc-acc-ci-shard-ddd.json" \
+	--include "gcp-svc-acc-ci-shard-eee.json" \
+	--include "gcp-svc-acc-ci-shard-fff.json"
 	chmod 600 secrets/ci.id_rsa
 
 

--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -50,7 +50,7 @@ source secrets/aws-dev-svc-acc-env.sh
 # https://github.com/opstrace/opstrace/pull/128#issuecomment-742519078 and
 # https://stackoverflow.com/q/5189913/145400.
 #OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
-OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-bbb ci-shard-ccc)
+OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-ddd ci-shard-eee ci-shard-fff)
 echo "--- random choice for GCP project ID: ${OPSTRACE_GCP_PROJECT_ID}"
 export GOOGLE_APPLICATION_CREDENTIALS=./secrets/gcp-svc-acc-${OPSTRACE_GCP_PROJECT_ID}.json
 


### PR DESCRIPTION
CI has been broken all weekend (except for one successful build).  #254 did not work as initially expected.  Let's just create 3 new projects to immediately unblock us.

I followed [our instructions](https://opstrace.com/docs/guides/administrator/gcp-setup#step-1-create-a-project) for creating a new project and uploaded the credentials from step 6 to our CI bucket.

Note: these projects initially have the default 40 instance limit.  We may increase that to the max 100 later, or may keep it as-is.
