### PR TITLE
alertmanager/ruler: ADD CONFIG BUCKET, get cortex alertmgr/ruler working (#430)

### DIFF
--- a/lib/gcp/src/bucket.ts
+++ b/lib/gcp/src/bucket.ts
@@ -96,7 +96,7 @@ export function* ensureBucketExists({
   region
 }: {
   bucketName: string;
-  retentionDays: number;
+  retentionDays: number | null;
   region: string;
 }): Generator<CallEffect, unknown, unknown> {
   const storage = new gcs.Storage();
@@ -118,11 +118,13 @@ export function* ensureBucketExists({
         location: region,
         storage
       });
-      yield call(setBucketLifecycle, {
-        name: bucketName,
-        days: retentionDays,
-        storage
-      });
+      if (retentionDays !== null) {
+        yield call(setBucketLifecycle, {
+          name: bucketName,
+          days: retentionDays,
+          storage
+        });
+      }
     } catch (e) {
       if (!e.code || (e.code && e.code !== 409)) {
         throw e;

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -3,7 +3,7 @@
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.2.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
   "configApi": "opstrace/config-api:25319736506ebf4d4650434700f6fc4e76efa120",
-  "cortex": "cortexproject/cortex:master-35fbe42",
+  "cortex": "cortexproject/cortex:master-9c46081",
   "cortexApiProxy": "opstrace/cortex-api:25319736506ebf4d4650434700f6fc4e76efa120",
   "ddApi": "opstrace/ddapi:25319736506ebf4d4650434700f6fc4e76efa120",
   "exporterCloudwatch": "prom/cloudwatch-exporter:cloudwatch_exporter-0.10.0",

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -88,6 +88,15 @@ export function* ensureGCPInfraExists(
     region: ccfg.gcp.region
   });
 
+  yield call(ensureBucketExists, {
+    bucketName: getBucketName({
+      clusterName: ccfg.cluster_name,
+      suffix: "cortex-config"
+    }),
+    retentionDays: null, // no TTL this bucket: configs should not expire
+    region: ccfg.gcp.region
+  });
+
   log.info(`Ensuring VPC exists`);
   yield call(ensureNetworkExists, ccfg.cluster_name);
 

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -90,9 +90,13 @@ export function* destroyGCPInfra(): Generator<
     clusterName: destroyConfig.clusterName,
     suffix: "loki"
   });
-  const cortexBucketName = getBucketName({
+  const cortexDataBucketName = getBucketName({
     clusterName: destroyConfig.clusterName,
     suffix: "cortex"
+  });
+  const cortexConfigBucketName = getBucketName({
+    clusterName: destroyConfig.clusterName,
+    suffix: "cortex-config"
   });
 
   log.info(`Ensure GKE deletion`);
@@ -137,18 +141,26 @@ export function* destroyGCPInfra(): Generator<
   });
 
   log.info(
-    `Setting Bucket Lifecycle on ${cortexBucketName} to delete after 0 days`
+    `Setting Bucket Lifecycle on ${cortexDataBucketName} to delete after 0 days`
   );
   yield call(emptyBucket, {
-    bucketName: cortexBucketName
+    bucketName: cortexDataBucketName
+  });
+
+  log.info(
+    `Setting Bucket Lifecycle on ${cortexConfigBucketName} to delete after 0 days`
+  );
+  yield call(emptyBucket, {
+    bucketName: cortexConfigBucketName
   });
 
   log.info(
     "GCS has been instructed to wipe the data buckets behind the scenes, " +
       "asynchronously. This process may take minutes, hours or days. After " +
-      "completion, two empty GCS buckets will be left behind which you " +
-      "have to delete manually: %s, %s",
+      "completion, three empty GCS buckets will be left behind which you " +
+      "have to delete manually: %s, %s, %s",
     lokiBucketName,
-    cortexBucketName
+    cortexDataBucketName,
+    cortexConfigBucketName
   );
 }


### PR DESCRIPTION
UPGRADE-AFFECTING CHANGE: Adds a new `<cluster>-cortex-config` bucket, separate from the `<cluster>-cortex` bucket where metric data are stored. A separate config bucket is needed for multiple reasons:
- The cortex alertmanager and ruler currently only support writing configs when S3/GCS storage is being used (`configdb` store is effectively read-only).
- The main `<cluster>-cortex` bucket is configured with a TTL/expiration policy to automatically delete old files, which we do not want for alert/rule configs.
- The compactor separately automatically writes files to `/alerts/bucket-index.json.gz` and `/rules/bucket-index.json.gz`, which for alertmanager in particular causes fatal problems when it tries to scan configs.
- The alertmanager and ruler currently require storing data in `/alerts` and `/rules`, respectively, which may conflict with tenants named `alerts` or `rules` in the main bucket. (But this is a relatively minor issue compared to the last two)

Several fixes to alertmanager/ruler configuration to get them working (see full notes in #430):
- Configure S3/GCS storage so that alertmanager/ruler are able to store submitted configurations. Meanwhile the default `configdb` storage doesn't implement writing configs, and is deprecated anyway.
- Disable sharding in alertmanager since cortex team it isn't fully implemented yet
- Override legacy prefix in alertmanager so that access to `/api/v1/alerts` isn't broken by a legacy handler at `/*` (upstream fix pending)

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
