### PR TITLE
cli: fix append to tenant names array

### DIFF
--- a/packages/cli/src/status.ts
+++ b/packages/cli/src/status.ts
@@ -38,11 +38,13 @@ import {
 } from "@opstrace/installer";
 import * as schemas from "./schemas";
 
-function readTenantApiTokenFiles(tenants: string[]): Dict<string> {
+function readTenantApiTokenFiles(tenantNames: string[]): Dict<string> {
   const tenantApiTokens: Dict<string> = {};
   // also read system tenant api token
-  tenants.push("system");
-  for (const tname of tenants) {
+  const tnames = [...tenantNames];
+  tnames.push("system");
+
+  for (const tname of tnames) {
     const fpath = `tenant-api-token-${tname}`;
     const token = fs.readFileSync(fpath);
     tenantApiTokens[tname] = token.toString();


### PR DESCRIPTION
`readTenantApiTokenFiles` was appending the `system` tenant to the input array. The other functions don't expect the system tenant to be in the input array.

Fix #296 