### PR TITLE
makefile: Print success message when build finishes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,16 +222,22 @@ cli-pkg:
 	yarn run pkg packages/cli/package.json --public \
 		--targets node14-$${TPLATFORM}-x64 \
 		--output build/bin/opstrace \
-		--options stack-trace-limit=100
+		--options stack-trace-limit=100 && \
+        set +o xtrace && \
+        echo "Successfully built CLI for $${TPLATFORM}: ./build/bin/opstrace"
 
 .PHONY: cli-pkg-macos
 cli-pkg-macos:
 	@# pkg-build CLI for macos (use this in CI -- linux -- to create macos
 	@# builds.
-	mkdir -p build/bin/macos && yarn run pkg packages/cli/package.json --public \
+	mkdir -p build/bin/macos && \
+	set -o xtrace && \
+        yarn run pkg packages/cli/package.json --public \
 		--targets node14-macos-x64 \
 		--output build/bin/macos/opstrace \
-		--options stack-trace-limit=100
+		--options stack-trace-limit=100 && \
+        set +o xtrace && \
+        echo "Successfully built CLI for macos: ./build/bin/macos/opstrace"
 
 
 .PHONY: generate-aws-api-call-list


### PR DESCRIPTION
At the moment there are some build warnings that at first glance make it look like the build failed. This should help counter that impression when it isn't the case, while also giving a handy pointer to the build output.

Sample output:
```
+ yarn run pkg packages/cli/package.json --public --targets node14-linux-x64 --output build/bin/opstrace --options stack-trace-limit=100
yarn run v1.22.10
$ /home/nick/opstrace/opstrace/node_modules/.bin/pkg packages/cli/package.json --public --targets node14-linux-x64 --output build/bin/opstrace --options stack-trace-limit=100
> pkg@4.4.9
> Warning Cannot include file %1 into executable.
  The file must be distributed with executable as %2.
  %1: node_modules/open/xdg-open
  %2: path-to-executable/xdg-open
> Warning Cannot include file %1 into executable.
  The file must be distributed with executable as %2.
  %1: node_modules/open/xdg-open
  %2: path-to-executable/xdg-open
> Warning Failed to make bytecode node14-x64 for file /snapshot/opstrace/node_modules/lodash-es/lodash.js
Done in 28.16s.
+ set +o xtrace
Successfully built CLI for linux: ./build/bin/opstrace
```

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [X] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
