### PR TITLE
controller: Update routes for config APIs (#379)

### DIFF
--- a/go/cmd/config/README.md
+++ b/go/cmd/config/README.md
@@ -29,7 +29,7 @@ HASURA_GRAPHQL_ADMIN_SECRET=myadminsecret \
   --disable-api-authn
 ```
 
-In normal use, the config service extracts the tenant name from the bearer token that must be provided with requests. When instead testing with `--disable-api-authn`, the service requires that we provide the tenant name using an `X-Tenant` header, as provided in the examples below.
+In normal use, the config service extracts the tenant name from the bearer token that must be provided with requests. When instead testing with `--disable-api-authn`, the service requires that we provide the tenant name using an `X-Scope-OrgID` header, as provided in the examples below.
 
 ## Example usage
 
@@ -51,22 +51,22 @@ type: gcp-service-account
 # gcp-service-account must contain valid json:
 value: |-
   {"json": "goes-here"}
-' | curl -v -H "X-Tenant: tenant-foo" -XPOST --data-binary @- http://127.0.0.1:8989/api/v1/credentials/
+' | curl -v -H "X-Scope-OrgID: tenant-foo" -XPOST --data-binary @- http://127.0.0.1:8989/api/v1/credentials/
 ```
 
 Get all
 ```
-curl -v -H "X-Tenant: tenant-foo" http://127.0.0.1:8989/api/v1/credentials/
+curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/credentials/
 ```
 
 Get foo
 ```
-curl -v -H "X-Tenant: tenant-foo" http://127.0.0.1:8989/api/v1/credentials/foo
+curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/credentials/foo
 ```
 
 Delete foo
 ```
-curl -v -H "X-Tenant: tenant-foo" -XDELETE http://127.0.0.1:8989/api/v1/credentials/foo
+curl -v -H "X-Scope-OrgID: tenant-foo" -XDELETE http://127.0.0.1:8989/api/v1/credentials/foo
 ```
 
 ### Exporters
@@ -106,20 +106,20 @@ config:
   - proj2
   monitoring.metrics-interval: '5m' # optional
   monitoring.metrics-offset: '0s' # optional
-' | curl -v -H "X-Tenant: tenant-foo" -XPOST --data-binary @- http://127.0.0.1:8989/api/v1/exporters/
+' | curl -v -H "X-Scope-OrgID: tenant-foo" -XPOST --data-binary @- http://127.0.0.1:8989/api/v1/exporters/
 ```
 
 Get all
 ```
-curl -v -H "X-Tenant: tenant-foo" http://127.0.0.1:8989/api/v1/exporters/
+curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/exporters/
 ```
 
 Get foo
 ```
-curl -v -H "X-Tenant: tenant-foo" http://127.0.0.1:8989/api/v1/exporters/foo
+curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/exporters/foo
 ```
 
 Delete foo
 ```
-curl -v -H "X-Tenant: tenant-foo" -XDELETE http://127.0.0.1:8989/api/v1/exporters/foo
+curl -v -H "X-Scope-OrgID: tenant-foo" -XDELETE http://127.0.0.1:8989/api/v1/exporters/foo
 ```

--- a/go/cmd/cortex/main.go
+++ b/go/cmd/cortex/main.go
@@ -31,8 +31,6 @@ var (
 	listenAddress            string
 	cortexQuerierURL         string
 	cortexDistributorURL     string
-	cortexRulerURL           string
-	cortexAlertmanagerURL    string
 	tenantName               string
 	disableAPIAuthentication bool
 )
@@ -41,8 +39,6 @@ func main() {
 	flag.StringVar(&listenAddress, "listen", "", "")
 	flag.StringVar(&cortexQuerierURL, "cortex-querier-url", "", "")
 	flag.StringVar(&cortexDistributorURL, "cortex-distributor-url", "", "")
-	flag.StringVar(&cortexRulerURL, "cortex-ruler-url", "", "")
-	flag.StringVar(&cortexAlertmanagerURL, "cortex-alertmanager-url", "", "")
 	flag.StringVar(&tenantName, "tenantname", "", "")
 	flag.StringVar(&loglevel, "loglevel", "info", "error|info|debug")
 	flag.BoolVar(&disableAPIAuthentication, "disable-api-authn", false, "")
@@ -65,48 +61,31 @@ func main() {
 		log.Fatalf("bad cortex distributor URL: %s", uerr)
 	}
 
-	cortexrurl, uerr := url.Parse(cortexRulerURL)
-	if uerr != nil {
-		log.Fatalf("bad cortex ruler URL: %s", uerr)
-	}
-
-	cortexaurl, uerr := url.Parse(cortexAlertmanagerURL)
-	if uerr != nil {
-		log.Fatalf("bad cortex Alertmanager URL: %s", uerr)
-	}
-
 	if !disableAPIAuthentication {
 		middleware.ReadAuthTokenVerificationKeyFromEnvOrCrash()
 	}
 
 	log.Infof("cortex querier URL: %s", cortexqurl)
 	log.Infof("cortex distributor URL: %s", cortexdurl)
-	log.Infof("cortex ruler URL: %s", cortexrurl)
-	log.Infof("cortex Alertmanager URL: %s", cortexaurl)
 	log.Infof("listen address: %s", listenAddress)
 	log.Infof("tenant name: %s", tenantName)
 	log.Infof("API authentication enabled: %v", !disableAPIAuthentication)
 
-	reverseProxy := middleware.NewReverseProxy(tenantName, cortexqurl, cortexdurl,
-		cortexrurl, cortexaurl, disableAPIAuthentication)
+	// See: https://github.com/cortexproject/cortex/blob/master/docs/api/_index.md
+	cortexTenantHeader := "X-Scope-OrgID"
+	querierProxy := middleware.NewTenantReverseProxy(&tenantName, cortexTenantHeader, cortexqurl, disableAPIAuthentication)
+	distributorProxy := middleware.NewTenantReverseProxy(&tenantName, cortexTenantHeader, cortexdurl, disableAPIAuthentication)
 
 	// mux matches based on registration order, not prefix length.
 	router := mux.NewRouter()
 	// router.PathPrefix("/api/prom/push").HandlerFunc(reverseProxy.HandleWithDistributorProxy)
 
 	// Require non-deprecated push path (instead of also allowing /api/prom/push)
-	router.PathPrefix("/api/v1/push").HandlerFunc(reverseProxy.HandleWithDistributorProxy)
-
-	// Alertmanager and ruler
-	router.PathPrefix("/ruler").HandlerFunc(reverseProxy.HandleWithRulerProxy)
-	router.PathPrefix("/api/v1/rules").HandlerFunc(reverseProxy.HandleWithRulerProxy)
-	router.PathPrefix("/alertmanager").HandlerFunc(reverseProxy.HandleWithAlertmanagerProxy)
-	router.PathPrefix("/multitenant_alertmanager").HandlerFunc(reverseProxy.HandleWithAlertmanagerProxy)
-	router.PathPrefix("/api/v1/alerts").HandlerFunc(reverseProxy.HandleWithAlertmanagerProxy)
+	router.PathPrefix("/api/v1/push").HandlerFunc(distributorProxy.HandleWithProxy)
 
 	// /api/v1/read, /api/v1/query, /api/v1/labels etc: direct everything that's not
 	// /api/v1/push to the querier for now.
-	router.PathPrefix("/api/v1").HandlerFunc(reverseProxy.HandleWithQuerierProxy)
+	router.PathPrefix("/api/v1").HandlerFunc(querierProxy.HandleWithProxy)
 
 	router.Handle("/metrics", promhttp.Handler())
 	router.Use(middleware.PrometheusMetrics("cortex_api_proxy"))

--- a/go/cmd/cortex/main.go
+++ b/go/cmd/cortex/main.go
@@ -73,8 +73,8 @@ func main() {
 
 	// See: https://github.com/cortexproject/cortex/blob/master/docs/api/_index.md
 	cortexTenantHeader := "X-Scope-OrgID"
-	querierProxy := middleware.NewTenantReverseProxy(&tenantName, cortexTenantHeader, cortexqurl, disableAPIAuthentication)
-	distributorProxy := middleware.NewTenantReverseProxy(&tenantName, cortexTenantHeader, cortexdurl, disableAPIAuthentication)
+	querierProxy := middleware.NewTenantReverseProxy(&tenantName, cortexTenantHeader, cortexqurl, nil, disableAPIAuthentication)
+	distributorProxy := middleware.NewTenantReverseProxy(&tenantName, cortexTenantHeader, cortexdurl, nil, disableAPIAuthentication)
 
 	// mux matches based on registration order, not prefix length.
 	router := mux.NewRouter()

--- a/go/cmd/cortex/main.go
+++ b/go/cmd/cortex/main.go
@@ -73,8 +73,18 @@ func main() {
 
 	// See: https://github.com/cortexproject/cortex/blob/master/docs/api/_index.md
 	cortexTenantHeader := "X-Scope-OrgID"
-	querierProxy := middleware.NewTenantReverseProxy(&tenantName, cortexTenantHeader, cortexqurl, nil, disableAPIAuthentication)
-	distributorProxy := middleware.NewTenantReverseProxy(&tenantName, cortexTenantHeader, cortexdurl, nil, disableAPIAuthentication)
+	querierProxy := middleware.NewReverseProxyFixedTenant(
+		tenantName,
+		cortexTenantHeader,
+		cortexqurl,
+		disableAPIAuthentication,
+	)
+	distributorProxy := middleware.NewReverseProxyFixedTenant(
+		tenantName,
+		cortexTenantHeader,
+		cortexdurl,
+		disableAPIAuthentication,
+	)
 
 	// mux matches based on registration order, not prefix length.
 	router := mux.NewRouter()

--- a/go/cmd/loki/main.go
+++ b/go/cmd/loki/main.go
@@ -73,8 +73,18 @@ func main() {
 
 	// See: https://github.com/grafana/loki/blob/master/docs/api.md#microservices-mode
 	lokiTenantHeader := "X-Scope-OrgID"
-	querierProxy := middleware.NewTenantReverseProxy(&tenantName, lokiTenantHeader, lokiqurl, nil, disableAPIAuthentication)
-	distributorProxy := middleware.NewTenantReverseProxy(&tenantName, lokiTenantHeader, lokidurl, nil, disableAPIAuthentication)
+	querierProxy := middleware.NewReverseProxyFixedTenant(
+		tenantName,
+		lokiTenantHeader,
+		lokiqurl,
+		disableAPIAuthentication,
+	)
+	distributorProxy := middleware.NewReverseProxyFixedTenant(
+		tenantName,
+		lokiTenantHeader,
+		lokidurl,
+		disableAPIAuthentication,
+	)
 
 	// mux matches based on registration order, not prefix length.
 	router := mux.NewRouter()

--- a/go/cmd/loki/main.go
+++ b/go/cmd/loki/main.go
@@ -73,8 +73,8 @@ func main() {
 
 	// See: https://github.com/grafana/loki/blob/master/docs/api.md#microservices-mode
 	lokiTenantHeader := "X-Scope-OrgID"
-	querierProxy := middleware.NewTenantReverseProxy(&tenantName, lokiTenantHeader, lokiqurl, disableAPIAuthentication)
-	distributorProxy := middleware.NewTenantReverseProxy(&tenantName, lokiTenantHeader, lokidurl, disableAPIAuthentication)
+	querierProxy := middleware.NewTenantReverseProxy(&tenantName, lokiTenantHeader, lokiqurl, nil, disableAPIAuthentication)
+	distributorProxy := middleware.NewTenantReverseProxy(&tenantName, lokiTenantHeader, lokidurl, nil, disableAPIAuthentication)
 
 	// mux matches based on registration order, not prefix length.
 	router := mux.NewRouter()

--- a/go/pkg/middleware/authenticator.go
+++ b/go/pkg/middleware/authenticator.go
@@ -30,7 +30,7 @@ import (
 
 // HTTP Request header used by GetTenant when disableAPIAuthentication is true and requireTenantName is nil.
 // This is only meant for use in testing, and lines up with the tenant HTTP header used by Cortex and Loki.
-const TEST_TENANT_HEADER = "X-Scope-OrgID"
+const TestTenantHeader = "X-Scope-OrgID"
 
 // Use a single key for now. Further down the road there should be support
 // for multiple public keys, each identified by a key id.
@@ -42,15 +42,20 @@ var authtokenVerificationPubKey *rsa.PublicKey
 // If expectedTenantName is non-nil, then all requests are required to have a matching tenant,
 // otherwise the tenant may vary per-request and is extracted from the verified Authorization header.
 //
-// If disableAPIAuthentication is true, then the provided expectedTenantName or X-Scope-OrgID is used without any verification.
-func GetTenant(w http.ResponseWriter, r *http.Request, expectedTenantName *string, disableAPIAuthentication bool) (string, bool) {
+// If disableAPIAuthentication is true, then the expectedTenantName or X-Scope-OrgID is used without verification.
+func GetTenant(
+	w http.ResponseWriter,
+	r *http.Request,
+	expectedTenantName *string,
+	disableAPIAuthentication bool,
+) (string, bool) {
 	if expectedTenantName == nil {
 		// Tenant may vary on a per-request basis to this endpoint
 		if disableAPIAuthentication {
 			// TESTING: No single expected tenant, so check for tenant in the X-Scope-OrgID header
-			tenantName := r.Header.Get(TEST_TENANT_HEADER)
+			tenantName := r.Header.Get(TestTenantHeader)
 			if tenantName == "" {
-				exit401(w, fmt.Sprintf("missing test %s header specifying tenant", TEST_TENANT_HEADER))
+				exit401(w, fmt.Sprintf("missing test %s header specifying tenant", TestTenantHeader))
 				return "", false
 			}
 			return tenantName, true

--- a/go/pkg/middleware/authenticator.go
+++ b/go/pkg/middleware/authenticator.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Opstrace, Inc.
+// Copyright 2021 Opstrace, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,9 +28,54 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// HTTP Request header used by GetTenant when disableAPIAuthentication is true and requireTenantName is nil.
+// This is only meant for use in testing, and lines up with the tenant HTTP header used by Cortex and Loki.
+const TEST_TENANT_HEADER = "X-Scope-OrgID"
+
 // Use a single key for now. Further down the road there should be support
 // for multiple public keys, each identified by a key id.
 var authtokenVerificationPubKey *rsa.PublicKey
+
+// Validates and returns the tenant name embedded in the request's Authorization header and returns (tenantName, true),
+// or writes a 401 error to the response and returns ('', false) if the tenant was invalid or not found.
+//
+// If expectedTenantName is non-nil, then all requests are required to have a matching tenant,
+// otherwise the tenant may vary per-request and is extracted from the verified Authorization header.
+//
+// If disableAPIAuthentication is true, then the provided expectedTenantName or X-Scope-OrgID is used without any verification.
+func GetTenant(w http.ResponseWriter, r *http.Request, expectedTenantName *string, disableAPIAuthentication bool) (string, bool) {
+	if expectedTenantName == nil {
+		// Tenant may vary on a per-request basis to this endpoint
+		if disableAPIAuthentication {
+			// TESTING: No single expected tenant, so check for tenant in the X-Scope-OrgID header
+			tenantName := r.Header.Get(TEST_TENANT_HEADER)
+			if tenantName == "" {
+				exit401(w, fmt.Sprintf("missing test %s header specifying tenant", TEST_TENANT_HEADER))
+				return "", false
+			}
+			return tenantName, true
+		} else {
+			// Read/validate tenant from signed bearer token
+			authTokenUnverified, ok := getAPIAuthTokenUnverified(w, r)
+			if !ok {
+				return "", false
+			}
+			return getRequestAuthenticator(w, authTokenUnverified)
+		}
+	} else {
+		// Tenant must match configured value across all requests to this endpoint
+		if disableAPIAuthentication {
+			// TESTING: Just assume the expected tenant
+			return *expectedTenantName, true
+		} else {
+			// Validate the Authentication/Bearer token in the request and check that it has the expected tenant.
+			if !DataAPIRequestAuthenticator(w, r, *expectedTenantName) {
+				return "", false
+			}
+			return *expectedTenantName, true
+		}
+	}
+}
 
 // Verifies that the tenant name embedded in the request's Authorization header is valid and matches the
 // expectedTenantName and returns true, or writes a 401 error to the response and returns false if the
@@ -41,16 +86,6 @@ func DataAPIRequestAuthenticator(w http.ResponseWriter, r *http.Request, expecte
 		return false
 	}
 	return compareRequestAuthenticator(w, authTokenUnverified, expectedTenantName)
-}
-
-// Returns the tenant name embedded in the request's Authorization header and returns (tenantName, true),
-// or writes a 401 error to the response and returns ('', false) if the tenant was invalid or not found.
-func DataAPIRequestTenantName(w http.ResponseWriter, r *http.Request) (string, bool) {
-	authTokenUnverified, ok := getAPIAuthTokenUnverified(w, r)
-	if !ok {
-		return "", false
-	}
-	return getRequestAuthenticator(w, authTokenUnverified)
 }
 
 // Expect HTTP request to have a header of the shape

--- a/go/pkg/middleware/proxy_test.go
+++ b/go/pkg/middleware/proxy_test.go
@@ -33,9 +33,9 @@ func createProxyUpstream(tenantName string, t *testing.T) (*url.URL, func()) {
 	// proxies to be tested. Any request to / checks the X-Scope-Orgid header
 	// and writes the tenant name to the response.
 	router := mux.NewRouter()
-	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	router.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, tenantName, r.Header.Get("X-Scope-Orgid"))
-		fmt.Fprintln(w, tenantName)
+		fmt.Fprintf(w, "%s %s", r.URL.String(), tenantName)
 	})
 
 	backend := httptest.NewServer(router)
@@ -56,26 +56,68 @@ func TestReverseProxy_healthy(t *testing.T) {
 
 	// Reuse the same backend for both the querier and distributor requests.
 	disableAPIAuth := true
-	rp := NewReverseProxy(tenantName, upstreamURL, upstreamURL, upstreamURL, upstreamURL, disableAPIAuth)
+	rp := NewTenantReverseProxy(&tenantName, "X-Scope-Orgid", upstreamURL, nil, disableAPIAuth)
 
 	// Create a request to the proxy (not to the backend/upstream). The URL
 	// does not really matter because we're bypassing the actual router.
 	req := httptest.NewRequest("GET", "http://localhost", nil)
-
-	checker := func(w *httptest.ResponseRecorder) {
-		resp := w.Result()
-		assert.Equal(t, 200, resp.StatusCode)
-		// Check that the proxy's upstream has indeed written the response.
-		assert.Equal(t, tenantName, getStrippedBody(resp))
-	}
-
 	w := httptest.NewRecorder()
-	rp.HandleWithDistributorProxy(w, req)
-	checker(w)
+	rp.HandleWithProxy(w, req)
+	resp := w.Result()
+	assert.Equal(t, 200, resp.StatusCode)
+	// Check that the proxy's upstream has indeed written the response.
+	assert.Equal(t, "/ test", getStrippedBody(resp))
 
+	req = httptest.NewRequest("GET", "http://localhost/robots.txt", nil)
 	w = httptest.NewRecorder()
-	rp.HandleWithQuerierProxy(w, req)
-	checker(w)
+	rp.HandleWithProxy(w, req)
+	resp = w.Result()
+	assert.Equal(t, 200, resp.StatusCode)
+	// Check that the proxy's upstream has indeed written the response.
+	assert.Equal(t, "/robots.txt test", getStrippedBody(resp))
+}
+
+func TestReverseProxy_pathreplace(t *testing.T) {
+	tenantName := "test"
+	upstreamURL, upstreamClose := createProxyUpstream(tenantName, t)
+	defer upstreamClose()
+
+	// Reuse the same backend for both the querier and distributor requests.
+	pathReplacement := func(requrl *url.URL) (string,string) {
+		if strings.HasPrefix(requrl.Path, "/replaceme") {
+			return strings.Replace(requrl.Path, "/replaceme", "/foo", 1), strings.Replace(requrl.RawPath, "/replaceme", "/foo", 1)
+		}
+		return requrl.Path, requrl.RawPath
+	}
+	disableAPIAuth := true
+	rp := NewTenantReverseProxy(&tenantName, "X-Scope-Orgid", upstreamURL, &pathReplacement, disableAPIAuth)
+
+	// /replaceme => /foo
+	req := httptest.NewRequest("GET", "http://localhost/replaceme", nil)
+	w := httptest.NewRecorder()
+	rp.HandleWithProxy(w, req)
+	resp := w.Result()
+	assert.Equal(t, 200, resp.StatusCode)
+	// Check that the proxy's upstream has indeed written the response.
+	assert.Equal(t, "/foo test", getStrippedBody(resp))
+
+	// /replaceme/bar => /foo/bar
+	req = httptest.NewRequest("GET", "http://localhost/replaceme/bar", nil)
+	w = httptest.NewRecorder()
+	rp.HandleWithProxy(w, req)
+	resp = w.Result()
+	assert.Equal(t, 200, resp.StatusCode)
+	// Check that the proxy's upstream has indeed written the response.
+	assert.Equal(t, "/foo/bar test", getStrippedBody(resp))
+
+	// /other/bar => /other/bar (no change)
+	req = httptest.NewRequest("GET", "http://localhost/other/bar", nil)
+	w = httptest.NewRecorder()
+	rp.HandleWithProxy(w, req)
+	resp = w.Result()
+	assert.Equal(t, 200, resp.StatusCode)
+	// Check that the proxy's upstream has indeed written the response.
+	assert.Equal(t, "/other/bar test", getStrippedBody(resp))
 }
 
 func TestReverseProxy_unhealthy(t *testing.T) {
@@ -91,33 +133,22 @@ func TestReverseProxy_unhealthy(t *testing.T) {
 	// we can reuse the same backend to send both the querier and distributor
 	// requests
 	disableAPIAuth := true
-	rp := NewReverseProxy(tenantName, u, u, u, u, disableAPIAuth)
+	rp := NewTenantReverseProxy(&tenantName, "X-Scope-Orgid", u, nil, disableAPIAuth)
 	// create a request to the test backend
 	req := httptest.NewRequest("GET", "http://localhost", nil)
 
-	checker := func(w *httptest.ResponseRecorder) {
-		resp := w.Result()
-
-		if resp.StatusCode != http.StatusBadGateway {
-			t.Errorf("want 502 Bad Gateway got %v", resp.StatusCode)
-		}
-
-		// Confirm that the original error message (for why the request could
-		// not be proxied) is contained in the response body.
-		assert.Regexp(
-			t,
-			regexp.MustCompile("^dial tcp .* connect: connection refused$"),
-			getStrippedBody(resp),
-		)
-	}
-
 	w := httptest.NewRecorder()
-	rp.HandleWithDistributorProxy(w, req)
-	checker(w)
+	rp.HandleWithProxy(w, req)
+	resp := w.Result()
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
 
-	w = httptest.NewRecorder()
-	rp.HandleWithQuerierProxy(w, req)
-	checker(w)
+	// Confirm that the original error message (for why the request could
+	// not be proxied) is contained in the response body.
+	assert.Regexp(
+		t,
+		regexp.MustCompile("^dial tcp .* connect: connection refused$"),
+		getStrippedBody(resp),
+	)
 }
 
 func TestReverseProxyAuthenticator_noheader(t *testing.T) {
@@ -127,30 +158,23 @@ func TestReverseProxyAuthenticator_noheader(t *testing.T) {
 
 	// No need for a proxy backend here because the request is expected to be
 	// processed in the proxy only, not going beyond the authenticator stage.
-	rp := NewReverseProxy("test", fakeURL, fakeURL, fakeURL, fakeURL, disableAPIAuth)
+	tenantName := "test"
+	rp := NewTenantReverseProxy(&tenantName, "X-Scope-Orgid", fakeURL, nil, disableAPIAuth)
 
 	req := httptest.NewRequest("GET", "http://localhost", nil)
 
-	checker := func(w *httptest.ResponseRecorder) {
-		resp := w.Result()
-		// Expect 401 response because no authentication proof is set.
-		assert.Equal(t, 401, resp.StatusCode)
-
-		// Confirm that a helpful error message is in the body.
-		assert.Equal(
-			t,
-			"Authorization header missing",
-			getStrippedBody(resp),
-		)
-	}
-
 	w := httptest.NewRecorder()
-	rp.HandleWithDistributorProxy(w, req)
-	checker(w)
+	rp.HandleWithProxy(w, req)
+	resp := w.Result()
+	// Expect 401 response because no authentication proof is set.
+	assert.Equal(t, 401, resp.StatusCode)
 
-	w = httptest.NewRecorder()
-	rp.HandleWithQuerierProxy(w, req)
-	checker(w)
+	// Confirm that a helpful error message is in the body.
+	assert.Equal(
+		t,
+		"Authorization header missing",
+		getStrippedBody(resp),
+	)
 }
 
 func TestReverseProxyAuthenticator_badtoken(t *testing.T) {
@@ -160,31 +184,20 @@ func TestReverseProxyAuthenticator_badtoken(t *testing.T) {
 
 	// No need for a proxy backend here because the request is expected to be
 	// processed in the proxy only, not going beyond the authenticator stage.
-	rp := NewReverseProxy("test", fakeURL, fakeURL, fakeURL, fakeURL, disableAPIAuth)
+	tenantName := "test"
+	rp := NewTenantReverseProxy(&tenantName, "X-Scope-Orgid", fakeURL, nil, disableAPIAuth)
 
 	req := httptest.NewRequest("GET", "http://localhost", nil)
 	req.Header.Set("Authorization", "Bearer foobarbadtoken")
 
-	checker := func(w *httptest.ResponseRecorder) {
-		resp := w.Result()
-		// Expect 401 response because no authentication proof is set.
-		assert.Equal(t, 401, resp.StatusCode)
-
-		// Confirm that a helpful error message is in the body.
-		assert.Equal(
-			t,
-			"bad authentication token",
-			getStrippedBody(resp),
-		)
-	}
-
 	w := httptest.NewRecorder()
-	rp.HandleWithDistributorProxy(w, req)
-	checker(w)
+	rp.HandleWithProxy(w, req)
+	resp := w.Result()
+	// Expect 401 response because no authentication proof is set.
+	assert.Equal(t, 401, resp.StatusCode)
 
-	w = httptest.NewRecorder()
-	rp.HandleWithQuerierProxy(w, req)
-	checker(w)
+	// Confirm that a helpful error message is in the body.
+	assert.Equal(t, "bad authentication token", getStrippedBody(resp))
 }
 
 // Read all response body bytes, and return response body as string, with

--- a/packages/app/config/swTemplate.js
+++ b/packages/app/config/swTemplate.js
@@ -42,8 +42,8 @@ precacheAndRoute(self.__precacheManifest);
 // This assumes /app-shell has been precached.
 const handler = createHandlerBoundToURL("/app-shell");
 const navigationRoute = new NavigationRoute(handler, {
-  // make sure we don't cache routes to our api
-  denylist: [new RegExp("^/_/"), new RegExp("^/modules/.*/latest/")]
+  // make sure we don't cache routes to our apis
+  denylist: [new RegExp("^/_/"), new RegExp("^/modules/.*/latest/"), new RegExp("^/api/")]
 });
 registerRoute(navigationRoute);
 

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -2,7 +2,7 @@
   "addonResizer": "k8s.gcr.io/addon-resizer:1.8.4",
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.1.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.1.0",
-  "configApi": "opstrace/config-api:606d50a8c0b2917279c4c2f3d83964ab8212173e",
+  "configApi": "opstrace/config-api:d4de7ba3a503780c7f5ffd1fba5ff073d662dba2",
   "cortex": "cortexproject/cortex:master-d9125be",
   "cortexApiProxy": "opstrace/cortex-api:f04cb9669fb32561f81b56a7b0dd864b",
   "ddApi": "opstrace/ddapi:fd813ccbf9a09d32c4c57cb0fac6b7949be71a92",

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -2,7 +2,7 @@
   "addonResizer": "k8s.gcr.io/addon-resizer:1.8.4",
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.1.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.1.0",
-  "configApi": "opstrace/config-api:c1a9e1d1712a55512cbb69c713ddc0207fbdeae4",
+  "configApi": "opstrace/config-api:606d50a8c0b2917279c4c2f3d83964ab8212173e",
   "cortex": "cortexproject/cortex:master-d9125be",
   "cortexApiProxy": "opstrace/cortex-api:f04cb9669fb32561f81b56a7b0dd864b",
   "ddApi": "opstrace/ddapi:fd813ccbf9a09d32c4c57cb0fac6b7949be71a92",

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -2,7 +2,7 @@
   "addonResizer": "k8s.gcr.io/addon-resizer:1.8.4",
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.1.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.1.0",
-  "configApi": "opstrace/config-api:c5b1a59208bc8712918010e90546b9c96e2d0e40",
+  "configApi": "opstrace/config-api:c1a9e1d1712a55512cbb69c713ddc0207fbdeae4",
   "cortex": "cortexproject/cortex:master-d9125be",
   "cortexApiProxy": "opstrace/cortex-api:f04cb9669fb32561f81b56a7b0dd864b",
   "ddApi": "opstrace/ddapi:fd813ccbf9a09d32c4c57cb0fac6b7949be71a92",

--- a/packages/controller/src/resources/apis/cortex.ts
+++ b/packages/controller/src/resources/apis/cortex.ts
@@ -66,16 +66,13 @@ export function CortexAPIResources(
   const name = `${api}-api`;
   const cortexQuerierUrl = "http://query-frontend.cortex.svc.cluster.local";
   const cortexDistributorUrl = "http://distributor.cortex.svc.cluster.local";
-  const cortexRulerUrl = "http://ruler.cortex.svc.cluster.local";
-  const cortexAlertmanagerUrl = "http://alertmanager.cortex.svc.cluster.local";
 
   const cortexApiProxyCliArgs = [
     "-listen=:8080",
     `-tenantname=${tenant.name}`,
+    // Upstream endpoints for the opstrace cortex proxy
     `-cortex-querier-url=${cortexQuerierUrl}`,
-    `-cortex-distributor-url=${cortexDistributorUrl}`,
-    `-cortex-ruler-url=${cortexRulerUrl}`,
-    `-cortex-alertmanager-url=${cortexAlertmanagerUrl}`
+    `-cortex-distributor-url=${cortexDistributorUrl}`
   ];
 
   let cortexApiProxyEnv: V1EnvVar[];

--- a/packages/controller/src/resources/apis/index.ts
+++ b/packages/controller/src/resources/apis/index.ts
@@ -19,7 +19,6 @@ import { KubeConfig } from "@kubernetes/client-node";
 import { ResourceCollection } from "@opstrace/kubernetes";
 import { State } from "../../reducer";
 
-import { ConfigAPIResources } from "./config";
 import { CortexAPIResources } from "./cortex";
 import { DDAPIResources } from "./dd";
 import { LokiAPIResources } from "./loki";
@@ -50,9 +49,6 @@ export function APIResources(
   kubeConfig: KubeConfig
 ): ResourceCollection {
   const collection = new ResourceCollection();
-
-  // Single instance 'application' namespace: allow access to hasura-admin-secret
-  collection.add(ConfigAPIResources(state, kubeConfig, "application"));
 
   // Per-tenant resources
   state.tenants.list.tenants.forEach(tenant => {

--- a/packages/controller/src/resources/apis/loki.ts
+++ b/packages/controller/src/resources/apis/loki.ts
@@ -62,6 +62,7 @@ export function LokiAPIResources(
   const lokiApiProxyCliArgs = [
     "-listen=:8080",
     `-tenantname=${tenant.name}`,
+    // Upstream endpoints for the opstrace loki proxy
     `-loki-querier-url=${lokiQuerierUrl}`,
     `-loki-distributor-url=${lokiDistributorUrl}`
   ];

--- a/packages/controller/src/resources/app/app.ts
+++ b/packages/controller/src/resources/app/app.ts
@@ -1,0 +1,477 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { urlJoin } from "url-join-ts";
+import {
+  ResourceCollection,
+  Deployment,
+  ClusterRoleBinding,
+  ServiceAccount,
+  Namespace,
+  Service,
+  Secret,
+  withPodAntiAffinityRequired
+} from "@opstrace/kubernetes";
+import { KubeConfig } from "@kubernetes/client-node";
+import { State } from "../../reducer";
+import {
+  generateSecretValue,
+  getControllerConfig
+} from "../../helpers";
+import { DockerImages } from "@opstrace/controller-config";
+
+export function OpstraceApplicationResources(
+  state: State,
+  kubeConfig: KubeConfig,
+  namespace: string,
+  domain: string
+): ResourceCollection {
+  const collection = new ResourceCollection();
+
+  const { envLabel } = getControllerConfig(state);
+
+  let auth0_client_id = "vs6bgTunbVK4dvdLRj02DptWjOmAVWVM";
+  if (envLabel === "opstrace-ci") {
+    auth0_client_id = "5MoCYfPXPuEzceBLRUr6T6SAklT2GDys";
+  }
+
+  collection.add(
+    new Namespace(
+      {
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: {
+          name: namespace,
+          labels: {
+            // although this isn't actually a "tenant", we use this label to trick
+            // kubed into thinking it's a tenant so that the certificates are copied into
+            // this namespace too.
+            tenant: "opstrace-application",
+            "cert-manager.io/disable-validation": "true"
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  collection.add(
+    new Service(
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "opstrace-application",
+          labels: {
+            app: "opstrace-application"
+          },
+          namespace
+        },
+        spec: {
+          ports: [
+            {
+              name: "http",
+              port: 3001,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              targetPort: "http" as any
+            }
+          ],
+          selector: {
+            app: "opstrace-application"
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  const sessionCookieSecret = new Secret(
+    {
+      apiVersion: "v1",
+      data: {
+        COOKIE_SECRET: Buffer.from(generateSecretValue()).toString("base64")
+      },
+      kind: "Secret",
+      metadata: {
+        name: "session-cookie-secret",
+        namespace: namespace
+      }
+    },
+    kubeConfig
+  );
+  // We don't want this value to change once it exists.
+  // This value changing would cause all sessions to be invalidated immediately
+  // and that would be a bad experience during an upgrade.
+  // This value of this secret can always be updated manually if instant session invalidation is desired.
+  sessionCookieSecret.setImmutable();
+
+  collection.add(sessionCookieSecret);
+
+  let secretValue = Buffer.from(generateSecretValue()).toString("base64");
+  // copy the secret that we've already set for Hasura in the kube-system namespace
+  const secretToCopy = state.kubernetes.cluster.Secrets.resources.find(
+    secret =>
+      secret.name === "hasura-admin-secret" &&
+      secret.namespace === "kube-system"
+  );
+
+  if (secretToCopy) {
+    // use the value of the secret we want to copy
+    secretValue = Buffer.from(
+      secretToCopy.data?.HASURA_ADMIN_SECRET ?? "",
+      "base64"
+    ).toString("base64");
+  }
+
+  // Specifying this secret in kube-system will ensure it exists if it didn't before.
+  const kubeSystemHasuraAdminSecret = new Secret(
+    {
+      apiVersion: "v1",
+      data: {
+        HASURA_ADMIN_SECRET: secretValue
+      },
+      kind: "Secret",
+      metadata: {
+        name: "hasura-admin-secret",
+        namespace: "kube-system"
+      }
+    },
+    kubeConfig
+  );
+  // We don't want this value to change once it exists either.
+  // The value of this secret can always be updated manually in the cluster if needs be (kubectl delete <name> -n application) and the controller will create a new one.
+  // The corresponding deployment pods that consume it will need to be restarted also to get the new env var containing the new secret.
+  kubeSystemHasuraAdminSecret.setImmutable();
+  collection.add(kubeSystemHasuraAdminSecret);
+
+  const hasuraAdminSecret = new Secret(
+    {
+      apiVersion: "v1",
+      data: {
+        HASURA_ADMIN_SECRET: secretValue
+      },
+      kind: "Secret",
+      metadata: {
+        name: "hasura-admin-secret",
+        namespace: namespace
+      }
+    },
+    kubeConfig
+  );
+  // We don't want this value to change once it exists either.
+  // The value of this secret can always be updated manually in the cluster if needs be (kubectl delete <name> -n application) and the controller will create a new one.
+  // The corresponding deployment pods that consume it will need to be restarted also to get the new env var containing the new secret.
+  hasuraAdminSecret.setImmutable();
+  collection.add(hasuraAdminSecret);
+
+  collection.add(
+    new Deployment(
+      {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {
+          name: "opstrace-application",
+          namespace,
+          labels: {
+            app: "opstrace-application"
+          }
+        },
+        spec: {
+          replicas: 1,
+          strategy: {
+            type: "RollingUpdate"
+          },
+          selector: {
+            matchLabels: {
+              app: "opstrace-application"
+            }
+          },
+          template: {
+            metadata: {
+              labels: {
+                app: "opstrace-application"
+              }
+            },
+            spec: {
+              serviceAccountName: "opstrace-application",
+              terminationGracePeriodSeconds: 80, // we give the app 60 seconds to drain existing connections
+              affinity: withPodAntiAffinityRequired({
+                app: "opstrace-application"
+              }),
+              containers: [
+                {
+                  name: "opstrace-application",
+                  image: DockerImages.app,
+                  imagePullPolicy: "Always",
+                  command: ["node", "dist/server.js"],
+                  env: [
+                    {
+                      name: "REDIS_HOST",
+                      value: `redis-master.${namespace}.svc.cluster.local`
+                    },
+                    {
+                      name: "REDIS_PASSWORD",
+                      valueFrom: {
+                        secretKeyRef: {
+                          name: "redis-password",
+                          key: "REDIS_MASTER_PASSWORD"
+                        }
+                      }
+                    },
+                    {
+                      name: "GRAPHQL_ENDPOINT_HOST",
+                      value: `graphql.${namespace}.svc.cluster.local`
+                    },
+                    { name: "GRAPHQL_ENDPOINT_PORT", value: "8080" },
+                    {
+                      name: "GRAPHQL_ENDPOINT",
+                      value: `http://graphql.${namespace}.svc.cluster.local:8080/v1/graphql`
+                    },
+                    {
+                      name: "AUTH0_CLIENT_ID",
+                      value: auth0_client_id
+                    },
+                    {
+                      name: "AUTH0_DOMAIN",
+                      value: "opstrace-dev.us.auth0.com"
+                    },
+                    { name: "DOMAIN", value: `https://${domain}` },
+                    { name: "UI_DOMAIN", value: `https://${domain}` },
+                    {
+                      name: "COOKIE_SECRET",
+                      valueFrom: {
+                        secretKeyRef: {
+                          name: "session-cookie-secret",
+                          key: "COOKIE_SECRET"
+                        }
+                      }
+                    },
+                    {
+                      name: "HASURA_GRAPHQL_ADMIN_SECRET",
+                      valueFrom: {
+                        secretKeyRef: {
+                          name: "hasura-admin-secret",
+                          key: "HASURA_ADMIN_SECRET"
+                        }
+                      }
+                    }
+                  ],
+                  ports: [
+                    {
+                      containerPort: 3001,
+                      name: "http"
+                    }
+                  ],
+                  resources: {},
+                  readinessProbe: {
+                    httpGet: {
+                      path: "/ready",
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      port: 9000 as any,
+                      scheme: "HTTP"
+                    },
+                    failureThreshold: 1,
+                    initialDelaySeconds: 5,
+                    periodSeconds: 5,
+                    successThreshold: 1,
+                    timeoutSeconds: 5
+                  },
+                  livenessProbe: {
+                    httpGet: {
+                      path: "/live",
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      port: 9000 as any,
+                      scheme: "HTTP"
+                    },
+                    failureThreshold: 3,
+                    initialDelaySeconds: 5,
+                    periodSeconds: 30,
+                    successThreshold: 1,
+                    timeoutSeconds: 5
+                  },
+                  startupProbe: {
+                    httpGet: {
+                      path: "/live",
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      port: 9000 as any
+                    },
+                    failureThreshold: 3,
+                    initialDelaySeconds: 10,
+                    periodSeconds: 30,
+                    successThreshold: 1,
+                    timeoutSeconds: 5
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  collection.add(
+    new Service(
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "graphql",
+          labels: {
+            app: "graphql"
+          },
+          namespace
+        },
+        spec: {
+          ports: [
+            {
+              name: "http",
+              port: 8080,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              targetPort: "http" as any
+            }
+          ],
+          selector: {
+            app: "graphql"
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  collection.add(
+    new Deployment(
+      {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {
+          name: "graphql",
+          namespace,
+          labels: {
+            app: "graphql"
+          }
+        },
+        spec: {
+          replicas: 1,
+          strategy: {
+            type: "RollingUpdate"
+          },
+          selector: {
+            matchLabels: {
+              app: "graphql"
+            }
+          },
+          template: {
+            metadata: {
+              labels: {
+                app: "graphql"
+              }
+            },
+            spec: {
+              affinity: withPodAntiAffinityRequired({
+                app: "graphql"
+              }),
+              containers: [
+                {
+                  name: "graphql",
+                  image: DockerImages.graphqlEngine,
+                  imagePullPolicy: "IfNotPresent",
+                  env: [
+                    {
+                      name: "HASURA_GRAPHQL_ADMIN_SECRET",
+                      valueFrom: {
+                        secretKeyRef: {
+                          name: "hasura-admin-secret",
+                          key: "HASURA_ADMIN_SECRET"
+                        }
+                      }
+                    },
+                    {
+                      name: "HASURA_GRAPHQL_DATABASE_URL",
+                      value: urlJoin(
+                        state.config.config?.postgreSQLEndpoint,
+                        state.config.config?.opstraceDBName
+                      )
+                    },
+                    {
+                      name: "HASURA_GRAPHQL_ENABLE_CONSOLE",
+                      value: "false"
+                    },
+                    {
+                      name: "HASURA_GRAPHQL_ENABLED_LOG_TYPES",
+                      value: "startup, http-log, websocket-log"
+                    }
+                  ],
+                  ports: [
+                    {
+                      containerPort: 8080,
+                      name: "http"
+                    }
+                  ],
+                  resources: {}
+                }
+              ]
+            }
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  collection.add(
+    new ServiceAccount(
+      {
+        apiVersion: "v1",
+        kind: "ServiceAccount",
+        metadata: {
+          name: "opstrace-application",
+          namespace
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  collection.add(
+    new ClusterRoleBinding(
+      {
+        apiVersion: "rbac.authorization.k8s.io/v1",
+        kind: "ClusterRoleBinding",
+        metadata: {
+          name: "opstrace-application-clusteradmin-binding"
+        },
+        roleRef: {
+          apiGroup: "rbac.authorization.k8s.io",
+          kind: "ClusterRole",
+          name: "cluster-admin"
+        },
+        subjects: [
+          {
+            kind: "ServiceAccount",
+            name: "opstrace-application",
+            namespace
+          }
+        ]
+      },
+      kubeConfig
+    )
+  );
+
+  return collection;
+}

--- a/packages/controller/src/resources/app/index.ts
+++ b/packages/controller/src/resources/app/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Opstrace, Inc.
+ * Copyright 2021 Opstrace, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,17 @@
  * limitations under the License.
  */
 
-import { urlJoin } from "url-join-ts";
-import {
-  ResourceCollection,
-  Deployment,
-  ClusterRoleBinding,
-  ServiceAccount,
-  Namespace,
-  Ingress,
-  Service,
-  Secret,
-  withPodAntiAffinityRequired
-} from "@opstrace/kubernetes";
+import { Ingress } from "@opstrace/kubernetes";
 import { KubeConfig } from "@kubernetes/client-node";
-import { State } from "../../reducer";
-import {
-  getDomain,
-  generateSecretValue,
-  getControllerConfig
-} from "../../helpers";
-import { DockerImages } from "@opstrace/controller-config";
 
-export function OpstraceApplicationResources(
+import { ResourceCollection } from "@opstrace/kubernetes";
+import { State } from "../../reducer";
+import { getDomain } from "../../helpers";
+
+import { OpstraceAPIResources } from "./api";
+import { OpstraceApplicationResources } from "./app";
+
+export function ApplicationResources(
   state: State,
   kubeConfig: KubeConfig,
   namespace: string
@@ -44,40 +33,19 @@ export function OpstraceApplicationResources(
 
   const domain = getDomain(state);
 
-  const { envLabel } = getControllerConfig(state);
+  // App UI
+  collection.add(OpstraceApplicationResources(state, kubeConfig, namespace, domain));
+  // Config API
+  collection.add(OpstraceAPIResources(state, kubeConfig, namespace));
 
-  let auth0_client_id = "vs6bgTunbVK4dvdLRj02DptWjOmAVWVM";
-  if (envLabel === "opstrace-ci") {
-    auth0_client_id = "5MoCYfPXPuEzceBLRUr6T6SAklT2GDys";
-  }
-
-  collection.add(
-    new Namespace(
-      {
-        apiVersion: "v1",
-        kind: "Namespace",
-        metadata: {
-          name: namespace,
-          labels: {
-            // although this isn't actually a "tenant", we use this label to trick
-            // kubed into thinking it's a tenant so that the certificates are copied into
-            // this namespace too.
-            tenant: "opstrace-application",
-            "cert-manager.io/disable-validation": "true"
-          }
-        }
-      },
-      kubeConfig
-    )
-  );
-
+  // Ingress for the root domain, shared by the App UI and Config API
   collection.add(
     new Ingress(
       {
         apiVersion: "networking.k8s.io/v1beta1",
         kind: "Ingress",
         metadata: {
-          name: "opstrace-application",
+          name: "opstrace-root",
           namespace,
           annotations: {
             "kubernetes.io/ingress.class": "ui",
@@ -97,425 +65,31 @@ export function OpstraceApplicationResources(
               host: domain,
               http: {
                 paths: [
+                  // Route everything except /api/* to the application
                   {
                     backend: {
                       serviceName: "opstrace-application",
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      servicePort: 3001 as any
+                      servicePort: "http" as any
                     },
-                    pathType: "ImplementationSpecific",
+                    pathType: "Prefix",
                     path: "/"
+                  },
+                  // Separate routing reserved for /api/*
+                  {
+                    backend: {
+                      serviceName: "opstrace-api",
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      servicePort: "http" as any
+                    },
+                    pathType: "Prefix",
+                    path: "/api/"
                   }
                 ]
               }
             }
           ]
         }
-      },
-      kubeConfig
-    )
-  );
-
-  collection.add(
-    new Service(
-      {
-        apiVersion: "v1",
-        kind: "Service",
-        metadata: {
-          name: "opstrace-application",
-          labels: {
-            app: "opstrace-application"
-          },
-          namespace
-        },
-        spec: {
-          ports: [
-            {
-              name: "http",
-              port: 3001,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              targetPort: "http" as any
-            }
-          ],
-          selector: {
-            app: "opstrace-application"
-          }
-        }
-      },
-      kubeConfig
-    )
-  );
-
-  const sessionCookieSecret = new Secret(
-    {
-      apiVersion: "v1",
-      data: {
-        COOKIE_SECRET: Buffer.from(generateSecretValue()).toString("base64")
-      },
-      kind: "Secret",
-      metadata: {
-        name: "session-cookie-secret",
-        namespace: namespace
-      }
-    },
-    kubeConfig
-  );
-  // We don't want this value to change once it exists.
-  // This value changing would cause all sessions to be invalidated immediately
-  // and that would be a bad experience during an upgrade.
-  // This value of this secret can always be updated manually if instant session invalidation is desired.
-  sessionCookieSecret.setImmutable();
-
-  collection.add(sessionCookieSecret);
-
-  let secretValue = Buffer.from(generateSecretValue()).toString("base64");
-  // copy the secret that we've already set for Hasura in the kube-system namespace
-  const secretToCopy = state.kubernetes.cluster.Secrets.resources.find(
-    secret =>
-      secret.name === "hasura-admin-secret" &&
-      secret.namespace === "kube-system"
-  );
-
-  if (secretToCopy) {
-    // use the value of the secret we want to copy
-    secretValue = Buffer.from(
-      secretToCopy.data?.HASURA_ADMIN_SECRET ?? "",
-      "base64"
-    ).toString("base64");
-  }
-
-  // Specifying this secret in kube-system will ensure it exists if it didn't before.
-  const kubeSystemHasuraAdminSecret = new Secret(
-    {
-      apiVersion: "v1",
-      data: {
-        HASURA_ADMIN_SECRET: secretValue
-      },
-      kind: "Secret",
-      metadata: {
-        name: "hasura-admin-secret",
-        namespace: "kube-system"
-      }
-    },
-    kubeConfig
-  );
-  // We don't want this value to change once it exists either.
-  // The value of this secret can always be updated manually in the cluster if needs be (kubectl delete <name> -n application) and the controller will create a new one.
-  // The corresponding deployment pods that consume it will need to be restarted also to get the new env var containing the new secret.
-  kubeSystemHasuraAdminSecret.setImmutable();
-  collection.add(kubeSystemHasuraAdminSecret);
-
-  const hasuraAdminSecret = new Secret(
-    {
-      apiVersion: "v1",
-      data: {
-        HASURA_ADMIN_SECRET: secretValue
-      },
-      kind: "Secret",
-      metadata: {
-        name: "hasura-admin-secret",
-        namespace: namespace
-      }
-    },
-    kubeConfig
-  );
-  // We don't want this value to change once it exists either.
-  // The value of this secret can always be updated manually in the cluster if needs be (kubectl delete <name> -n application) and the controller will create a new one.
-  // The corresponding deployment pods that consume it will need to be restarted also to get the new env var containing the new secret.
-  hasuraAdminSecret.setImmutable();
-  collection.add(hasuraAdminSecret);
-
-  collection.add(
-    new Deployment(
-      {
-        apiVersion: "apps/v1",
-        kind: "Deployment",
-        metadata: {
-          name: "opstrace-application",
-          namespace,
-          labels: {
-            app: "opstrace-application"
-          }
-        },
-        spec: {
-          replicas: 1,
-          strategy: {
-            type: "RollingUpdate"
-          },
-          selector: {
-            matchLabels: {
-              app: "opstrace-application"
-            }
-          },
-          template: {
-            metadata: {
-              labels: {
-                app: "opstrace-application"
-              }
-            },
-            spec: {
-              serviceAccountName: "opstrace-application",
-              terminationGracePeriodSeconds: 80, // we give the app 60 seconds to drain existing connections
-              affinity: withPodAntiAffinityRequired({
-                app: "opstrace-application"
-              }),
-              containers: [
-                {
-                  name: "opstrace-application",
-                  image: DockerImages.app,
-                  imagePullPolicy: "Always",
-                  command: ["node", "dist/server.js"],
-                  env: [
-                    {
-                      name: "REDIS_HOST",
-                      value: `redis-master.${namespace}.svc.cluster.local`
-                    },
-                    {
-                      name: "REDIS_PASSWORD",
-                      valueFrom: {
-                        secretKeyRef: {
-                          name: "redis-password",
-                          key: "REDIS_MASTER_PASSWORD"
-                        }
-                      }
-                    },
-                    {
-                      name: "GRAPHQL_ENDPOINT_HOST",
-                      value: `graphql.${namespace}.svc.cluster.local`
-                    },
-                    { name: "GRAPHQL_ENDPOINT_PORT", value: "8080" },
-                    {
-                      name: "GRAPHQL_ENDPOINT",
-                      value: `http://graphql.${namespace}.svc.cluster.local:8080/v1/graphql`
-                    },
-                    {
-                      name: "AUTH0_CLIENT_ID",
-                      value: auth0_client_id
-                    },
-                    {
-                      name: "AUTH0_DOMAIN",
-                      value: "opstrace-dev.us.auth0.com"
-                    },
-                    { name: "DOMAIN", value: `https://${domain}` },
-                    { name: "UI_DOMAIN", value: `https://${domain}` },
-                    {
-                      name: "COOKIE_SECRET",
-                      valueFrom: {
-                        secretKeyRef: {
-                          name: "session-cookie-secret",
-                          key: "COOKIE_SECRET"
-                        }
-                      }
-                    },
-                    {
-                      name: "HASURA_GRAPHQL_ADMIN_SECRET",
-                      valueFrom: {
-                        secretKeyRef: {
-                          name: "hasura-admin-secret",
-                          key: "HASURA_ADMIN_SECRET"
-                        }
-                      }
-                    }
-                  ],
-                  ports: [
-                    {
-                      containerPort: 3001,
-                      name: "http"
-                    }
-                  ],
-                  resources: {},
-                  readinessProbe: {
-                    httpGet: {
-                      path: "/ready",
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      port: 9000 as any,
-                      scheme: "HTTP"
-                    },
-                    failureThreshold: 1,
-                    initialDelaySeconds: 5,
-                    periodSeconds: 5,
-                    successThreshold: 1,
-                    timeoutSeconds: 5
-                  },
-                  livenessProbe: {
-                    httpGet: {
-                      path: "/live",
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      port: 9000 as any,
-                      scheme: "HTTP"
-                    },
-                    failureThreshold: 3,
-                    initialDelaySeconds: 5,
-                    periodSeconds: 30,
-                    successThreshold: 1,
-                    timeoutSeconds: 5
-                  },
-                  startupProbe: {
-                    httpGet: {
-                      path: "/live",
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      port: 9000 as any
-                    },
-                    failureThreshold: 3,
-                    initialDelaySeconds: 10,
-                    periodSeconds: 30,
-                    successThreshold: 1,
-                    timeoutSeconds: 5
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      kubeConfig
-    )
-  );
-
-  collection.add(
-    new Service(
-      {
-        apiVersion: "v1",
-        kind: "Service",
-        metadata: {
-          name: "graphql",
-          labels: {
-            app: "graphql"
-          },
-          namespace
-        },
-        spec: {
-          ports: [
-            {
-              name: "http",
-              port: 8080,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              targetPort: "http" as any
-            }
-          ],
-          selector: {
-            app: "graphql"
-          }
-        }
-      },
-      kubeConfig
-    )
-  );
-
-  collection.add(
-    new Deployment(
-      {
-        apiVersion: "apps/v1",
-        kind: "Deployment",
-        metadata: {
-          name: "graphql",
-          namespace,
-          labels: {
-            app: "graphql"
-          }
-        },
-        spec: {
-          replicas: 1,
-          strategy: {
-            type: "RollingUpdate"
-          },
-          selector: {
-            matchLabels: {
-              app: "graphql"
-            }
-          },
-          template: {
-            metadata: {
-              labels: {
-                app: "graphql"
-              }
-            },
-            spec: {
-              affinity: withPodAntiAffinityRequired({
-                app: "graphql"
-              }),
-              containers: [
-                {
-                  name: "graphql",
-                  image: DockerImages.graphqlEngine,
-                  imagePullPolicy: "IfNotPresent",
-                  env: [
-                    {
-                      name: "HASURA_GRAPHQL_ADMIN_SECRET",
-                      valueFrom: {
-                        secretKeyRef: {
-                          name: "hasura-admin-secret",
-                          key: "HASURA_ADMIN_SECRET"
-                        }
-                      }
-                    },
-                    {
-                      name: "HASURA_GRAPHQL_DATABASE_URL",
-                      value: urlJoin(
-                        state.config.config?.postgreSQLEndpoint,
-                        state.config.config?.opstraceDBName
-                      )
-                    },
-                    {
-                      name: "HASURA_GRAPHQL_ENABLE_CONSOLE",
-                      value: "false"
-                    },
-                    {
-                      name: "HASURA_GRAPHQL_ENABLED_LOG_TYPES",
-                      value: "startup, http-log, websocket-log"
-                    }
-                  ],
-                  ports: [
-                    {
-                      containerPort: 8080,
-                      name: "http"
-                    }
-                  ],
-                  resources: {}
-                }
-              ]
-            }
-          }
-        }
-      },
-      kubeConfig
-    )
-  );
-
-  collection.add(
-    new ServiceAccount(
-      {
-        apiVersion: "v1",
-        kind: "ServiceAccount",
-        metadata: {
-          name: "opstrace-application",
-          namespace
-        }
-      },
-      kubeConfig
-    )
-  );
-
-  collection.add(
-    new ClusterRoleBinding(
-      {
-        apiVersion: "rbac.authorization.k8s.io/v1",
-        kind: "ClusterRoleBinding",
-        metadata: {
-          name: "opstrace-application-clusteradmin-binding"
-        },
-        roleRef: {
-          apiGroup: "rbac.authorization.k8s.io",
-          kind: "ClusterRole",
-          name: "cluster-admin"
-        },
-        subjects: [
-          {
-            kind: "ServiceAccount",
-            name: "opstrace-application",
-            namespace
-          }
-        ]
       },
       kubeConfig
     )

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -186,11 +186,17 @@ export function CortexResources(
 
   const storageBackend = target === "gcp" ? "gcs" : "s3";
 
+  // Cortex config schema: https://cortexmetrics.io/docs/configuration/configuration-file/
   const cortexConfig = {
     // HTTP path prefix for Cortex API: default is /api/prom which we do not like
     // in front of e.g. /api/v1/query. Note that the "Prometheus API" is served
     // at api.prometheus_http_prefix.
     http_prefix: "",
+    api: {
+      // Serve Alertmanager UI at this custom location, matching the path served by the config-api pod.
+      // SEE ALSO: go/cmd/config/main.go
+      alertmanager_http_prefix: "/api/v1/alertmanager",
+    },
     auth_enabled: true,
     distributor: {
       shard_by_all_labels: true,

--- a/packages/controller/src/tasks/reconciliation.ts
+++ b/packages/controller/src/tasks/reconciliation.ts
@@ -35,7 +35,7 @@ import {
 import { KubeConfig } from "@kubernetes/client-node";
 
 import { APIResources } from "../resources/apis";
-import { OpstraceApplicationResources } from "../resources/app";
+import { ApplicationResources } from "../resources/app";
 import { CortexResources } from "../resources/cortex";
 import { CredentialResources } from "../resources/credentials";
 import { ExporterResources } from "../resources/exporters";
@@ -80,7 +80,7 @@ export function* reconciliationLoop(
     desired.add(MemcacheResources(state, kubeConfig, "cortex"));
     desired.add(CortexResources(state, kubeConfig, "cortex"));
     desired.add(IngressResources(state, kubeConfig, "ingress"));
-    desired.add(OpstraceApplicationResources(state, kubeConfig, "application"));
+    desired.add(ApplicationResources(state, kubeConfig, "application"));
     desired.add(RedisResources(state, kubeConfig, "application"));
     desired.add(TenantResources(state, kubeConfig));
     desired.add(CredentialResources(state, kubeConfig));


### PR DESCRIPTION
- Updates application ingress to route `<cluster>/api/*` to the config-api pod (was: `config.<cluster>/api/*`)
- Moves cortex alertmanager and ruler APIs into the config-api pod
- Updates the config-api pod with alertmanager and ruler endpoints to be proxied
- Refactors auth and proxy handling a bit for reuse across services, while adding custom path override support when routing requests
