### PR TITLE
controller: Add config API pod to application deployment

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -2,6 +2,7 @@
   "addonResizer": "k8s.gcr.io/addon-resizer:1.8.4",
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.1.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.1.0",
+  "configApi": "opstrace/config-api:c5b1a59208bc8712918010e90546b9c96e2d0e40",
   "cortex": "cortexproject/cortex:v1.7.0-rc.0",
   "cortexApiProxy": "opstrace/cortex-api:7633d73fc9cf6af5d2caaa25d90fe242",
   "ddApi": "opstrace/ddapi:fd813ccbf9a09d32c4c57cb0fac6b7949be71a92",

--- a/packages/controller/src/resources/apis/config.ts
+++ b/packages/controller/src/resources/apis/config.ts
@@ -1,0 +1,266 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Deployment,
+  Ingress,
+  ResourceCollection,
+  Service,
+  V1ServicemonitorResource,
+  withPodAntiAffinityRequired
+} from "@opstrace/kubernetes";
+import { State } from "../../reducer";
+import { KubeConfig, V1EnvVar } from "@kubernetes/client-node";
+import {
+  getControllerConfig,
+  getDomain
+} from "../../helpers";
+import {
+  DockerImages,
+  ControllerConfigType
+} from "@opstrace/controller-config";
+
+export function ConfigAPIResources(
+  state: State,
+  kubeConfig: KubeConfig,
+  namespace: string
+): ResourceCollection {
+  const collection = new ResourceCollection();
+
+  const domain = getDomain(state);
+
+  const controllerConfig: ControllerConfigType = getControllerConfig(state);
+
+  const api = "config";
+  const name = `${api}-api`;
+
+  const probeConfig = {
+    httpGet: {
+      path: "/metrics",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      port: 8080 as any,
+      scheme: "HTTP"
+    },
+    timeoutSeconds: 1,
+    periodSeconds: 10,
+    successThreshold: 1,
+    failureThreshold: 3
+  };
+
+  const commandArgs = [
+    "-listen=:8080",
+  ]
+  const commandEnv: V1EnvVar[] = [
+    {
+      name: "GRAPHQL_ENDPOINT",
+      value: `http://graphql.application.svc.cluster.local:8080/v1/graphql`
+    },
+    {
+      name: "HASURA_GRAPHQL_ADMIN_SECRET",
+      valueFrom: {
+        secretKeyRef: {
+          name: "hasura-admin-secret",
+          key: "HASURA_ADMIN_SECRET"
+        }
+      }
+    }
+  ]
+
+  if (controllerConfig.disable_data_api_authentication) {
+    commandArgs.push("-disable-api-authn");
+  } else {
+    commandEnv.push(
+      {
+        name: "API_AUTHTOKEN_VERIFICATION_PUBKEY",
+        value: controllerConfig.data_api_authn_pubkey_pem
+      }
+    );
+  }
+
+  collection.add(
+    new Deployment(
+      {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {
+          name,
+          namespace,
+          labels: {
+            "k8s-app": name
+          }
+        },
+        spec: {
+          replicas: 1,
+          selector: {
+            matchLabels: {
+              "k8s-app": name
+            }
+          },
+          template: {
+            metadata: {
+              labels: {
+                "k8s-app": name
+              }
+            },
+            spec: {
+              affinity: withPodAntiAffinityRequired({
+                "k8s-app": name
+              }),
+              containers: [
+                {
+                  name,
+                  image: DockerImages.configApi,
+                  imagePullPolicy: "Always",
+                  args: commandArgs,
+                  env: commandEnv,
+                  ports: [
+                    {
+                      name: "http",
+                      protocol: "TCP",
+                      containerPort: 8080
+                    }
+                  ],
+                  readinessProbe: probeConfig,
+                  livenessProbe: probeConfig,
+                  resources: {}
+                }
+              ]
+            }
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  collection.add(
+    new Service(
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name,
+          labels: {
+            "k8s-app": name,
+            job: `${namespace}.${name}`
+          },
+          namespace
+        },
+        spec: {
+          ports: [
+            {
+              name: "http",
+              port: 8080,
+              protocol: "TCP",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              targetPort: 8080 as any
+            }
+          ],
+          selector: {
+            "k8s-app": name
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  // No per-tenant ingress hosts at the moment.
+  // We could someday add per-tenant Ingresses, but they would be in other namespaces...
+  const apiHost = `${api}.${domain}`
+  collection.add(
+    new Ingress(
+      {
+        apiVersion: "networking.k8s.io/v1beta1",
+        kind: "Ingress",
+        metadata: {
+          name: `${api}`,
+          namespace,
+          annotations: {
+            "kubernetes.io/ingress.class": "api",
+            "external-dns.alpha.kubernetes.io/ttl": "30",
+            "nginx.ingress.kubernetes.io/client-body-buffer-size": "10m"
+          }
+        },
+        spec: {
+          tls: [
+            {
+              hosts: [apiHost],
+              secretName: "https-cert"
+            }
+          ],
+          rules: [
+            {
+              host: apiHost,
+              http: {
+                paths: [
+                  {
+                    backend: {
+                      serviceName: name,
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      servicePort: 8080 as any
+                    },
+                    pathType: "ImplementationSpecific",
+                    path: "/"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  collection.add(
+    new V1ServicemonitorResource(
+      {
+        apiVersion: "monitoring.coreos.com/v1",
+        kind: "ServiceMonitor",
+        metadata: {
+          labels: {
+            "k8s-app": name,
+            tenant: "system"
+          },
+          name,
+          namespace
+        },
+        spec: {
+          endpoints: [
+            {
+              interval: "30s",
+              path: "/metrics",
+              port: "http"
+            }
+          ],
+          jobLabel: "job",
+          namespaceSelector: {
+            matchNames: [namespace]
+          },
+          selector: {
+            matchLabels: {
+              "k8s-app": name
+            }
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  return collection;
+}

--- a/packages/controller/src/resources/apis/index.ts
+++ b/packages/controller/src/resources/apis/index.ts
@@ -19,16 +19,17 @@ import { KubeConfig } from "@kubernetes/client-node";
 import { ResourceCollection } from "@opstrace/kubernetes";
 import { State } from "../../reducer";
 
-import { LokiAPIResources } from "./loki";
+import { ConfigAPIResources } from "./config";
 import { CortexAPIResources } from "./cortex";
 import { DDAPIResources } from "./dd";
+import { LokiAPIResources } from "./loki";
 
 // This does not serve an API, right?
 // Maybe we should move this out of resources/apis or rename resources/apis
 import { SystemLogAgentResources } from "./systemlogs";
 
 /* Translate node count into replica count*/
-export function nodecountToReplicacount(nodecount: number) {
+export function nodecountToReplicacount(nodecount: number): number {
   const NC_RC_MAP: Record<string, number> = {
     "1": 1,
     "2": 2,
@@ -50,6 +51,10 @@ export function APIResources(
 ): ResourceCollection {
   const collection = new ResourceCollection();
 
+  // Single instance 'application' namespace: allow access to hasura-admin-secret
+  collection.add(ConfigAPIResources(state, kubeConfig, "application"));
+
+  // Per-tenant resources
   state.tenants.list.tenants.forEach(tenant => {
     collection.add(SystemLogAgentResources(state, tenant, kubeConfig));
     collection.add(LokiAPIResources(state, tenant, kubeConfig));


### PR DESCRIPTION
This deploys the `config` service from `go/cmd/config/`. It serves endpoints for adding/updating/removing credentials and exporters in the GraphQL service. It is accessible at e.g. `config.cluster-name.opstrace.io`. The endpoints are currently documented in `go/cmd/config/README.md`, planning on writing a nice user-facing guide once the controller sync support is complete.

The controller deploys a single common `config` ingress/service/pod into the `application` namespace, rather than the per-tenant namespaces, so that it can use the existing Hasura access secrets in the `application` namespace. This felt like a better tradeoff than running instances in each of the tenant namespaces, which would have meant needing to add a copy of the Hasura secret into the per-tenant namespaces as well. So, when the config service receives a request over HTTP, it extracts the tenant name from the (required and validated) bearer token, rather than being "locked" to a single tenant. See also #351.

As of this PR, we support writing/updating/deleting credentials and exporter configs in GraphQL via `curl`. The interface itself has pretty good validation and error handling for the configs, and should be pretty much ready to go. However, there isn't anything that actually consumes the configs yet. Next steps:
- Updating the controller itself to automatically sync GraphQL credentials/exporters into K8s tenant namespaces as Secrets and Deployments.
- Once things are known-working, writing a user guide for the docs describing how to configure and deploy exporters (and their prerequisite credentials) in various environments, using `curl` commands to the config service.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [X] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [X] Thought about which docs need updating?
