### PR TITLE
controller: deal with old config schema (param `data_api_authn_pubkey_pem`)

### DIFF
--- a/lib/utils/src/index.ts
+++ b/lib/utils/src/index.ts
@@ -24,6 +24,7 @@ export * from "./naming";
 export * from "./sagas";
 export * from "./errors";
 export * from "./diffutils";
+export * from "./pubkey";
 export {
   sleep,
   mtime,

--- a/lib/utils/src/pubkey.ts
+++ b/lib/utils/src/pubkey.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import crypto from "crypto";
+
+export function keyIDfromPEM(pemstring: string): string {
+  // See specification for key ID derivation in authenticator's README.
+  const hash = crypto.createHash("sha1");
+  // Trim leading and trailing whitespace from PEM string, take underlying
+  // bytes (implicitly using utf8 here, which is correct) and build the SHA1
+  // hash from it -- represent it in hex form as a string.
+  hash.write(pemstring.trim());
+  hash.end();
+  const data = hash.read();
+  const keyID = data.toString("hex");
+  return keyID;
+}

--- a/packages/cli/src/create.ts
+++ b/packages/cli/src/create.ts
@@ -16,7 +16,7 @@
 
 import fs from "fs";
 
-import { log, Dict, die } from "@opstrace/utils";
+import { log, Dict, die, keyIDfromPEM } from "@opstrace/utils";
 import { setAWSRegion } from "@opstrace/aws";
 import { GCPAuthOptions } from "@opstrace/gcp";
 
@@ -173,7 +173,7 @@ function genCryptoMaterialForAPIAuth(
     }
 
     const data_api_authn_pubkey_pem = cryp.getPubkeyAsPem();
-    const keyId = cryp.keyIDfromPEM(data_api_authn_pubkey_pem);
+    const keyId = keyIDfromPEM(data_api_authn_pubkey_pem);
     log.info(
       "serialized public key (id: %s) for tenant API token verification",
       keyId

--- a/packages/cli/src/crypto.ts
+++ b/packages/cli/src/crypto.ts
@@ -18,7 +18,7 @@ import crypto from "crypto";
 
 import jwt from "jsonwebtoken";
 
-import { log } from "@opstrace/utils";
+import { log, keyIDfromPEM } from "@opstrace/utils";
 
 interface RSAKeypair {
   privkeyObj: crypto.KeyObject;
@@ -131,19 +131,6 @@ function generateRSAkeypair(): RSAKeypair {
     privkeyObj: privateKey,
     pubkeyPem: pubkeyPem
   };
-}
-
-export function keyIDfromPEM(pemstring: string): string {
-  // See specification for key ID derivation in authenticator's README.
-  const hash = crypto.createHash("sha1");
-  // Trim leading and trailing whitespace from PEM string, take underlying
-  // bytes (implicitly using utf8 here, which is correct) and build the SHA1
-  // hash from it -- represent it in hex form as a string.
-  hash.write(pemstring.trim());
-  hash.end();
-  const data = hash.read();
-  const keyID = data.toString("hex");
-  return keyID;
 }
 
 function initialize() {


### PR DESCRIPTION
https://github.com/opstrace/opstrace/issues/456

This kind of patch should be considered an exception.

It makes the newer controller version work with an older controller config, transparently. **Without migrating the config schema**. 

Such approach is difficult to maintain: when can the relevant code path be removed?

If we want to be able to do controller upgrades, we need to build a controller config schema migration system that keeps track of the controller config schema version, and explicitly performs a migration when upgrading the controller (which after all writes a new value to the k8s config map holding the controller config).