### PR TITLE
DD API: be more liberal w.r.t. order of samples in request, keep interval as label

### DIFF
--- a/go/pkg/ddapi/translate.go
+++ b/go/pkg/ddapi/translate.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	json "github.com/json-iterator/go"
@@ -137,6 +138,7 @@ func TranslateDDSeriesJSON(doc []byte) ([]*prompb.TimeSeries, error) {
 			// Prom world.
 			"device":           fragment.Device,
 			"type":             fragment.Type,
+			"interval":         strconv.FormatInt(fragment.Interval, 10),
 			"source_type_name": fragment.SourceTypeName,
 		}
 


### PR DESCRIPTION
These changes are based on local testing / exploration. Also see code comments and https://github.com/opstrace/opstrace/issues/329.