### PR TITLE
Cortex: explicit tsdb config, enable purger

### DIFF
--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -330,7 +330,7 @@ export function CortexResources(
       tsdb: {
         dir: "/cortex/tsdb",
         wal_compression_enabled: true,
-        block_ranges_period: "2h", //default
+        block_ranges_period: "2h0m0s", //default
         retention_period: "6h" //default
       },
       backend: storageBackend,

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -329,7 +329,9 @@ export function CortexResources(
     blocks_storage: {
       tsdb: {
         dir: "/cortex/tsdb",
-        wal_compression_enabled: true
+        wal_compression_enabled: true,
+        block_ranges_period: "2h", //default
+        retention_period: "6h" //default
       },
       backend: storageBackend,
       bucket_store: {

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -330,7 +330,8 @@ export function CortexResources(
       tsdb: {
         dir: "/cortex/tsdb",
         wal_compression_enabled: true,
-        block_ranges_period: "2h0m0s", //default
+        // Note list_of_durations type, and e.g. "2h0m0s" does not validate as a single value
+        block_ranges_period: "2h0m0s,", //default
         retention_period: "6h" //default
       },
       backend: storageBackend,

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -331,7 +331,8 @@ export function CortexResources(
         dir: "/cortex/tsdb",
         wal_compression_enabled: true,
         // Note list_of_durations type, and e.g. "2h0m0s" does not validate as a single value
-        block_ranges_period: "2h0m0s,", //default
+        // "2h0m0s," also does not. How to provide a list with a single value?
+        // block_ranges_period: "2h0m0s,", //default
         retention_period: "6h" //default
       },
       backend: storageBackend,

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -244,7 +244,7 @@ export function CortexResources(
     api: {
       // Serve Alertmanager UI at this custom location, matching the path served by the config-api pod.
       // SEE ALSO: go/cmd/config/main.go
-      alertmanager_http_prefix: "/api/v1/alertmanager",
+      alertmanager_http_prefix: "/api/v1/alertmanager"
     },
     auth_enabled: true,
     distributor: {
@@ -381,6 +381,7 @@ export function CortexResources(
         }
       }
     },
+    purger: { enable: true },
     storage: {
       engine: "blocks"
     },


### PR DESCRIPTION
https://cortexmetrics.io/docs/configuration/configuration-file/#blocks_storage_config
https://cortexmetrics.io/docs/blocks-storage/

About `block_ranges_period`:

> The in-memory samples are periodically flushed to disk - and the WAL truncated - when a new TSDB block is created, **which by default occurs every 2 hours**. 

About `retention_period`:

> Each newly created block is then uploaded to the long-term storage and kept in the ingester until the configured -blocks-storage.tsdb.retention-period expires, in order to give queriers and store-gateways enough time to discover the new block on the storage and download its index-header.

Powerful knobs, affecting fault tolerance, local disk usage, query performance, etc.




