### PR TITLE
cortex: bump to current master

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -3,7 +3,7 @@
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.2.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
   "configApi": "opstrace/config-api:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
-  "cortex": "cortexproject/cortex:master-9c46081",
+  "cortex": "cortexproject/cortex:master-f476908",
   "cortexApiProxy": "opstrace/cortex-api:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
   "ddApi": "opstrace/ddapi:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
   "exporterCloudwatch": "prom/cloudwatch-exporter:cloudwatch_exporter-0.10.0",

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -3,7 +3,7 @@
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.2.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
   "configApi": "opstrace/config-api:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
-  "cortex": "cortexproject/cortex:master-f476908",
+  "cortex": "cortexproject/cortex:v1.8.0-rc.0",
   "cortexApiProxy": "opstrace/cortex-api:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
   "ddApi": "opstrace/ddapi:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
   "exporterCloudwatch": "prom/cloudwatch-exporter:cloudwatch_exporter-0.10.0",


### PR DESCRIPTION
https://github.com/cortexproject/cortex/commit/a0c89bdf98e24ebfa4bf52a19cbd0bdc61a7b212
https://github.com/cortexproject/cortex/commit/68d537bc7f2d638f3f375ab673f6807338db5c1d
https://github.com/cortexproject/cortex/commit/d6d06693abaed36fd770c8f81799943f03d5da41
https://github.com/cortexproject/cortex/commit/f47690485631b8e5b62ea023e76770ac822042aa
https://github.com/cortexproject/cortex/commit/2b9453306534c40ee00ec533d6370bab4f459c88
https://github.com/cortexproject/cortex/commit/5dccf0829299a7f393b5c078fc5c6a7accd10d51
https://github.com/cortexproject/cortex/commit/5e496f428302a195a68cc287d97641561dbe0afd


>  Alertmanager: load alertmanager configurations from object storage concurrently, and only load necessary configurations, speeding configuration synchronization process and executing fewer "GET object" operations to the storage when sharding is enabled. #3898

```
* Update Alertmanager dependency to master

The biggest changes are time-based muting and the inclusion of
interfaces for the clustering logic.

The latter supports the Alertmanager replication via the ring.

Signed-off-by: gotjosh <josue@grafana.com>

* Use NilPeer for the API clustering interface.

We don't want to expose information about the cluster back to tenants.

Signed-off-by: gotjosh <josue@grafana.com>

* gofmt fails me

Signed-off-by: gotjosh <josue@grafana.com>
```

CC @MatApple @terrcin @nickbp 


