### PR TITLE
CLI / CI: test cluster name length limit of 23

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,7 @@ steps:
     depends_on:
       - "unit-tests"
     env:
-      OPSTRACE_CLUSTER_NAME: "cicluster-x-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-g"
+      OPSTRACE_CLUSTER_NAME: "cicluster-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-g"
       OPSTRACE_BUILD_DIR: "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-gcp"
       OPSTRACE_CLOUD_PROVIDER: "gcp"
     command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,7 @@ steps:
     depends_on:
       - "unit-tests"
     env:
-      OPSTRACE_CLUSTER_NAME: "cicluster-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-g"
+      OPSTRACE_CLUSTER_NAME: "${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-g"
       OPSTRACE_BUILD_DIR: "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-gcp"
       OPSTRACE_CLOUD_PROVIDER: "gcp"
     command:
@@ -50,7 +50,7 @@ steps:
     depends_on:
       - "unit-tests"
     env:
-      OPSTRACE_CLUSTER_NAME: "cicluster-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-a"
+      OPSTRACE_CLUSTER_NAME: "${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-a"
       OPSTRACE_BUILD_DIR: "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-aws"
       OPSTRACE_CLOUD_PROVIDER: "aws"
     command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,7 @@ steps:
     depends_on:
       - "unit-tests"
     env:
-      OPSTRACE_CLUSTER_NAME: "bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-g"
+      OPSTRACE_CLUSTER_NAME: "cicluster-x-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-g"
       OPSTRACE_BUILD_DIR: "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-gcp"
       OPSTRACE_CLOUD_PROVIDER: "gcp"
     command:
@@ -50,7 +50,7 @@ steps:
     depends_on:
       - "unit-tests"
     env:
-      OPSTRACE_CLUSTER_NAME: "bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-a"
+      OPSTRACE_CLUSTER_NAME: "cicluster-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-a"
       OPSTRACE_BUILD_DIR: "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-aws"
       OPSTRACE_CLOUD_PROVIDER: "aws"
     command:

--- a/.buildkite/test-upgrade-pipeline.yml
+++ b/.buildkite/test-upgrade-pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: "🔨 main upgrade test (AWS)"
     key: "maintest-upgrade-aws"
     env:
-      OPSTRACE_CLUSTER_NAME: "bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-a"
+      OPSTRACE_CLUSTER_NAME: "upgrade-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-a"
       OPSTRACE_CLOUD_PROVIDER: "aws"
       AWS_CLI_REGION: "us-west-2"
     command:

--- a/lib/gcp/src/iam.ts
+++ b/lib/gcp/src/iam.ts
@@ -74,6 +74,9 @@ async function createServiceAccount({
     name: `projects/${projectId}`,
     accountId: accountId
   };
+  // Account ID must be at least 6 and at most 30 chars, otherwise
+  // API error: The account ID \"cicluster-bk-3667-998-g-cert-manager\" does not have a length
+  // between 6 and 30.
   const sa = await iam.projects.serviceAccounts.create(params);
   return sa.data;
 }

--- a/packages/cli/src/schemas.ts
+++ b/packages/cli/src/schemas.ts
@@ -118,9 +118,7 @@ export const renderedClusterConfigSchema = clusterConfigFileSchema.concat(
         .required()
         .matches(CLUSTER_NAME_REGEX)
         .min(2)
-        .max(13), // Note(JP): what's our rational here? Reply(Mat): If I remember correctly, this came from the limit
-      // imposed for BigTable instance names - they had a strict char limit. This is no longer applicable
-      // so we might want to increase the limit.
+        .max(23), // was 13 at some point, trying something larger now (set of constraints now clearly known)
       cloud_provider: yup
         .mixed<"gcp" | "aws">()
         .oneOf(["aws", "gcp"])

--- a/packages/cli/src/schemas.ts
+++ b/packages/cli/src/schemas.ts
@@ -118,7 +118,7 @@ export const renderedClusterConfigSchema = clusterConfigFileSchema.concat(
         .required()
         .matches(CLUSTER_NAME_REGEX)
         .min(2)
-        .max(23), // was 13 at some point, trying something larger now (set of constraints now clearly known)
+        .max(23), // was 13 at some point, trying something larger now (set of constraints not clearly known)
       cloud_provider: yup
         .mixed<"gcp" | "aws">()
         .oneOf(["aws", "gcp"])

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -33,7 +33,9 @@ import * as list from "./list";
  */
 export function validateClusterNameOrDie(cn: string): void {
   if (cn.length > 23) {
-    die(`cluster name must not be longer than 13 characters`);
+    die(
+      `cluster name must not be longer than 23 characters (is: ${cn.length})`
+    );
   }
 
   if (cn.length < 2) {

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -32,7 +32,7 @@ import * as list from "./list";
  * messages.
  */
 export function validateClusterNameOrDie(cn: string): void {
-  if (cn.length > 13) {
+  if (cn.length > 23) {
     die(`cluster name must not be longer than 13 characters`);
   }
 

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -10,7 +10,7 @@
   "exporterStackdriver": "prometheuscommunity/stackdriver-exporter:v0.11.0",
   "externalDNS": "k8s.gcr.io/external-dns/external-dns:v0.7.4",
   "systemlogFluentd": "opstrace/systemlog-fluentd:0798f0a-dev",
-  "grafana": "grafana/grafana:7.3.4-ubuntu",
+  "grafana": "grafana/grafana:7.4.3-ubuntu",
   "kubed": "appscode/kubed:v0.12.0",
   "kubeRBACProxy": "quay.io/coreos/kube-rbac-proxy:v0.4.1",
   "kubeStateMetrics": "quay.io/coreos/kube-state-metrics:v1.7.2",

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -158,7 +158,12 @@ export function* ensureGCPInfraExists(
   // Create a Google service account to be used by cert-manager.
   log.info(`Ensuring cert-manager service account exists`);
   const certManagerSA = yield call(ensureServiceAccountExists, {
-    name: `${ccfg.cluster_name}-cert-manager`,
+    // service account name ("account ID") in GCP must be at least 6 and at
+    // most 30 characters. `ccfg.cluster_name` is at most 23 characters at the
+    // time of writing. 23 plus 7 (len('-crtmgr')) is 30. Good.
+    // Note: this is a name-based convention, the uninstaller relies on this
+    // convention.
+    name: `${ccfg.cluster_name}-crtmgr`,
     projectId: gcpProjectID,
     role: "roles/dns.admin",
     kubernetesServiceAccount: "ingress/cert-manager"

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -174,7 +174,8 @@ export function* ensureGCPInfraExists(
   // Create a Google service account to be used by external-dns.
   log.info(`Ensuring external-dns service account exists`);
   const externalDNSSA = yield call(ensureServiceAccountExists, {
-    name: `${ccfg.cluster_name}-external-dns`,
+    // max length for svc acc name: 30, cluster name is max 23.
+    name: `${ccfg.cluster_name}-extdns`,
     projectId: gcpProjectID,
     role: "roles/dns.admin",
     kubernetesServiceAccount: "ingress/external-dns"

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -59,6 +59,13 @@ export function* destroyGCPInfra(): Generator<
   });
 
   log.info(`Ensure external-dns service account deletion`);
+
+  yield call(ensureServiceAccountDoesNotExist, {
+    name: `${destroyConfig.clusterName}-extdns`,
+    projectId: destroyConfig.gcpProjectID,
+    role: "roles/dns.admin"
+  });
+  // for backwards compat (name changed from *-external-dns to -extdns)
   yield call(ensureServiceAccountDoesNotExist, {
     name: `${destroyConfig.clusterName}-external-dns`,
     projectId: destroyConfig.gcpProjectID,

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -42,6 +42,16 @@ export function* destroyGCPInfra(): Generator<
 
   log.info(`Ensure cert-manager service account deletion`);
   yield call(ensureServiceAccountDoesNotExist, {
+    // name-based convention, sync with installer
+    name: `${destroyConfig.clusterName}-crtmgr`,
+    projectId: destroyConfig.gcpProjectID,
+    role: "roles/dns.admin"
+  });
+  // Note(JP): naming convention changed in Feb 2021.
+  // Previously, the account was called *-cert-manager.
+  // Make this newer installer compatible with older clusters.
+  yield call(ensureServiceAccountDoesNotExist, {
+    // name-based convention, sync with installer
     name: `${destroyConfig.clusterName}-cert-manager`,
     projectId: destroyConfig.gcpProjectID,
     role: "roles/dns.admin"

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -49,7 +49,7 @@ export function* destroyGCPInfra(): Generator<
   });
   // Note(JP): naming convention changed in Feb 2021. Previously, the account
   // was called *-cert-manager. Make this newer uninstaller compatible with
-  // clusters created with and older installer (so that the *-cert-manager is
+  // clusters created with an older installer (so that the *-cert-manager is
   // deleted if it exists).
   yield call(ensureServiceAccountDoesNotExist, {
     // name-based convention, sync with installer

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -47,9 +47,10 @@ export function* destroyGCPInfra(): Generator<
     projectId: destroyConfig.gcpProjectID,
     role: "roles/dns.admin"
   });
-  // Note(JP): naming convention changed in Feb 2021.
-  // Previously, the account was called *-cert-manager.
-  // Make this newer installer compatible with older clusters.
+  // Note(JP): naming convention changed in Feb 2021. Previously, the account
+  // was called *-cert-manager. Make this newer uninstaller compatible with
+  // clusters created with and older installer (so that the *-cert-manager is
+  // deleted if it exists).
   yield call(ensureServiceAccountDoesNotExist, {
     // name-based convention, sync with installer
     name: `${destroyConfig.clusterName}-cert-manager`,


### PR DESCRIPTION
This also changes the cluster name pattern used by the various CI pipelines. Relevant commit msg:

```
This helps addressing #294.

This also gets rid of using the same cluster name
pattern as for everything else in the upgrade
tests -- where the only difference was that we
started off with lower sequential build numbers.
```