### PR TITLE
controller: allow pvc volume expansion

### DIFF
--- a/packages/controller/src/resources/storage/aws.ts
+++ b/packages/controller/src/resources/storage/aws.ts
@@ -36,7 +36,8 @@ export function StorageResources(
           type: "gp2"
         },
         provisioner: "kubernetes.io/aws-ebs",
-        volumeBindingMode: "WaitForFirstConsumer"
+        volumeBindingMode: "WaitForFirstConsumer",
+        allowVolumeExpansion: true
       },
       kubeConfig
     )

--- a/packages/controller/src/resources/storage/gcp.ts
+++ b/packages/controller/src/resources/storage/gcp.ts
@@ -62,7 +62,8 @@ export function StorageResources(
           type: "pd-ssd"
         },
         provisioner: "kubernetes.io/gce-pd",
-        volumeBindingMode: "WaitForFirstConsumer"
+        volumeBindingMode: "WaitForFirstConsumer",
+        allowVolumeExpansion: true
       },
       kubeConfig
     )


### PR DESCRIPTION
This can be used in an emergency. For example, when the ingester volume reaches the default limit, this triggers a crash loop of that pod because it can't write to a full volume. Allowing the PVC to be resized makes it easier to address the issue proactively. 

[Kubernetes docs](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
[GCP docs](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/volume-expansion#using_volume_expansion) 
[AWS docs](https://kubernetes.io/docs/concepts/storage/storage-classes/#aws-ebs) 