### PR TITLE
ci: run wipe-bk-tmp-dir after unit tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,7 +60,9 @@ steps:
       - "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-aws/bk-artifacts/**/*"
   - label: "🔨 cleanup /tmp"
     key: "cleanup-tmp"
-    depends_on: "preamble"
+    depends_on:
+      - "preamble"
+      - "unit-tests"
     allow_dependency_failure: true
     command:
       - source ci/wipe-bk-tmp-dir.sh

--- a/ci/wipe-bk-tmp-dir.sh
+++ b/ci/wipe-bk-tmp-dir.sh
@@ -9,10 +9,12 @@ echo "--- wipe-bk-tmp-dir"
 # underneath them).
 
 set -o xtrace
+
 # Actual artifacts (docker images, etc) are meant to be produced by the
 # preamble step. The `node_modules` dir in the prebuild dir is expected to be
-# larger than 1 GB -- and it must be safe to wipe it right after the preamble.
-
+# larger than 1 GB -- and it must be safe to wipe it when this CI step starts.
+# At the time of writing, this has to be invoked after the preamble and after
+# the unit test stage, which both operate on the prebuild directory.
 rm -rf "${OPSTRACE_PREBUILD_DIR}/node_modules"
 
 # note(jp): remove this again, can take ~10 minutes easily otherwise
@@ -56,6 +58,6 @@ set +e
 ls -ahltr /tmp
 set -e
 
-# note(jp): remove this again, can take ~10 minutes easily otherwise
+# note(jp): remove this again when it becomes too expensive
 echo "expensive: the N largest files and directories in /tmp"
 du -ha /tmp | sort -r -h | head -n 100 || true


### PR DESCRIPTION
Fixes a concurrency issue where PREBUILD directory removal was invoked before unit-test ci step completion.

See https://github.com/opstrace/opstrace/issues/439#issuecomment-793731713
