### PR TITLE
systemlogs: bump fluentd and plugins

### DIFF
--- a/containers/systemlog-fluentd/Dockerfile
+++ b/containers/systemlog-fluentd/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.11.3-debian-1.0
+FROM fluent/fluentd:v1.12.0-debian-1.0
 USER root
 
 # What follows is a combination of instructions for how to customize the
@@ -15,12 +15,12 @@ RUN buildDeps="sudo make gcc g++ libc-dev git" \
    && apt-get install -y --no-install-recommends $buildDeps \
    && oldpath=`pwd` && mkdir /tmp/lokicheckout && cd /tmp/lokicheckout \
    && git init && git remote add origin https://github.com/jgehrcke/loki \
-   && git fetch origin 207ebdad69a318d2d81f419fba53ed85d73bd694 \
+   && git fetch origin 081cc024d67d0292a377f5995f4822a07a8e38af \
    && git reset --hard FETCH_HEAD \
    && cd /tmp/lokicheckout/cmd/fluentd/ \
    && gem build fluent-plugin-grafana-loki.gemspec \
    && gem install --ignore-dependencies *gem \
-   && gem install fluent-plugin-kubernetes_metadata_filter -v 2.5.2 \
+   && gem install fluent-plugin-kubernetes_metadata_filter -v 2.6.0 \
    && sudo gem sources --clear-all \
    && SUDO_FORCE_REMOVE=yes \
    apt-get purge -y --auto-remove \

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -7,7 +7,7 @@
   "cortexApiProxy": "opstrace/cortex-api:f04cb9669fb32561f81b56a7b0dd864b",
   "ddApi": "opstrace/ddapi:fd813ccbf9a09d32c4c57cb0fac6b7949be71a92",
   "externalDNS": "k8s.gcr.io/external-dns/external-dns:v0.7.4",
-  "systemlogFluentd": "opstrace/systemlog-fluentd:fe6d0d84-dev",
+  "systemlogFluentd": "opstrace/systemlog-fluentd:0798f0a-dev",
   "grafana": "grafana/grafana:7.3.4-ubuntu",
   "kubed": "appscode/kubed:v0.12.0",
   "kubeRBACProxy": "quay.io/coreos/kube-rbac-proxy:v0.4.1",


### PR DESCRIPTION
Log of building and pushing image:
```
$ make build-image
docker build -t opstrace/systemlog-fluentd:0798f0a-dev .
Sending build context to Docker daemon   7.68kB
Step 1/4 : FROM fluent/fluentd:v1.12.0-debian-1.0
 ---> 9c3c00d2a1d1
Step 2/4 : USER root
 ---> Using cache
 ---> 40a080b18123
Step 3/4 : RUN buildDeps="sudo make gcc g++ libc-dev git"    && apt-get update    && apt-get install -y --no-install-recommends $buildDeps    && oldpath=`pwd` && mkdir /tmp/lokicheckout && cd /tmp/lokicheckout    && git init && git remote add origin https://github.com/jgehrcke/loki    && git fetch origin 081cc024d67d0292a377f5995f4822a07a8e38af    && git reset --hard FETCH_HEAD    && cd /tmp/lokicheckout/cmd/fluentd/    && gem build fluent-plugin-grafana-loki.gemspec    && gem install --ignore-dependencies *gem    && gem install fluent-plugin-kubernetes_metadata_filter -v 2.6.0    && sudo gem sources --clear-all    && SUDO_FORCE_REMOVE=yes    apt-get purge -y --auto-remove    -o APT::AutoRemove::RecommendsImportant=false    $buildDeps    && rm -rf /var/lib/apt/lists/*    && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 ---> Running in 5a52fe56b3bb
Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
Get:4 http://deb.debian.org/debian buster/main amd64 Packages [7907 kB]
Get:5 http://security.debian.org/debian-security buster/updates/main amd64 Packages [267 kB]
Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages [9504 B]
Fetched 8422 kB in 2s (3886 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
libc6-dev is already the newest version (2.28-10).
The following additional packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu cpp cpp-8 g++-8 gcc-8
  git-man libasan5 libatomic1 libbinutils libcc1-0 libcurl3-gnutls
  liberror-perl libexpat1 libgcc-8-dev libgomp1 libgssapi-krb5-2 libisl19
  libitm1 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2
  libldap-common liblsan0 libmpc3 libmpfr6 libmpx2 libnghttp2-14 libpcre2-8-0
  libperl5.28 libpsl5 libquadmath0 librtmp1 libsasl2-2 libsasl2-modules-db
  libssh2-1 libstdc++-8-dev libtsan0 libubsan1 perl perl-modules-5.28
Suggested packages:
  binutils-doc cpp-doc gcc-8-locales g++-multilib g++-8-multilib gcc-8-doc
  libstdc++6-8-dbg gcc-multilib manpages-dev autoconf automake libtool flex
  bison gdb gcc-doc gcc-8-multilib libgcc1-dbg libgomp1-dbg libitm1-dbg
  libatomic1-dbg libasan5-dbg liblsan0-dbg libtsan0-dbg libubsan1-dbg
  libmpx2-dbg libquadmath0-dbg gettext-base git-daemon-run
  | git-daemon-sysvinit git-doc git-el git-email git-gui gitk gitweb git-cvs
  git-mediawiki git-svn krb5-doc krb5-user sensible-utils libstdc++-8-doc
  make-doc perl-doc libterm-readline-gnu-perl | libterm-readline-perl-perl
  libb-debug-perl liblocale-codes-perl
Recommended packages:
  patch less ssh-client krb5-locales publicsuffix libsasl2-modules netbase
The following NEW packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu cpp cpp-8 g++ g++-8 gcc
  gcc-8 git git-man libasan5 libatomic1 libbinutils libcc1-0 libcurl3-gnutls
  liberror-perl libexpat1 libgcc-8-dev libgomp1 libgssapi-krb5-2 libisl19
  libitm1 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2
  libldap-common liblsan0 libmpc3 libmpfr6 libmpx2 libnghttp2-14 libpcre2-8-0
  libperl5.28 libpsl5 libquadmath0 librtmp1 libsasl2-2 libsasl2-modules-db
  libssh2-1 libstdc++-8-dev libtsan0 libubsan1 make perl perl-modules-5.28
  sudo
0 upgraded, 49 newly installed, 0 to remove and 12 not upgraded.
Need to get 57.1 MB of archives.
After this operation, 245 MB of additional disk space will be used.
Get:1 http://security.debian.org/debian-security buster/updates/main amd64 libldap-common all 2.4.47+dfsg-3+deb10u6 [90.0 kB]
Get:2 http://deb.debian.org/debian buster/main amd64 perl-modules-5.28 all 5.28.1-6+deb10u1 [2873 kB]
Get:3 http://security.debian.org/debian-security buster/updates/main amd64 libldap-2.4-2 amd64 2.4.47+dfsg-3+deb10u6 [224 kB]
Get:4 http://deb.debian.org/debian buster/main amd64 libperl5.28 amd64 5.28.1-6+deb10u1 [3894 kB]
Get:5 http://deb.debian.org/debian buster/main amd64 perl amd64 5.28.1-6+deb10u1 [204 kB]
Get:6 http://deb.debian.org/debian buster/main amd64 libsasl2-modules-db amd64 2.1.27+dfsg-1+deb10u1 [69.1 kB]
Get:7 http://deb.debian.org/debian buster/main amd64 libsasl2-2 amd64 2.1.27+dfsg-1+deb10u1 [106 kB]
Get:8 http://deb.debian.org/debian buster/main amd64 binutils-common amd64 2.31.1-16 [2073 kB]
Get:9 http://deb.debian.org/debian buster/main amd64 libbinutils amd64 2.31.1-16 [478 kB]
Get:10 http://deb.debian.org/debian buster/main amd64 binutils-x86-64-linux-gnu amd64 2.31.1-16 [1823 kB]
Get:11 http://deb.debian.org/debian buster/main amd64 binutils amd64 2.31.1-16 [56.8 kB]
Get:12 http://deb.debian.org/debian buster/main amd64 libisl19 amd64 0.20-2 [587 kB]
Get:13 http://deb.debian.org/debian buster/main amd64 libmpfr6 amd64 4.0.2-1 [775 kB]
Get:14 http://deb.debian.org/debian buster/main amd64 libmpc3 amd64 1.1.0-1 [41.3 kB]
Get:15 http://deb.debian.org/debian buster/main amd64 cpp-8 amd64 8.3.0-6 [8914 kB]
Get:16 http://deb.debian.org/debian buster/main amd64 cpp amd64 4:8.3.0-1 [19.4 kB]
Get:17 http://deb.debian.org/debian buster/main amd64 libcc1-0 amd64 8.3.0-6 [46.6 kB]
Get:18 http://deb.debian.org/debian buster/main amd64 libgomp1 amd64 8.3.0-6 [75.8 kB]
Get:19 http://deb.debian.org/debian buster/main amd64 libitm1 amd64 8.3.0-6 [27.7 kB]
Get:20 http://deb.debian.org/debian buster/main amd64 libatomic1 amd64 8.3.0-6 [9032 B]
Get:21 http://deb.debian.org/debian buster/main amd64 libasan5 amd64 8.3.0-6 [362 kB]
Get:22 http://deb.debian.org/debian buster/main amd64 liblsan0 amd64 8.3.0-6 [131 kB]
Get:23 http://deb.debian.org/debian buster/main amd64 libtsan0 amd64 8.3.0-6 [283 kB]
Get:24 http://deb.debian.org/debian buster/main amd64 libubsan1 amd64 8.3.0-6 [120 kB]
Get:25 http://deb.debian.org/debian buster/main amd64 libmpx2 amd64 8.3.0-6 [11.4 kB]
Get:26 http://deb.debian.org/debian buster/main amd64 libquadmath0 amd64 8.3.0-6 [133 kB]
Get:27 http://deb.debian.org/debian buster/main amd64 libgcc-8-dev amd64 8.3.0-6 [2298 kB]
Get:28 http://deb.debian.org/debian buster/main amd64 gcc-8 amd64 8.3.0-6 [9452 kB]
Get:29 http://deb.debian.org/debian buster/main amd64 gcc amd64 4:8.3.0-1 [5196 B]
Get:30 http://deb.debian.org/debian buster/main amd64 libstdc++-8-dev amd64 8.3.0-6 [1532 kB]
Get:31 http://deb.debian.org/debian buster/main amd64 g++-8 amd64 8.3.0-6 [9752 kB]
Get:32 http://deb.debian.org/debian buster/main amd64 g++ amd64 4:8.3.0-1 [1644 B]
Get:33 http://deb.debian.org/debian buster/main amd64 libkeyutils1 amd64 1.6-6 [15.0 kB]
Get:34 http://deb.debian.org/debian buster/main amd64 libkrb5support0 amd64 1.17-3+deb10u1 [65.8 kB]
Get:35 http://deb.debian.org/debian buster/main amd64 libk5crypto3 amd64 1.17-3+deb10u1 [122 kB]
Get:36 http://deb.debian.org/debian buster/main amd64 libkrb5-3 amd64 1.17-3+deb10u1 [369 kB]
Get:37 http://deb.debian.org/debian buster/main amd64 libgssapi-krb5-2 amd64 1.17-3+deb10u1 [158 kB]
Get:38 http://deb.debian.org/debian buster/main amd64 libnghttp2-14 amd64 1.36.0-2+deb10u1 [85.0 kB]
Get:39 http://deb.debian.org/debian buster/main amd64 libpsl5 amd64 0.20.2-2 [53.7 kB]
Get:40 http://deb.debian.org/debian buster/main amd64 librtmp1 amd64 2.4+20151223.gitfa8646d.1-2 [60.5 kB]
Get:41 http://deb.debian.org/debian buster/main amd64 libssh2-1 amd64 1.8.0-2.1 [140 kB]
Get:42 http://deb.debian.org/debian buster/main amd64 libcurl3-gnutls amd64 7.64.0-4+deb10u1 [330 kB]
Get:43 http://deb.debian.org/debian buster/main amd64 libexpat1 amd64 2.2.6-2+deb10u1 [106 kB]
Get:44 http://deb.debian.org/debian buster/main amd64 libpcre2-8-0 amd64 10.32-5 [213 kB]
Get:45 http://deb.debian.org/debian buster/main amd64 liberror-perl all 0.17027-2 [30.9 kB]
Get:46 http://deb.debian.org/debian buster/main amd64 git-man all 1:2.20.1-2+deb10u3 [1620 kB]
Get:47 http://deb.debian.org/debian buster/main amd64 git amd64 1:2.20.1-2+deb10u3 [5633 kB]
Get:48 http://deb.debian.org/debian buster/main amd64 make amd64 4.2.1-1.2 [341 kB]
Get:49 http://deb.debian.org/debian buster/main amd64 sudo amd64 1.8.27-1+deb10u3 [1244 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 57.1 MB in 3s (20.1 MB/s)
Selecting previously unselected package perl-modules-5.28.
(Reading database ... 8572 files and directories currently installed.)
Preparing to unpack .../00-perl-modules-5.28_5.28.1-6+deb10u1_all.deb ...
Unpacking perl-modules-5.28 (5.28.1-6+deb10u1) ...
Selecting previously unselected package libperl5.28:amd64.
Preparing to unpack .../01-libperl5.28_5.28.1-6+deb10u1_amd64.deb ...
Unpacking libperl5.28:amd64 (5.28.1-6+deb10u1) ...
Selecting previously unselected package perl.
Preparing to unpack .../02-perl_5.28.1-6+deb10u1_amd64.deb ...
Unpacking perl (5.28.1-6+deb10u1) ...
Selecting previously unselected package libsasl2-modules-db:amd64.
Preparing to unpack .../03-libsasl2-modules-db_2.1.27+dfsg-1+deb10u1_amd64.deb ...
Unpacking libsasl2-modules-db:amd64 (2.1.27+dfsg-1+deb10u1) ...
Selecting previously unselected package libsasl2-2:amd64.
Preparing to unpack .../04-libsasl2-2_2.1.27+dfsg-1+deb10u1_amd64.deb ...
Unpacking libsasl2-2:amd64 (2.1.27+dfsg-1+deb10u1) ...
Selecting previously unselected package libldap-common.
Preparing to unpack .../05-libldap-common_2.4.47+dfsg-3+deb10u6_all.deb ...
Unpacking libldap-common (2.4.47+dfsg-3+deb10u6) ...
Selecting previously unselected package libldap-2.4-2:amd64.
Preparing to unpack .../06-libldap-2.4-2_2.4.47+dfsg-3+deb10u6_amd64.deb ...
Unpacking libldap-2.4-2:amd64 (2.4.47+dfsg-3+deb10u6) ...
Selecting previously unselected package binutils-common:amd64.
Preparing to unpack .../07-binutils-common_2.31.1-16_amd64.deb ...
Unpacking binutils-common:amd64 (2.31.1-16) ...
Selecting previously unselected package libbinutils:amd64.
Preparing to unpack .../08-libbinutils_2.31.1-16_amd64.deb ...
Unpacking libbinutils:amd64 (2.31.1-16) ...
Selecting previously unselected package binutils-x86-64-linux-gnu.
Preparing to unpack .../09-binutils-x86-64-linux-gnu_2.31.1-16_amd64.deb ...
Unpacking binutils-x86-64-linux-gnu (2.31.1-16) ...
Selecting previously unselected package binutils.
Preparing to unpack .../10-binutils_2.31.1-16_amd64.deb ...
Unpacking binutils (2.31.1-16) ...
Selecting previously unselected package libisl19:amd64.
Preparing to unpack .../11-libisl19_0.20-2_amd64.deb ...
Unpacking libisl19:amd64 (0.20-2) ...
Selecting previously unselected package libmpfr6:amd64.
Preparing to unpack .../12-libmpfr6_4.0.2-1_amd64.deb ...
Unpacking libmpfr6:amd64 (4.0.2-1) ...
Selecting previously unselected package libmpc3:amd64.
Preparing to unpack .../13-libmpc3_1.1.0-1_amd64.deb ...
Unpacking libmpc3:amd64 (1.1.0-1) ...
Selecting previously unselected package cpp-8.
Preparing to unpack .../14-cpp-8_8.3.0-6_amd64.deb ...
Unpacking cpp-8 (8.3.0-6) ...
Selecting previously unselected package cpp.
Preparing to unpack .../15-cpp_4%3a8.3.0-1_amd64.deb ...
Unpacking cpp (4:8.3.0-1) ...
Selecting previously unselected package libcc1-0:amd64.
Preparing to unpack .../16-libcc1-0_8.3.0-6_amd64.deb ...
Unpacking libcc1-0:amd64 (8.3.0-6) ...
Selecting previously unselected package libgomp1:amd64.
Preparing to unpack .../17-libgomp1_8.3.0-6_amd64.deb ...
Unpacking libgomp1:amd64 (8.3.0-6) ...
Selecting previously unselected package libitm1:amd64.
Preparing to unpack .../18-libitm1_8.3.0-6_amd64.deb ...
Unpacking libitm1:amd64 (8.3.0-6) ...
Selecting previously unselected package libatomic1:amd64.
Preparing to unpack .../19-libatomic1_8.3.0-6_amd64.deb ...
Unpacking libatomic1:amd64 (8.3.0-6) ...
Selecting previously unselected package libasan5:amd64.
Preparing to unpack .../20-libasan5_8.3.0-6_amd64.deb ...
Unpacking libasan5:amd64 (8.3.0-6) ...
Selecting previously unselected package liblsan0:amd64.
Preparing to unpack .../21-liblsan0_8.3.0-6_amd64.deb ...
Unpacking liblsan0:amd64 (8.3.0-6) ...
Selecting previously unselected package libtsan0:amd64.
Preparing to unpack .../22-libtsan0_8.3.0-6_amd64.deb ...
Unpacking libtsan0:amd64 (8.3.0-6) ...
Selecting previously unselected package libubsan1:amd64.
Preparing to unpack .../23-libubsan1_8.3.0-6_amd64.deb ...
Unpacking libubsan1:amd64 (8.3.0-6) ...
Selecting previously unselected package libmpx2:amd64.
Preparing to unpack .../24-libmpx2_8.3.0-6_amd64.deb ...
Unpacking libmpx2:amd64 (8.3.0-6) ...
Selecting previously unselected package libquadmath0:amd64.
Preparing to unpack .../25-libquadmath0_8.3.0-6_amd64.deb ...
Unpacking libquadmath0:amd64 (8.3.0-6) ...
Selecting previously unselected package libgcc-8-dev:amd64.
Preparing to unpack .../26-libgcc-8-dev_8.3.0-6_amd64.deb ...
Unpacking libgcc-8-dev:amd64 (8.3.0-6) ...
Selecting previously unselected package gcc-8.
Preparing to unpack .../27-gcc-8_8.3.0-6_amd64.deb ...
Unpacking gcc-8 (8.3.0-6) ...
Selecting previously unselected package gcc.
Preparing to unpack .../28-gcc_4%3a8.3.0-1_amd64.deb ...
Unpacking gcc (4:8.3.0-1) ...
Selecting previously unselected package libstdc++-8-dev:amd64.
Preparing to unpack .../29-libstdc++-8-dev_8.3.0-6_amd64.deb ...
Unpacking libstdc++-8-dev:amd64 (8.3.0-6) ...
Selecting previously unselected package g++-8.
Preparing to unpack .../30-g++-8_8.3.0-6_amd64.deb ...
Unpacking g++-8 (8.3.0-6) ...
Selecting previously unselected package g++.
Preparing to unpack .../31-g++_4%3a8.3.0-1_amd64.deb ...
Unpacking g++ (4:8.3.0-1) ...
Selecting previously unselected package libkeyutils1:amd64.
Preparing to unpack .../32-libkeyutils1_1.6-6_amd64.deb ...
Unpacking libkeyutils1:amd64 (1.6-6) ...
Selecting previously unselected package libkrb5support0:amd64.
Preparing to unpack .../33-libkrb5support0_1.17-3+deb10u1_amd64.deb ...
Unpacking libkrb5support0:amd64 (1.17-3+deb10u1) ...
Selecting previously unselected package libk5crypto3:amd64.
Preparing to unpack .../34-libk5crypto3_1.17-3+deb10u1_amd64.deb ...
Unpacking libk5crypto3:amd64 (1.17-3+deb10u1) ...
Selecting previously unselected package libkrb5-3:amd64.
Preparing to unpack .../35-libkrb5-3_1.17-3+deb10u1_amd64.deb ...
Unpacking libkrb5-3:amd64 (1.17-3+deb10u1) ...
Selecting previously unselected package libgssapi-krb5-2:amd64.
Preparing to unpack .../36-libgssapi-krb5-2_1.17-3+deb10u1_amd64.deb ...
Unpacking libgssapi-krb5-2:amd64 (1.17-3+deb10u1) ...
Selecting previously unselected package libnghttp2-14:amd64.
Preparing to unpack .../37-libnghttp2-14_1.36.0-2+deb10u1_amd64.deb ...
Unpacking libnghttp2-14:amd64 (1.36.0-2+deb10u1) ...
Selecting previously unselected package libpsl5:amd64.
Preparing to unpack .../38-libpsl5_0.20.2-2_amd64.deb ...
Unpacking libpsl5:amd64 (0.20.2-2) ...
Selecting previously unselected package librtmp1:amd64.
Preparing to unpack .../39-librtmp1_2.4+20151223.gitfa8646d.1-2_amd64.deb ...
Unpacking librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2) ...
Selecting previously unselected package libssh2-1:amd64.
Preparing to unpack .../40-libssh2-1_1.8.0-2.1_amd64.deb ...
Unpacking libssh2-1:amd64 (1.8.0-2.1) ...
Selecting previously unselected package libcurl3-gnutls:amd64.
Preparing to unpack .../41-libcurl3-gnutls_7.64.0-4+deb10u1_amd64.deb ...
Unpacking libcurl3-gnutls:amd64 (7.64.0-4+deb10u1) ...
Selecting previously unselected package libexpat1:amd64.
Preparing to unpack .../42-libexpat1_2.2.6-2+deb10u1_amd64.deb ...
Unpacking libexpat1:amd64 (2.2.6-2+deb10u1) ...
Selecting previously unselected package libpcre2-8-0:amd64.
Preparing to unpack .../43-libpcre2-8-0_10.32-5_amd64.deb ...
Unpacking libpcre2-8-0:amd64 (10.32-5) ...
Selecting previously unselected package liberror-perl.
Preparing to unpack .../44-liberror-perl_0.17027-2_all.deb ...
Unpacking liberror-perl (0.17027-2) ...
Selecting previously unselected package git-man.
Preparing to unpack .../45-git-man_1%3a2.20.1-2+deb10u3_all.deb ...
Unpacking git-man (1:2.20.1-2+deb10u3) ...
Selecting previously unselected package git.
Preparing to unpack .../46-git_1%3a2.20.1-2+deb10u3_amd64.deb ...
Unpacking git (1:2.20.1-2+deb10u3) ...
Selecting previously unselected package make.
Preparing to unpack .../47-make_4.2.1-1.2_amd64.deb ...
Unpacking make (4.2.1-1.2) ...
Selecting previously unselected package sudo.
Preparing to unpack .../48-sudo_1.8.27-1+deb10u3_amd64.deb ...
Unpacking sudo (1.8.27-1+deb10u3) ...
Setting up perl-modules-5.28 (5.28.1-6+deb10u1) ...
Setting up libexpat1:amd64 (2.2.6-2+deb10u1) ...
Setting up libkeyutils1:amd64 (1.6-6) ...
Setting up libpsl5:amd64 (0.20.2-2) ...
Setting up binutils-common:amd64 (2.31.1-16) ...
Setting up libnghttp2-14:amd64 (1.36.0-2+deb10u1) ...
Setting up libgomp1:amd64 (8.3.0-6) ...
Setting up libldap-common (2.4.47+dfsg-3+deb10u6) ...
Setting up libkrb5support0:amd64 (1.17-3+deb10u1) ...
Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg-1+deb10u1) ...
Setting up libasan5:amd64 (8.3.0-6) ...
Setting up make (4.2.1-1.2) ...
Setting up libmpfr6:amd64 (4.0.2-1) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2) ...
Setting up libquadmath0:amd64 (8.3.0-6) ...
Setting up libmpc3:amd64 (1.1.0-1) ...
Setting up libatomic1:amd64 (8.3.0-6) ...
Setting up sudo (1.8.27-1+deb10u3) ...
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Setting up libpcre2-8-0:amd64 (10.32-5) ...
Setting up libk5crypto3:amd64 (1.17-3+deb10u1) ...
Setting up libsasl2-2:amd64 (2.1.27+dfsg-1+deb10u1) ...
Setting up libperl5.28:amd64 (5.28.1-6+deb10u1) ...
Setting up libmpx2:amd64 (8.3.0-6) ...
Setting up libubsan1:amd64 (8.3.0-6) ...
Setting up libisl19:amd64 (0.20-2) ...
Setting up git-man (1:2.20.1-2+deb10u3) ...
Setting up libssh2-1:amd64 (1.8.0-2.1) ...
Setting up libkrb5-3:amd64 (1.17-3+deb10u1) ...
Setting up libbinutils:amd64 (2.31.1-16) ...
Setting up cpp-8 (8.3.0-6) ...
Setting up libcc1-0:amd64 (8.3.0-6) ...
Setting up liblsan0:amd64 (8.3.0-6) ...
Setting up libitm1:amd64 (8.3.0-6) ...
Setting up binutils-x86-64-linux-gnu (2.31.1-16) ...
Setting up libtsan0:amd64 (8.3.0-6) ...
Setting up libldap-2.4-2:amd64 (2.4.47+dfsg-3+deb10u6) ...
Setting up binutils (2.31.1-16) ...
Setting up perl (5.28.1-6+deb10u1) ...
Setting up libgssapi-krb5-2:amd64 (1.17-3+deb10u1) ...
Setting up libgcc-8-dev:amd64 (8.3.0-6) ...
Setting up cpp (4:8.3.0-1) ...
Setting up libstdc++-8-dev:amd64 (8.3.0-6) ...
Setting up gcc-8 (8.3.0-6) ...
Setting up libcurl3-gnutls:amd64 (7.64.0-4+deb10u1) ...
Setting up gcc (4:8.3.0-1) ...
Setting up liberror-perl (0.17027-2) ...
Setting up git (1:2.20.1-2+deb10u3) ...
Setting up g++-8 (8.3.0-6) ...
Setting up g++ (4:8.3.0-1) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Processing triggers for libc-bin (2.28-10) ...
Initialized empty Git repository in /tmp/lokicheckout/.git/
From https://github.com/jgehrcke/loki
 * branch            081cc024d67d0292a377f5995f4822a07a8e38af -> FETCH_HEAD
Checking out files: 100% (8144/8144), done.
HEAD is now at 081cc024 fluent-plugin: Improve escaping in key_value format (#2434)
WARNING:  description and summary are identical
WARNING:  open-ended dependency on bundler (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rubocop-rspec (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on simplecov (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on test-unit (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: fluent-plugin-grafana-loki
  Version: 1.2.15
  File: fluent-plugin-grafana-loki-1.2.15.gem
Successfully installed fluent-plugin-grafana-loki-1.2.15
1 gem installed
Successfully installed lru_redux-1.1.0
Successfully installed multi_json-1.15.0
Successfully installed jsonpath-1.1.0
Successfully installed http-accept-1.7.0
Building native extensions. This could take a while...
Successfully installed unf_ext-0.0.7.7
Successfully installed unf-0.1.4
Successfully installed domain_name-0.5.20190701
Successfully installed http-cookie-1.0.3
Successfully installed mime-types-data-3.2021.0212
Successfully installed mime-types-3.3.1
Successfully installed netrc-0.11.0
Successfully installed rest-client-2.1.0
Successfully installed recursive-open-struct-1.1.3
Successfully installed public_suffix-4.0.6
Successfully installed addressable-2.7.0
Successfully installed http-form_data-2.3.0
Building native extensions. This could take a while...
Successfully installed ffi-1.14.2
Successfully installed ffi-compiler-1.0.1
Building native extensions. This could take a while...
Successfully installed http-parser-1.2.3
Successfully installed http-4.4.1
Successfully installed kubeclient-4.9.1
Successfully installed fluent-plugin-kubernetes_metadata_filter-2.6.0
22 gems installed
*** Removed specs cache ***
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  binutils* binutils-common* binutils-x86-64-linux-gnu* cpp* cpp-8* g++*
  g++-8* gcc* gcc-8* git* git-man* libasan5* libatomic1* libbinutils*
  libcc1-0* libcurl3-gnutls* liberror-perl* libexpat1* libgcc-8-dev* libgomp1*
  libgssapi-krb5-2* libisl19* libitm1* libk5crypto3* libkeyutils1* libkrb5-3*
  libkrb5support0* libldap-2.4-2* libldap-common* liblsan0* libmpc3* libmpfr6*
  libmpx2* libnghttp2-14* libpcre2-8-0* libperl5.28* libpsl5* libquadmath0*
  librtmp1* libsasl2-2* libsasl2-modules-db* libssh2-1* libstdc++-8-dev*
  libtsan0* libubsan1* make* perl* perl-modules-5.28* sudo*
0 upgraded, 0 newly installed, 49 to remove and 12 not upgraded.
After this operation, 245 MB disk space will be freed.
(Reading database ... 13241 files and directories currently installed.)
Removing g++ (4:8.3.0-1) ...
Removing gcc (4:8.3.0-1) ...
Removing cpp (4:8.3.0-1) ...
Removing g++-8 (8.3.0-6) ...
Removing git (1:2.20.1-2+deb10u3) ...
Removing git-man (1:2.20.1-2+deb10u3) ...
Removing libstdc++-8-dev:amd64 (8.3.0-6) ...
Removing libcurl3-gnutls:amd64 (7.64.0-4+deb10u1) ...
Removing liberror-perl (0.17027-2) ...
Removing libexpat1:amd64 (2.2.6-2+deb10u1) ...
Removing libgssapi-krb5-2:amd64 (1.17-3+deb10u1) ...
Removing libkrb5-3:amd64 (1.17-3+deb10u1) ...
Removing libk5crypto3:amd64 (1.17-3+deb10u1) ...
Removing libkrb5support0:amd64 (1.17-3+deb10u1) ...
Removing libkeyutils1:amd64 (1.6-6) ...
Removing libldap-2.4-2:amd64 (2.4.47+dfsg-3+deb10u6) ...
Removing libldap-common (2.4.47+dfsg-3+deb10u6) ...
Removing libnghttp2-14:amd64 (1.36.0-2+deb10u1) ...
Removing libpcre2-8-0:amd64 (10.32-5) ...
Removing perl (5.28.1-6+deb10u1) ...
Removing libperl5.28:amd64 (5.28.1-6+deb10u1) ...
Removing libpsl5:amd64 (0.20.2-2) ...
Removing librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2) ...
Removing libsasl2-2:amd64 (2.1.27+dfsg-1+deb10u1) ...
Removing libsasl2-modules-db:amd64 (2.1.27+dfsg-1+deb10u1) ...
Removing libssh2-1:amd64 (1.8.0-2.1) ...
Removing make (4.2.1-1.2) ...
Removing perl-modules-5.28 (5.28.1-6+deb10u1) ...
Removing sudo (1.8.27-1+deb10u3) ...
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of stop.
Removing gcc-8 (8.3.0-6) ...
Removing binutils (2.31.1-16) ...
Removing binutils-x86-64-linux-gnu (2.31.1-16) ...
Removing libbinutils:amd64 (2.31.1-16) ...
Removing binutils-common:amd64 (2.31.1-16) ...
Removing cpp-8 (8.3.0-6) ...
Removing libgcc-8-dev:amd64 (8.3.0-6) ...
Removing libasan5:amd64 (8.3.0-6) ...
Removing libatomic1:amd64 (8.3.0-6) ...
Removing libcc1-0:amd64 (8.3.0-6) ...
Removing libgomp1:amd64 (8.3.0-6) ...
Removing libisl19:amd64 (0.20-2) ...
Removing libitm1:amd64 (8.3.0-6) ...
Removing liblsan0:amd64 (8.3.0-6) ...
Removing libmpc3:amd64 (1.1.0-1) ...
Removing libmpfr6:amd64 (4.0.2-1) ...
Removing libmpx2:amd64 (8.3.0-6) ...
Removing libquadmath0:amd64 (8.3.0-6) ...
Removing libtsan0:amd64 (8.3.0-6) ...
Removing libubsan1:amd64 (8.3.0-6) ...
Processing triggers for libc-bin (2.28-10) ...
(Reading database ... 8584 files and directories currently installed.)
Purging configuration files for libldap-common (2.4.47+dfsg-3+deb10u6) ...
Purging configuration files for perl (5.28.1-6+deb10u1) ...
Purging configuration files for libgssapi-krb5-2:amd64 (1.17-3+deb10u1) ...
Purging configuration files for sudo (1.8.27-1+deb10u3) ...
Purging configuration files for git (1:2.20.1-2+deb10u3) ...
Removing intermediate container 5a52fe56b3bb
 ---> 674c864b6981
Step 4/4 : RUN mv /fluentd/etc/fluent.conf /fluentd/etc/fluent.conf.orig.deactivated
 ---> Running in 227491a32c85
Removing intermediate container 227491a32c85
 ---> c9b99c9c7eaf
Successfully built c9b99c9c7eaf
Successfully tagged opstrace/systemlog-fluentd:0798f0a-dev
```

```
$ make publish
docker push opstrace/systemlog-fluentd:0798f0a-dev
The push refers to repository [docker.io/opstrace/systemlog-fluentd]
94cf0d78b1aa: Pushed 
8e128cdbc6b0: Pushed 
d2f140950b6b: Mounted from fluent/fluentd 
19bf291c5275: Mounted from fluent/fluentd 
1c7096a6e81a: Mounted from fluent/fluentd 
6029375c35b9: Mounted from fluent/fluentd 
3bb00315a7fe: Mounted from fluent/fluentd 
c778b871e47c: Mounted from fluent/fluentd 
aaa9e36b9b9a: Mounted from fluent/fluentd 
ad1af6b1b17a: Mounted from fluent/fluentd 
87c8a1d8f54f: Mounted from fluent/fluentd 
0798f0a-dev: digest: sha256:a6c211e96e4b88d6272a702977a03cee642b2444a32d11ca619456ff7e31157d size: 2621

```