### PR TITLE
ci: fetch fluentd logs with kubectl, switch to GKE REGULAR release channel (k8s 1.18)

### DIFF
--- a/ci/create-cluster-artifacts.sh
+++ b/ci/create-cluster-artifacts.sh
@@ -16,6 +16,12 @@ kubectl describe --namespace=kube-system deployment.apps/opstrace-controller \
 kubectl logs statefulset.apps/prometheus-system-prometheus \
  --container prometheus --namespace=system-tenant > clusterlogs_systemprom-${OPSTRACE_CLUSTER_NAME}.log
 
+# Fluentd collects and pushes system logs into Loki.
+kubectl get all --namespace=system-tenant 2>/dev/null | awk '{print $1}' | \
+    grep 'pod/systemlog' | while read PNAME; do echo "get logs for $PNAME" | \
+    tee /dev/stderr ; kubectl logs $PNAME --namespace=system-tenant --all-containers=true; done \
+    > clusterlogs_fluentd-${OPSTRACE_CLUSTER_NAME}.log
+
 kubectl get all --namespace=loki 2>/dev/null | awk '{print $1}' | \
     grep 'pod/' | while read PNAME; do echo "get logs for $PNAME" | \
     tee /dev/stderr ; kubectl logs $PNAME --namespace=loki --all-containers=true; done \

--- a/packages/config/src/gke.ts
+++ b/packages/config/src/gke.ts
@@ -30,7 +30,6 @@ export function getGKEClusterConfig(
     env: ccfg.env_label
   };
 
-  // const k8sVersion = "1.18";
   const masterAuthorizedNetworks = [
     {
       displayName: "all",
@@ -50,13 +49,13 @@ export function getGKEClusterConfig(
     opstrace_cluster_name: ccfg.cluster_name
   };
 
+  // https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster
   return {
     network: ccfg.cluster_name,
     subnetwork: ccfg.cluster_name,
-    // initialClusterVersion: k8sVersion, (only set this once we move back to the REGULAR channel)
+    initialClusterVersion: "1.18", // "1.X": picks the highest valid patch+gke.N patch in the 1.X version
     releaseChannel: {
-      channel: "RAPID" // v1.18 currently only available in the rapid channel (NOTE: Rapid channel has automatic upgrades
-      // that cannot be disabled.)
+      channel: "REGULAR"
     },
     loggingService: "none",
     monitoringService: "none",


### PR DESCRIPTION
PR for debugging and resolving #407

Tested manually with

```
 ± kubectl get all --namespace=system-tenant 2>/dev/null | awk '{print $1}' | \
>     grep 'pod/systemlog' | while read PNAME; do echo "get logs for $PNAME" | \
>     tee /dev/stderr ; kubectl logs $PNAME --namespace=system-tenant --all-containers=true; done \
>     > clusterlogs_fluentd-${OPSTRACE_CLUSTER_NAME}.log
get logs for pod/systemlog-cnjj2
get logs for pod/systemlog-jslcq
get logs for pod/systemlog-wpz69
```