### PR TITLE
graphql: Revert to accepting the tenant via commandline argument

### DIFF
--- a/go/cmd/graphql/README.md
+++ b/go/cmd/graphql/README.md
@@ -18,14 +18,15 @@ Terminal B:
 opstrace/packages/app$ yarn console
 ```
 
-Terminal C:
+Terminal C (requires that a tenant named `tenant-foo` be created):
 ```
 opstrace/go/cmd/graphql$ go build && \
 GRAPHQL_ENDPOINT=http://127.0.0.1:8080/v1/graphql \
 HASURA_GRAPHQL_ADMIN_SECRET=myadminsecret \
 ./graphql \
   --loglevel debug \
-  --listen "127.0.0.1:8989"
+  --listen "127.0.0.1:8989" \
+  --tenantname tenant-foo
 ```
 
 ## Example usage
@@ -48,22 +49,22 @@ type: gcp-service-account
 # gcp-service-account must contain valid json:
 value: |-
   {"json": "goes-here"}
-' | curl -v -XPOST -H "X-Scope-OrgID: tenant-foo" --data-binary @- http://127.0.0.1:8989/api/v1/credentials/
+' | curl -v -XPOST --data-binary @- http://127.0.0.1:8989/api/v1/credentials/
 ```
 
 Get all
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/credentials/
+curl -v http://127.0.0.1:8989/api/v1/credentials/
 ```
 
 Get foo
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/credentials/foo
+curl -v http://127.0.0.1:8989/api/v1/credentials/foo
 ```
 
 Delete foo
 ```
-curl -v -XDELETE -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/credentials/foo
+curl -v -XDELETE http://127.0.0.1:8989/api/v1/credentials/foo
 ```
 
 ### Exporters
@@ -103,20 +104,20 @@ config:
   - proj2
   monitoring.metrics-interval: '5m' # optional
   monitoring.metrics-offset: '0s' # optional
-' | curl -v -XPOST -H "X-Scope-OrgID: tenant-foo" --data-binary @- http://127.0.0.1:8989/api/v1/exporters/
+' | curl -v -XPOST --data-binary @- http://127.0.0.1:8989/api/v1/exporters/
 ```
 
 Get all
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/exporters/
+curl -v http://127.0.0.1:8989/api/v1/exporters/
 ```
 
 Get foo
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/exporters/foo
+curl -v http://127.0.0.1:8989/api/v1/exporters/foo
 ```
 
 Delete foo
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" -XDELETE http://127.0.0.1:8989/api/v1/exporters/foo
+curl -v -XDELETE http://127.0.0.1:8989/api/v1/exporters/foo
 ```

--- a/go/cmd/graphql/main.go
+++ b/go/cmd/graphql/main.go
@@ -181,7 +181,7 @@ func writeCredentials(w http.ResponseWriter, r *http.Request) {
 		err := decoder.Decode(&yamlCredential)
 		if err != nil {
 			if err != io.EOF {
-				log.Debugf("Decoding exporter input at index=%d failed: %s", len(inserts)+len(updates), err)
+				log.Debugf("Decoding credential input at index=%d failed: %s", len(inserts)+len(updates), err)
 				http.Error(w, fmt.Sprintf(
 					"Decoding credential input at index=%d failed: %s", len(inserts)+len(updates), err,
 				), http.StatusBadRequest)

--- a/go/pkg/graphql/exporter.go
+++ b/go/pkg/graphql/exporter.go
@@ -21,12 +21,14 @@ import (
 )
 
 type ExporterAccess struct {
+	tenant        String
 	client        *Client
 	graphqlSecret string
 }
 
-func NewExporterAccess(graphqlURL *url.URL, graphqlSecret string) ExporterAccess {
+func NewExporterAccess(tenant string, graphqlURL *url.URL, graphqlSecret string) ExporterAccess {
 	return ExporterAccess{
+		String(tenant),
 		NewClient(graphqlURL.String()),
 		graphqlSecret,
 	}
@@ -46,8 +48,8 @@ type FixedGetExportersResponse struct {
 	} `json:"Exporter"`
 }
 
-func (c *ExporterAccess) List(tenant string) (*FixedGetExportersResponse, error) {
-	req, err := NewGetExportersRequest(c.client.Url, &GetExportersVariables{Tenant: String(tenant)})
+func (c *ExporterAccess) List() (*FixedGetExportersResponse, error) {
+	req, err := NewGetExportersRequest(c.client.Url, &GetExportersVariables{Tenant: c.tenant})
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +81,8 @@ type FixedGetExporterResponse struct {
 	} `json:"Exporter_By_Pk"` // fix missing underscores
 }
 
-func (c *ExporterAccess) Get(tenant string, name string) (*FixedGetExporterResponse, error) {
-	req, err := NewGetExporterRequest(c.client.Url, &GetExporterVariables{Tenant: String(tenant), Name: String(name)})
+func (c *ExporterAccess) Get(name string) (*FixedGetExporterResponse, error) {
+	req, err := NewGetExporterRequest(c.client.Url, &GetExporterVariables{Tenant: c.tenant, Name: String(name)})
 	if err != nil {
 		return nil, err
 	}
@@ -111,11 +113,8 @@ type FixedDeleteExporterResponse struct {
 	} `json:"Delete_Exporter_By_Pk"` // fix missing underscores
 }
 
-func (c *ExporterAccess) Delete(tenant string, name string) (*FixedDeleteExporterResponse, error) {
-	req, err := NewDeleteExporterRequest(
-		c.client.Url,
-		&DeleteExporterVariables{Tenant: String(tenant), Name: String(name)},
-	)
+func (c *ExporterAccess) Delete(name string) (*FixedDeleteExporterResponse, error) {
+	req, err := NewDeleteExporterRequest(c.client.Url, &DeleteExporterVariables{Tenant: c.tenant, Name: String(name)})
 	if err != nil {
 		return nil, err
 	}
@@ -139,12 +138,11 @@ func (c *ExporterAccess) Delete(tenant string, name string) (*FixedDeleteExporte
 }
 
 // Insert inserts one or more exporters, returns an error if any already exists.
-func (c *ExporterAccess) Insert(tenant string, inserts []ExporterInsertInput) error {
+func (c *ExporterAccess) Insert(inserts []ExporterInsertInput) error {
 	// Ensure the inserts each have the correct tenant name
 	insertsWithTenant := make([]ExporterInsertInput, 0)
-	tenantg := String(tenant)
 	for _, insert := range inserts {
-		insert.Tenant = &tenantg
+		insert.Tenant = &c.tenant
 		insertsWithTenant = append(insertsWithTenant, insert)
 	}
 
@@ -159,9 +157,9 @@ func (c *ExporterAccess) Insert(tenant string, inserts []ExporterInsertInput) er
 }
 
 // Update updates an existing exporter, returns an error if a exporter of the same tenant/name doesn't exist.
-func (c *ExporterAccess) Update(tenant string, update UpdateExporterVariables) error {
+func (c *ExporterAccess) Update(update UpdateExporterVariables) error {
 	// Ensure the update has the correct tenant name
-	update.Tenant = String(tenant)
+	update.Tenant = c.tenant
 
 	req, err := NewUpdateExporterRequest(c.client.Url, &update)
 	if err != nil {


### PR DESCRIPTION
The graphql api service doesn't have a reverse proxy in front of it, instead we SHOULD accept the tenant name on startup.
I had misunderstood the existing controller code and thought there was a reverse proxy injecting the tenant name on requests.

Partial revert of commit 17916c497f7a4de2107ff576a52f777959cffadc.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
