### PR TITLE
Grafana: use postgres db

### DIFF
--- a/packages/controller-config/src/types.ts
+++ b/packages/controller-config/src/types.ts
@@ -36,6 +36,7 @@ export const controllerConfigSchema = yup
     uiSourceIpFirewallRules: yup.array(yup.string()).ensure(),
     apiSourceIpFirewallRules: yup.array(yup.string()).ensure(),
     postgreSQLEndpoint: yup.string().notRequired(),
+    opstraceDBName: yup.string().notRequired(),
     envLabel: yup.string(),
     // Note: remove one of cert_issuer and `tlsCertificateIssuer`.
     cert_issuer: yup

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -23,19 +23,20 @@
     "copyGraphqlSdk": "cp ../app/src/state/graphql-api-types.ts ./src/dbSDK.ts"
   },
   "dependencies": {
-    "argparse": "^1.0.10",
-    "js-yaml": "^3.14.0",
     "@opstrace/config": "^0.0.0",
+    "@opstrace/controller-config": "^0.0.0",
     "@opstrace/kubernetes": "^0.0.0",
     "@opstrace/tenants": "^0.0.0",
     "@opstrace/utils": "^0.0.0",
-    "@opstrace/controller-config": "^0.0.0",
+    "argparse": "^1.0.10",
     "graphql": "^15.0.0",
     "graphql-request": "^3.0.0",
     "graphql-tag": "^2.10.3",
+    "js-yaml": "^3.14.0",
     "redux": "^4.0.4",
     "redux-saga": "^1.1.3",
-    "typed-redux-saga": "^1.3.1"
+    "typed-redux-saga": "^1.3.1",
+    "url-join-ts": "^1.0.5"
   },
   "devDependencies": {
     "@types/argparse": "^1.0.38"

--- a/packages/controller/src/resources/app/index.ts
+++ b/packages/controller/src/resources/app/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { urlJoin } from "url-join-ts";
 import {
   ResourceCollection,
   Deployment,
@@ -450,7 +451,10 @@ export function OpstraceApplicationResources(
                     },
                     {
                       name: "HASURA_GRAPHQL_DATABASE_URL",
-                      value: state.config.config?.postgreSQLEndpoint
+                      value: urlJoin(
+                        state.config.config?.postgreSQLEndpoint,
+                        state.config.config?.opstraceDBName
+                      )
                     },
                     {
                       name: "HASURA_GRAPHQL_ENABLE_CONSOLE",

--- a/packages/controller/src/resources/monitoring/tenants/grafana.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafana.ts
@@ -22,7 +22,6 @@ import {
   Deployment,
   Service,
   ServiceAccount,
-  PersistentVolumeClaim,
   V1ServicemonitorResource
 } from "@opstrace/kubernetes";
 
@@ -114,32 +113,6 @@ export function GrafanaResources(
         metadata: {
           name: "grafana-dashboards",
           namespace
-        }
-      },
-      kubeConfig
-    )
-  );
-
-  collection.add(
-    new PersistentVolumeClaim(
-      {
-        apiVersion: "v1",
-        kind: "PersistentVolumeClaim",
-        metadata: {
-          labels: {
-            app: "grafana"
-          },
-          name: "grafana-storage-claim",
-          namespace
-        },
-        spec: {
-          storageClassName: "pd-ssd",
-          accessModes: ["ReadWriteOnce"],
-          resources: {
-            requests: {
-              storage: "10Gi"
-            }
-          }
         }
       },
       kubeConfig
@@ -325,11 +298,6 @@ export function GrafanaResources(
                   volumeMounts: [
                     ...[
                       {
-                        mountPath: "/var/lib/grafana",
-                        name: "grafana-storage",
-                        readOnly: false
-                      },
-                      {
                         mountPath: "/etc/grafana/provisioning/datasources",
                         name: "grafana-datasources",
                         readOnly: false
@@ -356,12 +324,6 @@ export function GrafanaResources(
               serviceAccountName: "grafana",
               volumes: [
                 ...[
-                  {
-                    name: "grafana-storage",
-                    persistentVolumeClaim: {
-                      claimName: "grafana-storage-claim"
-                    }
-                  },
                   {
                     name: "grafana-datasources",
                     secret: {

--- a/packages/installer/src/aws.ts
+++ b/packages/installer/src/aws.ts
@@ -826,7 +826,8 @@ export function* ensureAWSInfraExists(): Generator<
     // additional steps to reset the password on the postgres instance.
     // The Postgres endpoint is attached to it's own private subnet which is only accessible from within the cluster's VPC.
     // Their is no public endpoint for the RDS instance.
-    postgreSQLEndpoint: `postgres://opstrace:2020WasQuiteTheYear@${dbCluster.Endpoint}/opstrace`
+    postgreSQLEndpoint: `postgres://opstrace:2020WasQuiteTheYear@${dbCluster.Endpoint}/`,
+    opstraceDBName: "opstrace"
   };
 }
 

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -207,6 +207,7 @@ export function* ensureGCPInfraExists(
     // The Postgres endpoint is attached to it's own private subnet which is only accessible from within the cluster's VPC.
     // Their is no public endpoint for the CloudSQL instance.
     // The default user created when standing up a CloudSQL instance is "postgres".
-    postgreSQLEndpoint: `postgres://postgres:2020WasQuiteTheYear@${privateAddress.ipAddress}:5432/opstrace`
+    postgreSQLEndpoint: `postgres://postgres:2020WasQuiteTheYear@${privateAddress.ipAddress}:5432/`,
+    opstraceDBName: "opstrace"
   };
 }

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -188,6 +188,7 @@ function* createClusterCore() {
 
   let kubeconfigString = "";
   let postgreSQLEndpoint = "";
+  let opstraceDBName = "";
 
   if (ccfg.cloud_provider === "gcp") {
     if (!gcpAuthOptions) {
@@ -199,6 +200,7 @@ function* createClusterCore() {
     );
     kubeconfigString = res.kubeconfigString;
     postgreSQLEndpoint = res.postgreSQLEndpoint;
+    opstraceDBName = res.opstraceDBName;
 
     controllerConfig.gcp = {
       projectId: gcpAuthOptions.projectId,
@@ -223,7 +225,11 @@ function* createClusterCore() {
   }
 
   // Update our controllerConfig with the Postgress Endpoint and revalidate for good measure
-  controllerConfig = { ...controllerConfig, postgreSQLEndpoint };
+  controllerConfig = {
+    ...controllerConfig,
+    postgreSQLEndpoint,
+    opstraceDBName
+  };
   controllerConfigSchema.validateSync(controllerConfig, { strict: true });
 
   if (!kubeconfigString) {

--- a/packages/installer/src/types.ts
+++ b/packages/installer/src/types.ts
@@ -17,6 +17,7 @@
 export type EnsureInfraExistsResponse = {
   kubeconfigString: string;
   postgreSQLEndpoint: string;
+  opstraceDBName: string;
   // Only applicable to AWS
   certManagerRoleArn?: string;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7099,7 +7099,15 @@ bintrees@1.0.1:
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
   integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
 
-bl@^1.0.0, bl@^4.0.3:
+bl@^1.0.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.3.tgz#1e8dd80142eac80d7158c9dccc047fb620e035e7"
+  integrity sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
+bl@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
   integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
@@ -9401,7 +9409,7 @@ dot-object@^2.1.4:
     commander "^4.0.0"
     glob "^7.1.5"
 
-dot-prop@^5.1.0, dot-prop@^5.1.1, dot-prop@^5.2.0:
+dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
@@ -15840,10 +15848,10 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-path@0.11.4, object-path@^0.11.5:
-  version "0.11.5"
-  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.5.tgz#d4e3cf19601a5140a55a16ad712019a9c50b577a"
-  integrity sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==
+object-path@0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
+  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -18322,7 +18330,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -19329,10 +19337,22 @@ serialize-error@^5.0.0:
   dependencies:
     type-fest "^0.8.0"
 
-serialize-javascript@5.0.1, serialize-javascript@^2.1.2, serialize-javascript@^3.1.0, serialize-javascript@^4.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
-  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
+serialize-javascript@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
   dependencies:
     randombytes "^2.1.0"
 
@@ -21409,6 +21429,11 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url-join-ts@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/url-join-ts/-/url-join-ts-1.0.5.tgz#6413f36ae294235e7f15e414c97db1218696e1a2"
+  integrity sha512-u+5gi7JyOwhj58ZKwkmkzFGHuepTpmwjqfUDGVjsJJstsCz63CJAINixgJaDcMbmuyWPJIxbtBpIfaDgOQ9KMQ==
+
 url-loader@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-2.3.0.tgz#e0e2ef658f003efb8ca41b0f3ffbf76bab88658b"
@@ -22428,10 +22453,23 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@13.1.2, yargs-parser@20.x, yargs-parser@^13.1.2, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@20.x:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
+yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
Before this PR grafana was still using sqlite in a volume.
This PR takes advantage of the aurora and cloudsql databases to fix that.