### PR TITLE
fix: increase available memory for node build

### DIFF
--- a/containers/controller/Dockerfile
+++ b/containers/controller/Dockerfile
@@ -26,6 +26,7 @@ COPY packages/controller-config /build/packages/controller-config/
 
 WORKDIR /build/packages/controller
 
+ENV NODE_OPTIONS "--max-old-space-size=8192"
 RUN yarn --frozen-lockfile
 RUN yarn run tsc -b
 

--- a/containers/controller/Dockerfile
+++ b/containers/controller/Dockerfile
@@ -26,7 +26,7 @@ COPY packages/controller-config /build/packages/controller-config/
 
 WORKDIR /build/packages/controller
 
-ENV NODE_OPTIONS "--max-old-space-size=8192"
+ENV NODE_OPTIONS "--max-old-space-size=1536"
 RUN yarn --frozen-lockfile
 RUN yarn run tsc -b
 


### PR DESCRIPTION
`make build-and-push-controller-image` fails consistently with "JavaScript heap out of memory" on macOS Big Sur + Docker 3.0.4.
