### PR TITLE
loki: bump grpc msg size limits 10x

### DIFF
--- a/packages/controller/src/resources/loki/index.ts
+++ b/packages/controller/src/resources/loki/index.ts
@@ -113,7 +113,9 @@ export function LokiResources(
 
   const lokiConfig = {
     server: {
-      http_listen_port: 1080
+      http_listen_port: 1080,
+      grpc_server_max_recv_msg_size: 41943040, // default (4 MB) * 10
+      grpc_server_max_send_msg_size: 41943040 // default (4 MB) * 10
     },
     auth_enabled: true,
     chunk_store_config: {


### PR DESCRIPTION
Analogue to https://github.com/opstrace/opstrace/pull/419.