### PR TITLE
bump: cortex 1.7.0-rc0

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -2,7 +2,7 @@
   "addonResizer": "k8s.gcr.io/addon-resizer:1.8.4",
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.0.4",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.0.4",
-  "cortex": "cortexproject/cortex:v1.6.0",
+  "cortex": "cortexproject/cortex:v1.7.0-rc.0",
   "cortexApiProxy": "opstrace/cortex-api:7633d73fc9cf6af5d2caaa25d90fe242",
   "ddApi": "opstrace/ddapi:fd813ccbf9a09d32c4c57cb0fac6b7949be71a92",
   "externalDNS": "k8s.gcr.io/external-dns/external-dns:v0.7.4",


### PR DESCRIPTION
https://github.com/cortexproject/cortex/releases/tag/v1.7.0-rc.0

A few points that I found particularly itneresting:

>  Blocks storage: the default value of -blocks-storage.bucket-store.sync-interval has been changed from 5m to 15m


> Blocks storage: introduced a per-tenant bucket index, periodically updated by the compactor, used to avoid full bucket scanning done by queriers, store-gateways and rulers. The bucket index is updated by the compactor during blocks cleanup, on every -compactor.cleanup-interval. #3553 #3555 #3561 #3583 #3625 #3711 #3715

> Blocks storage: introduced an option -blocks-storage.bucket-store.bucket-index.enabled to enable the usage of the bucket index in the querier, store-gateway and ruler. When enabled, the querier, store-gateway and ruler will use the bucket index to find a tenant's blocks instead of running the periodic bucket scan. The following new metrics are exported by the querier and ruler: 

New compactor metrics!

> Memberlist: add status page (/memberlist) with available details about memberlist-based KV store and memberlist cluster. It's also possible to view KV values in Go struct or JSON format, or download for inspection. 

> New /runtime_config endpoint that returns the defined runtime configuration in YAML format. The returned configuration includes overrides.

and much more of course.

