### PR TITLE
chore: make go build cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ pkg/datadog/datadog
 pkg/fluent-http/fluent-http
 pkg/loki/loki
 
+go/cortex-api
+go/ddapi
+go/loki-api
+
 tenant-api-token-*
 opstrace_cli_*.log
 packages/cli/src/buildinfo.ts

--- a/ci/check-if-docs-pr.sh
+++ b/ci/check-if-docs-pr.sh
@@ -52,7 +52,7 @@ ALLOWLIST="\
 ^ci/check-if-docs-pr.sh\
 "
 
-DOCS_ONLY_CHANGES=$(echo ${FILES_EDITED_IN_PR}| egrep -v "${ALLOWLIST}" | tr -d '[:space:]')
+DOCS_ONLY_CHANGES=$(echo "${FILES_EDITED_IN_PR}" | egrep -v "${ALLOWLIST}" | tr -d '[:space:]')
 if [ -z "${DOCS_ONLY_CHANGES}" ];
 then
     echo "--- docs only PR (${BUILDKITE_PULL_REQUEST}) - skipping next steps"

--- a/go/Makefile
+++ b/go/Makefile
@@ -2,10 +2,10 @@
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 
 DOCKER_REPO ?= opstrace
-# DOCKER_IMAGE_TAG is a md5sum of all the files (except hidden) in the go
+# DOCKER_IMAGE_TAG is a shasum of all the files (except hidden) in the go
 # directory. We use it to have a deterministic method to calculate a docker
 # image tag.
-DOCKER_IMAGE_TAG ?= $(shell find . -type f -not -name ".*" -print0 | sort -z -d -f | xargs -0 cat | md5sum | cut -d' ' -f1)
+DOCKER_IMAGE_TAG ?= $(shell find . -type f -not -name ".*" -print0 | sort -z -d -f | xargs -0 cat | shasum | cut -d' ' -f1)
 
 DOCKERFILE = ./Dockerfile
 


### PR DESCRIPTION
* `md5sum` is not available on macos by default; use shasum as a cross-platform alternative
* also ignore local build artifacts
