### PR TITLE
bump: cortex 1.7.0 rc0 -> rc2

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -3,7 +3,7 @@
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.1.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.1.0",
   "configApi": "opstrace/config-api:c5b1a59208bc8712918010e90546b9c96e2d0e40",
-  "cortex": "cortexproject/cortex:v1.7.0-rc.0",
+  "cortex": "cortexproject/cortex:v1.7.0-rc.2",
   "cortexApiProxy": "opstrace/cortex-api:f04cb9669fb32561f81b56a7b0dd864b",
   "ddApi": "opstrace/ddapi:fd813ccbf9a09d32c4c57cb0fac6b7949be71a92",
   "externalDNS": "k8s.gcr.io/external-dns/external-dns:v0.7.4",


### PR DESCRIPTION
Cortex 1.7.0-rc.2 was released about a day ago.

Since rc0, there have been two important fixes:

> [BUGFIX] Handle missing samples due to large steps and single point extents
> [BUGFIX] Fix ring tokens sorting regression introduced in #3601

https://github.com/cortexproject/cortex/releases