### PR TITLE
systemlogs: revert fluentd bump (see #432)

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -9,7 +9,7 @@
   "exporterCloudwatch": "prom/cloudwatch-exporter:cloudwatch_exporter-0.10.0",
   "exporterStackdriver": "prometheuscommunity/stackdriver-exporter:v0.11.0",
   "externalDNS": "k8s.gcr.io/external-dns/external-dns:v0.7.4",
-  "systemlogFluentd": "opstrace/systemlog-fluentd:0798f0a-dev",
+  "systemlogFluentd": "opstrace/systemlog-fluentd:fe6d0d84-dev",
   "grafana": "grafana/grafana:7.4.3-ubuntu",
   "kubed": "appscode/kubed:v0.12.0",
   "kubeRBACProxy": "quay.io/coreos/kube-rbac-proxy:v0.4.1",


### PR DESCRIPTION
CI instability https://github.com/opstrace/opstrace/issues/432 motivated debugging, resulting in https://github.com/fluent/fluentd/pull/3274 and the corresponding patch https://github.com/fluent/fluentd/pull/3275. In the meantime, this reverts to the previously used systemlog docker container image.