### PR TITLE
docs(quickstart): document workaround for known issue #151

### DIFF
--- a/docs/guides/administrator/troubleshooting.md
+++ b/docs/guides/administrator/troubleshooting.md
@@ -112,3 +112,31 @@ And delete the certificate to have the controller recreate it and restart the re
 ```bash
 kubectl -n ingress delete certificate http-cert
 ```
+
+Check the installation succeeded by reissuing the `create` command.
+
+<!-- tabs -->
+
+### AWS
+
+```bash
+./opstrace create aws $OPSTRACE_NAME \
+  -c opstrace-config.yaml
+```
+
+When everything is done, you'll see the following log line:
+
+`info: cluster creation finished: $OPSTRACE_NAME (aws)`
+
+### GCP
+
+```bash
+./opstrace create gcp $OPSTRACE_NAME \
+  -c opstrace-config.yaml
+```
+
+When everything is done, you'll see the following log line:
+
+`info: cluster creation finished: $OPSTRACE_NAME (gcp)`
+
+<!-- tabs -->

--- a/docs/guides/administrator/troubleshooting.md
+++ b/docs/guides/administrator/troubleshooting.md
@@ -93,7 +93,7 @@ First, if the installation process is stuck, you can exit by pressing Ctrl-C. Th
 Afterward, find the certificate request created by cert-manager:
 
 ```bash
-> kubectl -n ingress get certificaterequest
+$ kubectl -n ingress get certificaterequest
 NAME                         READY   AGE
 https-cert-XXXXX             False   30m
 kubed-apiserver-cert-XXXXX   True    30m

--- a/docs/guides/administrator/troubleshooting.md
+++ b/docs/guides/administrator/troubleshooting.md
@@ -115,7 +115,7 @@ kubectl -n ingress delete certificate http-cert
 
 Check the installation succeeded by reissuing the `create` command.
 
-<!-- tabs -->
+<!--tabs-->
 
 ### AWS
 
@@ -139,4 +139,4 @@ When everything is done, you'll see the following log line:
 
 `info: cluster creation finished: $OPSTRACE_NAME (gcp)`
 
-<!-- tabs -->
+<!--/tabs-->

--- a/docs/guides/administrator/troubleshooting.md
+++ b/docs/guides/administrator/troubleshooting.md
@@ -59,3 +59,56 @@ When the Opstrace controller (a deployment running in the Opstrace cluster) is s
 kubectl logs deployment/opstrace-controller \
   --all-containers=true --namespace=kube-system > controller.log
 ```
+
+## Known Issues
+
+It's possible your installation can fail waiting for the certificates to be ready. When this happens, you'll see messages such as the following:
+
+```text
+info: waiting for 0 DaemonSets
+info: waiting for 0 StatefulSets
+info: waiting for 1 Certificates
+debug:   Waiting for Certificate ingress/https-cert to be ready
+```
+
+And when the installation fails:
+
+```text
+info: waiting for 0 DaemonSets
+info: waiting for 0 StatefulSets
+info: waiting for 1 Certificates
+warning: cluster creation attempt timed out after 2400 seconds
+error: 3 attempt(s) failed. Stop retrying. Exit.
+```
+
+This is a known problem that we are tracking in these issues:
+
+* [ci: waiting "for Certificate ingress/https-cert to be ready" didn't resolve](https://github.com/opstrace/opstrace/issues/151)
+* [Certificate sometimes fails to issue properly](https://github.com/jetstack/cert-manager/issues/3594)
+
+If this happens, the recommended workaround is to restart the certificate request process.
+
+First, if the installation process is stuck, you can exit by pressing Ctrl-C. Then proceed to [connect kubectl to your Opstrace cluster](#kubernetes-based-debugging).
+
+Afterward, find the certificate request created by cert-manager:
+
+```bash
+> kubectl -n ingress get certificaterequest
+NAME                         READY   AGE
+https-cert-XXXXX             False   30m
+kubed-apiserver-cert-XXXXX   True    30m
+```
+
+The certificate request starts with `https-cert-` followed by five random characters.
+
+Delete the failed certificate request:
+
+```bash
+kubectl -n ingress delete certificaterequest https-cert-XXXXX
+```
+
+And delete the certificate to have the controller recreate it and restart the request process:
+
+```bash
+kubectl -n ingress delete certificate http-cert
+```

--- a/docs/guides/administrator/troubleshooting.md
+++ b/docs/guides/administrator/troubleshooting.md
@@ -113,7 +113,7 @@ And delete the certificate to have the controller recreate it and restart the re
 kubectl -n ingress delete certificate http-cert
 ```
 
-Check the installation succeeded by reissuing the `create` command.
+Check the installation succeeded by reissuing the `create` command:
 
 <!--tabs-->
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -117,7 +117,7 @@ When everything is done, you'll see the following log line:
 
 `info: cluster creation finished: $OPSTRACE_NAME (aws)`
 
-In case of any **installation errors** check the [known issues section](./guides/administrator/troubleshooting.md#known-issues) or search our [github issues](https://github.com/opstrace/opstrace/issues).
+In case of any **installation errors** check the [known issues section](./guides/administrator/troubleshooting.md#known-issues) or search our [GitHub issues](https://github.com/opstrace/opstrace/issues).
 
 You now have a secure, scalable, multi-tenant, open standards-based observability platform running _inside_ your cloud account, right next to the software that you want to monitor.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -117,6 +117,8 @@ When everything is done, you'll see the following log line:
 
 `info: cluster creation finished: $OPSTRACE_NAME (aws)`
 
+In case of any **installation errors** check the [known issues section](./guides/administrator/troubleshooting.md#known-issues) or search our [github issues](https://github.com/opstrace/opstrace/issues).
+
 You now have a secure, scalable, multi-tenant, open standards-based observability platform running _inside_ your cloud account, right next to the software that you want to monitor.
 
 Now that Opstrace is up and running, let's take a closer look.
@@ -325,56 +327,3 @@ That's it! 👏
 
 Congratulations, you're now an Opstrace user!
 
-
-## Known Issues
-
-It's possible your installation can fail waiting for the certificates to be ready. When this happens, you'll see messages such as the following:
-
-```text
-info: waiting for 0 DaemonSets
-info: waiting for 0 StatefulSets
-info: waiting for 1 Certificates
-debug:   Waiting for Certificate ingress/https-cert to be ready
-```
-
-And when the installation fails:
-
-```text
-info: waiting for 0 DaemonSets
-info: waiting for 0 StatefulSets
-info: waiting for 1 Certificates
-warning: cluster creation attempt timed out after 2400 seconds
-error: 3 attempt(s) failed. Stop retrying. Exit.
-```
-
-This is a known problem that we are tracking in these issues:
-
-* [ci: waiting "for Certificate ingress/https-cert to be ready" didn't resolve](https://github.com/opstrace/opstrace/issues/151)
-* [Certificate sometimes fails to issue properly](https://github.com/jetstack/cert-manager/issues/3594)
-
-If this happens, the recommended workaround is to restart the certificate request process.
-
-First, if the installation process is stuck, you can exit by pressing Ctrl-C. Then proceed to [connect kubectl to your Opstrace cluster](./guides/administrator/troubleshooting.md#kubernetes-based-debugging).
-
-Afterward, find the certificate request created by cert-manager:
-
-```bash
-> kubectl -n ingress get certificaterequest
-NAME                         READY   AGE
-https-cert-XXXXX             False   30m
-kubed-apiserver-cert-XXXXX   True    30m
-```
-
-The certificate request starts with `https-cert-` followed by five random characters.
-
-Delete the failed certificate request:
-
-```bash
-kubectl -n ingress delete certificaterequest https-cert-XXXXX
-```
-
-And delete the certificate to have the controller recreate it and restart the request process:
-
-```bash
-kubectl -n ingress delete certificate http-cert
-```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -115,7 +115,7 @@ For additional information understanding and troubleshooting the `create` comman
 
 When everything is done, you'll see the following log line:
 
-`info: cluster creation finished: $OPSTRACE_NAME (aws)`  
+`info: cluster creation finished: $OPSTRACE_NAME (aws)`
 
 You now have a secure, scalable, multi-tenant, open standards-based observability platform running _inside_ your cloud account, right next to the software that you want to monitor.
 
@@ -325,3 +325,56 @@ That's it! 👏
 
 Congratulations, you're now an Opstrace user!
 
+
+## Known Issues
+
+It's possible your installation can fail waiting for the certificates to be ready. When this happens, you'll see messages such as the following:
+
+```text
+info: waiting for 0 DaemonSets
+info: waiting for 0 StatefulSets
+info: waiting for 1 Certificates
+debug:   Waiting for Certificate ingress/https-cert to be ready
+```
+
+And when the installation fails:
+
+```text
+info: waiting for 0 DaemonSets
+info: waiting for 0 StatefulSets
+info: waiting for 1 Certificates
+warning: cluster creation attempt timed out after 2400 seconds
+error: 3 attempt(s) failed. Stop retrying. Exit.
+```
+
+This is a known problem that we are tracking in these issues:
+
+* [ci: waiting "for Certificate ingress/https-cert to be ready" didn't resolve](https://github.com/opstrace/opstrace/issues/151)
+* [Certificate sometimes fails to issue properly](https://github.com/jetstack/cert-manager/issues/3594)
+
+If this happens, the recommended workaround is to restart the certificate request process.
+
+First, if the installation process is stuck, you can exit by pressing Ctrl-C. Then proceed to [connect kubectl to your Opstrace cluster](./guides/administrator/troubleshooting#kubernetes-based-debugging).
+
+Afterward, find the certificate request created by cert-manager:
+
+```bash
+> kubectl -n ingress get certificaterequest
+NAME                         READY   AGE
+https-cert-XXXXX             False   30m
+kubed-apiserver-cert-XXXXX   True    30m
+```
+
+The certificate request starts with `https-cert-` followed by five random characters.
+
+Delete the failed certificate request:
+
+```bash
+kubectl -n ingress delete certificaterequest https-cert-XXXXX
+```
+
+And delete the certificate to have the controller recreate it and restart the request process:
+
+```bash
+kubectl -n ingress delete certificate http-cert
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -354,7 +354,7 @@ This is a known problem that we are tracking in these issues:
 
 If this happens, the recommended workaround is to restart the certificate request process.
 
-First, if the installation process is stuck, you can exit by pressing Ctrl-C. Then proceed to [connect kubectl to your Opstrace cluster](./guides/administrator/troubleshooting#kubernetes-based-debugging).
+First, if the installation process is stuck, you can exit by pressing Ctrl-C. Then proceed to [connect kubectl to your Opstrace cluster](./guides/administrator/troubleshooting.md#kubernetes-based-debugging).
 
 Afterward, find the certificate request created by cert-manager:
 


### PR DESCRIPTION
As discussed, this PR adds a new section to the quickstart describing a workaround when the installation is stuck waiting for the certificate to be ready.