### PR TITLE
config: Implement Hasura Actions for alertmanager get/set and creds/exporters (#373)

### DIFF
--- a/go/cmd/config/README.md
+++ b/go/cmd/config/README.md
@@ -25,7 +25,8 @@ GRAPHQL_ENDPOINT=http://127.0.0.1:8080/v1/graphql \
 HASURA_GRAPHQL_ADMIN_SECRET=myadminsecret \
 ./config \
   --loglevel debug \
-  --listen "127.0.0.1:8989" \
+  --config "127.0.0.1:8989" \
+  --action "127.0.0.1:8990" \
   --disable-api-authn
 ```
 

--- a/go/cmd/config/actions/types.go
+++ b/go/cmd/config/actions/types.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Opstrace, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+type GraphQLError struct {
+	Message string `json:"message"`
+}
+
+type ErrorType string
+
+const (
+	ServiceOfflineType   ErrorType = "SERVICE_OFFLINE"
+	ServiceErrorType     ErrorType = "SERVICE_ERROR"
+	ValidationFailedType ErrorType = "VALIDATION_FAILED"
+)
+
+type Alertmanager struct {
+	TenantID string  `json:"tenant_id"`
+	Config   *string `json:"config"`
+	Online   bool    `json:"online"`
+}
+
+type AlertmanagerUpdateResponse struct {
+	Success          bool       `json:"success"`
+	ErrorType        *ErrorType `json:"error_type"`
+	ErrorMessage     *string    `json:"error_message"`
+	ErrorRawResponse *string    `json:"error_raw_response"`
+}
+
+type ValidateOutput struct {
+	Success          bool       `json:"success"`
+	ErrorType        *ErrorType `json:"error_type"`
+	ErrorMessage     *string    `json:"error_message"`
+	ErrorRawResponse *string    `json:"error_raw_response"`
+}
+
+type AlertmanagerInput struct {
+	Config string `json:"config"`
+}
+
+type GetAlertmanagerArgs struct {
+	TenantID string `json:"tenant_id"`
+}
+
+type UpdateAlertmanagerArgs struct {
+	TenantID string             `json:"tenant_id"`
+	Input    *AlertmanagerInput `json:"input"`
+}
+
+type ValidateCredentialArgs struct {
+	TenantID string `json:"tenant_id"`
+	Content  string `json:"content"`
+}
+
+type ValidateExporterArgs struct {
+	TenantID string `json:"tenant_id"`
+	Content  string `json:"content"`
+}
+
+type GetAlertmanagerPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            GetAlertmanagerArgs    `json:"input"`
+}
+
+type UpdateAlertmanagerPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            UpdateAlertmanagerArgs `json:"input"`
+}
+
+type ValidateCredentialPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            ValidateCredentialArgs `json:"input"`
+}
+
+type ValidateExporterPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            ValidateExporterArgs   `json:"input"`
+}

--- a/go/cmd/config/actions/util.go
+++ b/go/cmd/config/actions/util.go
@@ -1,0 +1,54 @@
+// Copyright 2021 Opstrace, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"encoding/json"
+)
+
+type hasuraActionInfo struct {
+	Action hasuraActionName `json:"action"`
+}
+
+type hasuraActionName struct {
+	Name string `json:"name"`
+}
+
+// Extracts and returns the name of the action specified in the payload.
+func GetActionName(body []byte) (string, error) {
+	var actionInfo hasuraActionInfo
+	err := json.Unmarshal(body, &actionInfo)
+	if err != nil {
+		return "", err
+	}
+	return actionInfo.Action.Name, nil
+}
+
+func ValidateError(t ErrorType, message string, rawResponse string) ValidateOutput {
+	var messagePtr *string
+	if message != "" {
+		messagePtr = &message
+	}
+	var rawResponsePtr *string
+	if rawResponse != "" {
+		rawResponsePtr = &rawResponse
+	}
+	return ValidateOutput{
+		Success:          false,
+		ErrorType:        &t,
+		ErrorMessage:     messagePtr,
+		ErrorRawResponse: rawResponsePtr,
+	}
+}

--- a/go/cmd/config/config_types.go
+++ b/go/cmd/config/config_types.go
@@ -34,6 +34,11 @@ var (
 	}
 )
 
+type AWSCredentialValue struct {
+	AwsAccessKeyID     string `json:"AWS_ACCESS_KEY_ID"`
+	AwsSecretAccessKey string `json:"AWS_SECRET_ACCESS_KEY"`
+}
+
 // Accepts and validates a credential YAML value for writing to graphql as JSON.
 func convertCredValue(credName string, credType string, credValue interface{}) (*graphql.Json, error) {
 	switch credType {

--- a/go/cmd/config/credential.go
+++ b/go/cmd/config/credential.go
@@ -1,0 +1,235 @@
+// Copyright 2021 Opstrace, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
+	"github.com/opstrace/opstrace/go/pkg/graphql"
+)
+
+// Information about a credential. Custom type which omits the tenant field.
+// This also given some extra protection that the value isn't disclosed,
+// even if it was mistakenly added to the underlying graphql interface.
+type CredentialInfo struct {
+	Name      string `yaml:"name"`
+	Type      string `yaml:"type,omitempty"`
+	CreatedAt string `yaml:"created_at,omitempty"`
+	UpdatedAt string `yaml:"updated_at,omitempty"`
+}
+
+func listCredentials(tenant string, w http.ResponseWriter, r *http.Request) {
+	resp, err := credentialAccess.List(tenant)
+	if err != nil {
+		log.Warnf("Listing credentials failed: %s", err)
+		http.Error(w, fmt.Sprintf("Listing credentials failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	log.Debugf("Listing %d credentials", len(resp.Credential))
+
+	encoder := yaml.NewEncoder(w)
+	for _, credential := range resp.Credential {
+		encoder.Encode(CredentialInfo{
+			Name:      credential.Name,
+			Type:      credential.Type,
+			CreatedAt: credential.CreatedAt,
+			UpdatedAt: credential.UpdatedAt,
+		})
+	}
+}
+
+// Full credential entry (with secret value) received from a POST request.
+type Credential struct {
+	Name  string      `yaml:"name"`
+	Type  string      `yaml:"type"`
+	Value interface{} `yaml:"value"` // nested yaml, or payload string, depending on type
+}
+
+func listCredentialTypes(tenant string) (map[string]string, error) {
+	// Collect map of existing name->type so that we can decide between insert vs update
+	existingTypes := make(map[string]string)
+	resp, err := credentialAccess.List(tenant)
+	if err != nil {
+		log.Warnf("Listing credentials failed: %s", err)
+		return nil, err
+	}
+	for _, credential := range resp.Credential {
+		existingTypes[credential.Name] = credential.Type
+	}
+	return existingTypes, nil
+}
+
+// Accepts the tenant name, the name->type mapping of any existin credentials, and the new credential payload.
+// Returns the JSON credential value, whether the credential already exists, and any validation error.
+func validateCredential(existingTypes map[string]string, yamlCredential Credential) (*graphql.Json, bool, error) {
+	value, err := convertCredValue(yamlCredential.Name, yamlCredential.Type, yamlCredential.Value)
+	if err != nil {
+		return nil, false, fmt.Errorf("Credential format validation failed: %s", err)
+	}
+	var existingType string
+	var exists bool
+	if existingType, exists = existingTypes[yamlCredential.Name]; exists {
+		// Explicitly check and complain if the user tries to change the credential type
+		if yamlCredential.Type != "" && existingType != yamlCredential.Type {
+			return nil, false, fmt.Errorf(
+				"Credential '%s' type cannot be updated (current=%s, updated=%s)",
+				yamlCredential.Name, existingType, yamlCredential.Type,
+			)
+		}
+	}
+	return value, exists, nil
+}
+
+func writeCredentials(tenant string, w http.ResponseWriter, r *http.Request) {
+	decoder := yaml.NewDecoder(r.Body)
+	// Return error for unrecognized or duplicate fields in the input
+	decoder.SetStrict(true)
+
+	// Collect map of existing name->type so that we can decide between insert vs update
+	existingTypes, err := listCredentialTypes(tenant)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Listing credentials failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	now := nowTimestamp()
+
+	var inserts []graphql.CredentialInsertInput
+	var updates []graphql.UpdateCredentialVariables
+	for {
+		var yamlCredential Credential
+		err := decoder.Decode(&yamlCredential)
+		if err != nil {
+			if err != io.EOF {
+				log.Debugf("Decoding credential input at index=%d failed: %s", len(inserts)+len(updates), err)
+				http.Error(w, fmt.Sprintf(
+					"Decoding credential input at index=%d failed: %s", len(inserts)+len(updates), err,
+				), http.StatusBadRequest)
+				return
+			}
+			break
+		}
+		value, exists, err := validateCredential(existingTypes, yamlCredential)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		name := graphql.String(yamlCredential.Name)
+		credType := graphql.String(yamlCredential.Type)
+		if exists {
+			// TODO check for no-op updates and skip them (and avoid unnecessary changes to UpdatedAt)
+			updates = append(updates, graphql.UpdateCredentialVariables{
+				Name:      name,
+				Value:     *value,
+				UpdatedAt: now,
+			})
+		} else {
+			inserts = append(inserts, graphql.CredentialInsertInput{
+				Name:      &name,
+				Type:      &credType,
+				Value:     value,
+				CreatedAt: &now,
+				UpdatedAt: &now,
+			})
+		}
+	}
+
+	if len(inserts)+len(updates) == 0 {
+		log.Debugf("Writing credentials: No data provided")
+		http.Error(w, "Missing credential YAML data in request body", http.StatusBadRequest)
+		return
+	}
+
+	log.Debugf("Writing credentials: %d insert, %d update", len(inserts), len(updates))
+
+	if len(inserts) != 0 {
+		err := credentialAccess.Insert(tenant, inserts)
+		if err != nil {
+			log.Warnf("Insert: %d credentials failed: %s", len(inserts), err)
+			http.Error(
+				w,
+				fmt.Sprintf("Creating %d credentials failed: %s", len(inserts), err),
+				http.StatusInternalServerError,
+			)
+			return
+		}
+	}
+	if len(updates) != 0 {
+		for _, update := range updates {
+			err := credentialAccess.Update(tenant, update)
+			if err != nil {
+				log.Warnf("Update: Credential %s failed: %s", update.Name, err)
+				http.Error(
+					w,
+					fmt.Sprintf("Updating credential %s failed: %s", update.Name, err),
+					http.StatusInternalServerError,
+				)
+				return
+			}
+		}
+	}
+}
+
+func getCredential(tenant string, w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	log.Debugf("Getting credential: %s", name)
+
+	resp, err := credentialAccess.Get(tenant, name)
+	if err != nil {
+		log.Warnf("Get: Credential %s failed: %s", name, err)
+		http.Error(w, fmt.Sprintf("Getting credential failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+	if resp == nil {
+		log.Debugf("Get: Credential %s not found", name)
+		http.Error(w, fmt.Sprintf("Credential not found: %s", name), http.StatusNotFound)
+		return
+	}
+
+	encoder := yaml.NewEncoder(w)
+	encoder.Encode(CredentialInfo{
+		Name:      resp.CredentialByPk.Name,
+		Type:      resp.CredentialByPk.Type,
+		CreatedAt: resp.CredentialByPk.CreatedAt,
+		UpdatedAt: resp.CredentialByPk.UpdatedAt,
+	})
+}
+
+func deleteCredential(tenant string, w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	log.Debugf("Deleting credential: %s", name)
+
+	resp, err := credentialAccess.Delete(tenant, name)
+	if err != nil {
+		log.Warnf("Delete: Credential %s failed: %s", name, err)
+		http.Error(w, fmt.Sprintf("Deleting credential failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+	if resp == nil {
+		log.Debugf("Delete: Credential %s not found", name)
+		http.Error(w, fmt.Sprintf("Credential not found: %s", name), http.StatusNotFound)
+		return
+	}
+
+	encoder := yaml.NewEncoder(w)
+	encoder.Encode(CredentialInfo{Name: resp.DeleteCredentialByPk.Name})
+}

--- a/go/cmd/config/exporter.go
+++ b/go/cmd/config/exporter.go
@@ -1,0 +1,341 @@
+// Copyright 2021 Opstrace, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
+	"github.com/opstrace/opstrace/go/pkg/graphql"
+)
+
+// Information about an exporter. Custom type which omits the tenant field.
+type ExporterInfo struct {
+	Name       string      `yaml:"name"`
+	Type       string      `yaml:"type,omitempty"`
+	Credential string      `yaml:"credential,omitempty"`
+	Config     interface{} `yaml:"config,omitempty"`
+	CreatedAt  string      `yaml:"created_at,omitempty"`
+	UpdatedAt  string      `yaml:"updated_at,omitempty"`
+}
+
+func listExporters(tenant string, w http.ResponseWriter, r *http.Request) {
+	resp, err := exporterAccess.List(tenant)
+	if err != nil {
+		log.Warnf("Listing exporters failed: %s", err)
+		http.Error(w, fmt.Sprintf("Listing exporters failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	log.Debugf("Listing %d exporters", len(resp.Exporter))
+
+	encoder := yaml.NewEncoder(w)
+	for _, exporter := range resp.Exporter {
+		configJSON := make(map[string]interface{})
+		err := json.Unmarshal([]byte(exporter.Config), &configJSON)
+		if err != nil {
+			// give up and pass-through the json
+			log.Warnf("Failed to decode JSON config for exporter %s (err: %s): %s", exporter.Name, err, exporter.Config)
+			configJSON["json"] = exporter.Config
+		}
+		encoder.Encode(ExporterInfo{
+			Name:       exporter.Name,
+			Type:       exporter.Type,
+			Credential: exporter.Credential,
+			Config:     configJSON,
+			CreatedAt:  exporter.CreatedAt,
+			UpdatedAt:  exporter.UpdatedAt,
+		})
+	}
+}
+
+// Exporter entry received from a POST request.
+type Exporter struct {
+	Name       string      `yaml:"name"`
+	Type       string      `yaml:"type"`
+	Credential string      `yaml:"credential,omitempty"`
+	Config     interface{} `yaml:"config"` // nested yaml
+}
+
+func listExporterTypes(tenant string) (map[string]string, error) {
+	// Collect map of existing name->type so that we can decide between insert vs update
+	existingTypes := make(map[string]string)
+	resp, err := exporterAccess.List(tenant)
+	if err != nil {
+		log.Warnf("Listing exporters failed: %s", err)
+		return nil, err
+	}
+	for _, exporter := range resp.Exporter {
+		existingTypes[exporter.Name] = exporter.Type
+	}
+	return existingTypes, nil
+}
+
+// Returns the JSON exporter value, whether the exporter already exists, and any validation error.
+func validateExporter(
+	tenant string,
+	existingTypes map[string]string,
+	yamlExporter Exporter,
+) (*graphql.Json, bool, error) {
+	if yamlExporter.Credential == "" {
+		if err := validateExporterTypes(yamlExporter.Type, nil); err != nil {
+			msg := fmt.Sprintf("Invalid exporter input %s: %s", yamlExporter.Name, err)
+			log.Debug(msg)
+			return nil, false, errors.New(msg)
+		}
+	} else {
+		// Check that the referenced credential exists and has a compatible type for this exporter.
+		// If the credential didn't exist, then the graphql insert would fail anyway due to a missing relation,
+		// but type mismatches are not validated by graphql.
+		cred, err := credentialAccess.Get(tenant, yamlExporter.Credential)
+		if err != nil {
+			return nil, false, fmt.Errorf(
+				"failed to read credential %s referenced in new exporter %s",
+				yamlExporter.Credential, yamlExporter.Name,
+			)
+		} else if cred == nil {
+			return nil, false, fmt.Errorf(
+				"missing credential %s referenced in exporter %s", yamlExporter.Credential, yamlExporter.Name,
+			)
+		} else if err := validateExporterTypes(yamlExporter.Type, &cred.CredentialByPk.Type); err != nil {
+			return nil, false, fmt.Errorf("invalid exporter input %s: %s", yamlExporter.Name, err)
+		}
+	}
+
+	var gconfig graphql.Json
+	switch yamlMap := yamlExporter.Config.(type) {
+	case map[interface{}]interface{}:
+		// Encode the parsed YAML config tree as JSON
+		convMap, err := recurseMapStringKeys(yamlMap)
+		if err != nil {
+			return nil, false, fmt.Errorf(
+				"Exporter '%s' config could not be encoded as JSON: %s", yamlExporter.Name, err,
+			)
+		}
+		json, err := json.Marshal(convMap)
+		if err != nil {
+			return nil, false, fmt.Errorf(
+				"Exporter '%s' config could not be encoded as JSON: %s", yamlExporter.Name, err,
+			)
+		}
+		gconfig = graphql.Json(json)
+	default:
+		return nil, false, fmt.Errorf(
+			"Exporter '%s' config is invalid (must be YAML map)", yamlExporter.Name,
+		)
+	}
+
+	var existingType string
+	var exists bool
+	if existingType, exists = existingTypes[yamlExporter.Name]; exists {
+		// Explicitly check and complain if the user tries to change the exporter type
+		if yamlExporter.Type != "" && existingType != yamlExporter.Type {
+			return nil, false, fmt.Errorf(
+				"Exporter '%s' type cannot be updated (current=%s, updated=%s)",
+				yamlExporter.Name, existingType, yamlExporter.Type,
+			)
+		}
+	}
+	return &gconfig, exists, nil
+}
+
+func writeExporters(tenant string, w http.ResponseWriter, r *http.Request) {
+	decoder := yaml.NewDecoder(r.Body)
+	// Return error for unrecognized or duplicate fields in the input
+	decoder.SetStrict(true)
+
+	// Collect map of existing name->type so that we can decide between insert vs update
+	existingTypes, err := listExporterTypes(tenant)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Listing exporters failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	now := nowTimestamp()
+
+	var inserts []graphql.ExporterInsertInput
+	var updates []graphql.UpdateExporterVariables
+	for {
+		var yamlExporter Exporter
+		if err := decoder.Decode(&yamlExporter); err != nil {
+			if err != io.EOF {
+				msg := fmt.Sprintf("Decoding exporter input at index=%d failed: %s", len(inserts)+len(updates), err)
+				log.Debug(msg)
+				http.Error(w, msg, http.StatusBadRequest)
+				return
+			}
+			break
+		}
+
+		var credential *graphql.String
+		if yamlExporter.Credential == "" {
+			credential = nil
+		} else {
+			gcredential := graphql.String(yamlExporter.Credential)
+			credential = &gcredential
+		}
+
+		gconfig, exists, err := validateExporter(tenant, existingTypes, yamlExporter)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		name := graphql.String(yamlExporter.Name)
+		if exists {
+			// TODO check for no-op updates and skip them (and avoid unnecessary changes to UpdatedAt)
+			updates = append(updates, graphql.UpdateExporterVariables{
+				Name:       name,
+				Credential: credential,
+				Config:     *gconfig,
+				UpdatedAt:  now,
+			})
+		} else {
+			expType := graphql.String(yamlExporter.Type)
+			inserts = append(inserts, graphql.ExporterInsertInput{
+				Name:       &name,
+				Type:       &expType,
+				Credential: credential,
+				Config:     gconfig,
+				CreatedAt:  &now,
+				UpdatedAt:  &now,
+			})
+		}
+	}
+
+	if len(inserts)+len(updates) == 0 {
+		log.Debugf("Writing exporters: No data provided")
+		http.Error(w, "Missing exporter YAML data in request body", http.StatusBadRequest)
+		return
+	}
+
+	log.Debugf("Writing exporters: %d insert, %d update", len(inserts), len(updates))
+
+	if len(inserts) != 0 {
+		if err := exporterAccess.Insert(tenant, inserts); err != nil {
+			log.Warnf("Insert: %d exporters failed: %s", len(inserts), err)
+			http.Error(w, fmt.Sprintf("Creating %d exporters failed: %s", len(inserts), err), http.StatusInternalServerError)
+			return
+		}
+	}
+	if len(updates) != 0 {
+		for _, update := range updates {
+			if err := exporterAccess.Update(tenant, update); err != nil {
+				log.Warnf("Update: Exporter %s/%s failed: %s", tenant, update.Name, err)
+				http.Error(w, fmt.Sprintf("Updating exporter %s failed: %s", update.Name, err), http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+}
+
+// Searches through the provided object tree for any maps with interface keys (from YAML),
+// and converts those keys to strings (required for JSON).
+func recurseMapStringKeys(in interface{}) (interface{}, error) {
+	switch inType := in.(type) {
+	case map[interface{}]interface{}: // yaml type for maps. needs string keys to work with JSON
+		// Ensure the map keys are converted, RECURSE into values to find nested maps
+		strMap := make(map[string]interface{})
+		for k, v := range inType {
+			switch kType := k.(type) {
+			case string:
+				conv, err := recurseMapStringKeys(v)
+				if err != nil {
+					return nil, err
+				}
+				strMap[kType] = conv
+			default:
+				return nil, errors.New("map is invalid (keys must be strings)")
+			}
+		}
+		return strMap, nil
+	case []interface{}:
+		// RECURSE into entries to convert any nested maps are converted
+		for i, v := range inType {
+			conv, err := recurseMapStringKeys(v)
+			if err != nil {
+				return nil, err
+			}
+			inType[i] = conv
+		}
+		return inType, nil
+	default:
+		return in, nil
+	}
+}
+
+func getExporter(tenant string, w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	log.Debugf("Getting exporter: %s", name)
+
+	resp, err := exporterAccess.Get(tenant, name)
+	if err != nil {
+		log.Warnf("Get: Exporter %s/%s failed: %s", tenant, name, err)
+		http.Error(w, fmt.Sprintf("Getting exporter failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+	if resp == nil {
+		log.Debugf("Get: Exporter %s/%s not found", tenant, name)
+		http.Error(w, fmt.Sprintf("Exporter not found: %s", name), http.StatusNotFound)
+		return
+	}
+
+	configJSON := make(map[string]interface{})
+	if err = json.Unmarshal([]byte(resp.ExporterByPk.Config), &configJSON); err != nil {
+		// give up and pass-through the json
+		log.Warnf(
+			"Failed to decode JSON config for exporter %s (err: %s): %s",
+			resp.ExporterByPk.Name, err, resp.ExporterByPk.Config,
+		)
+		configJSON["json"] = resp.ExporterByPk.Config
+	}
+
+	encoder := yaml.NewEncoder(w)
+	encoder.Encode(ExporterInfo{
+		Name:       resp.ExporterByPk.Name,
+		Type:       resp.ExporterByPk.Type,
+		Credential: resp.ExporterByPk.Credential,
+		Config:     configJSON,
+		CreatedAt:  resp.ExporterByPk.CreatedAt,
+		UpdatedAt:  resp.ExporterByPk.UpdatedAt,
+	})
+}
+
+func deleteExporter(tenant string, w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	log.Debugf("Deleting exporter: %s/%s", tenant, name)
+
+	resp, err := exporterAccess.Delete(tenant, name)
+	if err != nil {
+		log.Warnf("Delete: Exporter %s/%s failed: %s", tenant, name, err)
+		http.Error(w, fmt.Sprintf("Deleting exporter failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+	if resp == nil {
+		log.Debugf("Delete: Exporter %s/%s not found", tenant, name)
+		http.Error(w, fmt.Sprintf("Exporter not found: %s", name), http.StatusNotFound)
+		return
+	}
+
+	encoder := yaml.NewEncoder(w)
+	encoder.Encode(ExporterInfo{Name: resp.DeleteExporterByPk.Name})
+}

--- a/go/cmd/config/hasura_handler.go
+++ b/go/cmd/config/hasura_handler.go
@@ -1,0 +1,292 @@
+// Copyright 2021 Opstrace, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
+	"github.com/opstrace/opstrace/go/cmd/config/actions"
+)
+
+type HasuraHandler struct {
+	rulerURL        *url.URL
+	alertmanagerURL *url.URL
+	expectedSecret  string
+}
+
+func NewHasuraHandler(rulerURL *url.URL, alertmanagerURL *url.URL, expectedSecret string) *HasuraHandler {
+	return &HasuraHandler{
+		rulerURL,
+		alertmanagerURL,
+		expectedSecret,
+	}
+}
+
+func (h *HasuraHandler) handler(w http.ResponseWriter, r *http.Request) {
+	// FIRST: Check secret header is correct - ensure this is actually Hasura sending the request
+	if h.expectedSecret != "" {
+		gotSecret := r.Header.Get(actionSecretHeaderName)
+		if gotSecret != h.expectedSecret {
+			// This implies invalid request from hasura itself, so use plain HTTP error
+			writeGraphQLError(w, fmt.Sprintf("Missing or invalid %s", actionSecretHeaderName))
+			return
+		}
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		writeGraphQLError(w, "invalid payload")
+		return
+	}
+
+	actionName, err := actions.GetActionName(body)
+	if err != nil {
+		// This implies invalid request from hasura itself, so use plain HTTP error
+		writeGraphQLError(w, fmt.Sprintf("invalid/missing action name: %s", err.Error()))
+		return
+	}
+
+	// use action name to decide how to unmarshal the input
+	var data []byte
+	switch actionName {
+	case "getAlertmanager":
+		var request actions.GetAlertmanagerPayload
+		err = json.Unmarshal(body, &request)
+		if err != nil {
+			writeGraphQLError(w, "invalid request payload")
+			return
+		}
+
+		// see https://cortexmetrics.io/docs/api/#get-alertmanager-configuration
+		var response actions.Alertmanager
+		resp, err := h.alertmanagerQuery(request.Input.TenantID, "GET", "/api/v1/alerts", "")
+		if err != nil {
+			switch {
+			case resp == nil:
+				// Network failure
+				log.Warnf("Failed to retrieve alertmanager config for tenant %s: %s", request.Input.TenantID, err.Error())
+				response = actions.Alertmanager{
+					TenantID: request.Input.TenantID,
+					Config:   nil,
+					Online:   false,
+				}
+			case resp.StatusCode == 404:
+				// Query succeeded, config not assigned yet
+				emptyConfig := ""
+				response = actions.Alertmanager{
+					TenantID: request.Input.TenantID,
+					Config:   &emptyConfig,
+					Online:   true,
+				}
+			default:
+				// Other HTTP error (e.g. serialization/storage error)
+				log.Warnf("Error when retrieving alertmanager config for tenant %s: %s", request.Input.TenantID, err.Error())
+				response = actions.Alertmanager{
+					TenantID: request.Input.TenantID,
+					Config:   nil,
+					Online:   true,
+				}
+			}
+		} else {
+			// NOTE: Returning the full cortex content (with template_files and/or alertmanager_config fields)
+			respBody, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				writeGraphQLError(w, fmt.Sprintf("cortex response body failed: %s", err))
+				return
+			}
+			respBodyStr := string(respBody)
+			response = actions.Alertmanager{
+				TenantID: request.Input.TenantID,
+				Config:   &respBodyStr,
+				Online:   true,
+			}
+		}
+
+		data, err = json.Marshal(response)
+		if err != nil {
+			writeGraphQLError(w, fmt.Sprintf("serializing response body failed: %s", err))
+			return
+		}
+
+	case "updateAlertmanager":
+		var request actions.UpdateAlertmanagerPayload
+		err = json.Unmarshal(body, &request)
+		if err != nil {
+			writeGraphQLError(w, "invalid request payload")
+			return
+		}
+
+		// NOTE: Expecting the full cortex content (with template_files and/or alertmanager_config fields)
+		var response actions.AlertmanagerUpdateResponse
+		resp, err := h.alertmanagerQuery(request.Input.TenantID, "POST", "/api/v1/alerts", request.Input.Input.Config)
+		if err != nil {
+			var errType actions.ErrorType
+			var errMsg string
+			var errRaw string
+			switch {
+			case resp == nil:
+				// Network failure
+				errType = actions.ServiceOfflineType
+				errMsg = "Alertmanager query failed"
+				errRaw = err.Error()
+			case resp.StatusCode == http.StatusBadRequest:
+				// Query succeeded, config parsing/validation failed
+				errType = actions.ValidationFailedType
+				errMsg = "Alertmanager config validation failed"
+				errRaw = err.Error()
+			default:
+				// Other HTTP error (e.g. storage error)
+				errType = actions.ServiceErrorType
+				errMsg = "Error when updating Alertmanager config"
+				errRaw = err.Error()
+			}
+			response = actions.AlertmanagerUpdateResponse{
+				Success:          false,
+				ErrorType:        &errType,
+				ErrorMessage:     &errMsg,
+				ErrorRawResponse: &errRaw,
+			}
+		} else {
+			response = actions.AlertmanagerUpdateResponse{
+				Success: true,
+			}
+		}
+
+		data, err = json.Marshal(response)
+		if err != nil {
+			writeGraphQLError(w, fmt.Sprintf("serializing response body failed: %s", err))
+			return
+		}
+
+	case "validateCredential":
+		var request actions.ValidateCredentialPayload
+		err = json.Unmarshal(body, &request)
+		if err != nil {
+			writeGraphQLError(w, "invalid request payload")
+			return
+		}
+
+		data, err = json.Marshal(h.validateCredential(request))
+		if err != nil {
+			writeGraphQLError(w, fmt.Sprintf("serializing response body failed: %s", err))
+			return
+		}
+
+	case "validateExporter":
+		var request actions.ValidateExporterPayload
+		err = json.Unmarshal(body, &request)
+		if err != nil {
+			writeGraphQLError(w, "invalid request payload")
+			return
+		}
+
+		data, err = json.Marshal(h.validateExporter(request))
+		if err != nil {
+			writeGraphQLError(w, fmt.Sprintf("serializing response body failed: %s", err))
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
+func (h *HasuraHandler) validateCredential(request actions.ValidateCredentialPayload) actions.ValidateOutput {
+	existingTypes, err := listCredentialTypes(request.Input.TenantID)
+	if err != nil {
+		return actions.ValidateError(actions.ServiceErrorType, "listing credentials failed", err.Error())
+	}
+
+	var yamlCredential Credential
+	err = yaml.UnmarshalStrict([]byte(request.Input.Content), &yamlCredential)
+	if err != nil {
+		return actions.ValidateError(actions.ValidationFailedType, "decoding yaml content failed", err.Error())
+	}
+
+	_, _, err = validateCredential(existingTypes, yamlCredential)
+	if err != nil {
+		return actions.ValidateError(actions.ValidationFailedType, "config validation failed", err.Error())
+	}
+
+	return actions.ValidateOutput{
+		Success: true,
+	}
+}
+
+func (h *HasuraHandler) validateExporter(request actions.ValidateExporterPayload) actions.ValidateOutput {
+	existingTypes, err := listExporterTypes(request.Input.TenantID)
+	if err != nil {
+		return actions.ValidateError(actions.ServiceErrorType, "listing exporters failed", err.Error())
+	}
+
+	var yamlExporter Exporter
+	err = yaml.UnmarshalStrict([]byte(request.Input.Content), &yamlExporter)
+	if err != nil {
+		return actions.ValidateError(actions.ValidationFailedType, "decoding yaml content failed", err.Error())
+	}
+
+	_, _, err = validateExporter(request.Input.TenantID, existingTypes, yamlExporter)
+	if err != nil {
+		return actions.ValidateError(actions.ValidationFailedType, "config validation failed", err.Error())
+	}
+
+	return actions.ValidateOutput{
+		Success: true,
+	}
+}
+
+func (h *HasuraHandler) alertmanagerQuery(tenant, method, path, body string) (*http.Response, error) {
+	url := *h.alertmanagerURL
+	url.Path = path
+	req := http.Request{
+		Method: method,
+		URL:    &url,
+		Header: map[string][]string{
+			cortexTenantHeaderName: {tenant},
+		},
+	}
+	if body != "" {
+		req.Body = ioutil.NopCloser(strings.NewReader(body))
+	}
+	client := http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Do(&req)
+	if err != nil {
+		return nil, fmt.Errorf("cortex query failed: %s", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp, fmt.Errorf("cortex returned %d response", resp.StatusCode)
+	}
+	return resp, nil
+}
+
+func writeGraphQLError(w http.ResponseWriter, err string) {
+	errorObject := actions.GraphQLError{
+		Message: err,
+	}
+	errorBody, _ := json.Marshal(errorObject)
+	w.WriteHeader(http.StatusBadRequest)
+	w.Write(errorBody)
+}

--- a/go/cmd/config/hasura_handler.go
+++ b/go/cmd/config/hasura_handler.go
@@ -154,12 +154,26 @@ func (h *HasuraHandler) handler(w http.ResponseWriter, r *http.Request) {
 				// Query succeeded, config parsing/validation failed
 				errType = actions.ValidationFailedType
 				errMsg = "Alertmanager config validation failed"
-				errRaw = err.Error()
+				// Try to include original content returned by cortex
+				errRawBytes, err := ioutil.ReadAll(resp.Body)
+				if err != nil || len(errRawBytes) == 0 {
+					// Give up and just give generic "cortex returned <code> response"
+					errRaw = err.Error()
+				} else {
+					errRaw = string(errRawBytes)
+				}
 			default:
 				// Other HTTP error (e.g. storage error)
 				errType = actions.ServiceErrorType
 				errMsg = "Error when updating Alertmanager config"
-				errRaw = err.Error()
+				// Try to include original content returned by cortex
+				errRawBytes, err := ioutil.ReadAll(resp.Body)
+				if err != nil || len(errRawBytes) == 0 {
+					// Give up and just give generic "cortex returned <code> response"
+					errRaw = err.Error()
+				} else {
+					errRaw = string(errRawBytes)
+				}
 			}
 			response = actions.AlertmanagerUpdateResponse{
 				Success:          false,

--- a/go/cmd/config/main.go
+++ b/go/cmd/config/main.go
@@ -15,11 +15,7 @@
 package main
 
 import (
-	"encoding/json"
-	"errors"
 	"flag"
-	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -29,13 +25,15 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 
 	"github.com/opstrace/opstrace/go/pkg/authenticator"
 	"github.com/opstrace/opstrace/go/pkg/config"
 	"github.com/opstrace/opstrace/go/pkg/graphql"
 	"github.com/opstrace/opstrace/go/pkg/middleware"
 )
+
+const actionSecretHeaderName string = "X-Action-Secret"
+const cortexTenantHeaderName string = "X-Scope-OrgID"
 
 var (
 	credentialAccess         config.CredentialAccess
@@ -46,8 +44,10 @@ var (
 func main() {
 	var loglevel string
 	flag.StringVar(&loglevel, "loglevel", "info", "error|info|debug")
-	var listenAddress string
-	flag.StringVar(&listenAddress, "listen", "", "")
+	var configAddress string
+	flag.StringVar(&configAddress, "config", "", "")
+	var actionAddress string
+	flag.StringVar(&actionAddress, "action", "", "")
 
 	flag.BoolVar(&disableAPIAuthentication, "disable-api-authn", false, "")
 
@@ -59,10 +59,11 @@ func main() {
 	}
 	log.SetLevel(level)
 
-	if listenAddress == "" {
-		log.Fatalf("missing required --listen")
+	if configAddress == "" {
+		log.Fatalf("missing required --config")
 	}
-	log.Infof("listen address: %s", listenAddress)
+	log.Infof("config listen address: %s", configAddress)
+	log.Infof("action listen address: %s", actionAddress)
 
 	cortexDefault := "http://localhost"
 	rulerURL := envEndpointURL("CORTEX_RULER_ENDPOINT", &cortexDefault)
@@ -91,13 +92,36 @@ func main() {
 		}
 	}
 
+	if actionAddress != "" {
+		actionSecret := os.Getenv("HASURA_ACTION_SECRET")
+		if actionSecret == "" {
+			log.Fatalf("missing HASURA_ACTION_SECRET, required when -action is specified")
+		}
+
+		handler := NewHasuraHandler(rulerURL, alertmanagerURL, actionSecret)
+		// Not blocking on this one, but it will panic internally if there's a problem
+		go runActionListener(handler, actionAddress)
+	}
+
+	// Block on this one
+	runConfigListener(rulerURL, alertmanagerURL, configAddress)
+}
+
+func runActionListener(handler *HasuraHandler, actionAddress string) {
 	router := mux.NewRouter()
+	// Run metrics listener on this internal-only addresss instead of the main/ingress address.
 	router.Handle("/metrics", promhttp.Handler())
+	router.HandleFunc("/", handler.handler)
+
+	log.Fatalf("terminated action listener: %v", http.ListenAndServe(actionAddress, router))
+}
+
+func runConfigListener(rulerURL *url.URL, alertmanagerURL *url.URL, configAddress string) {
+	router := mux.NewRouter()
 
 	// Cortex config, see: https://github.com/cortexproject/cortex/blob/master/docs/api/_index.md
 
 	// Cortex Ruler config
-	cortexTenantHeader := "X-Scope-OrgID"
 	rulerPathReplacement := func(requrl *url.URL) string {
 		// Route /api/v1/ruler* requests to /ruler* on the backend
 		// Note: /api/v1/rules does not need to change on the way to the backend.
@@ -107,7 +131,7 @@ func main() {
 		return requrl.Path
 	}
 	rulerProxy := middleware.NewReverseProxyDynamicTenant(
-		cortexTenantHeader,
+		cortexTenantHeaderName,
 		rulerURL,
 		disableAPIAuthentication,
 	).ReplacePaths(rulerPathReplacement)
@@ -133,7 +157,7 @@ func main() {
 		return requrl.Path
 	}
 	alertmanagerProxy := middleware.NewReverseProxyDynamicTenant(
-		cortexTenantHeader,
+		cortexTenantHeaderName,
 		alertmanagerURL,
 		disableAPIAuthentication,
 	).ReplacePaths(alertmanagerPathReplacement)
@@ -147,7 +171,7 @@ func main() {
 	exporters := router.PathPrefix("/api/v1/exporters").Subrouter()
 	setupConfigAPI(exporters, listExporters, writeExporters, getExporter, deleteExporter)
 
-	log.Fatalf("terminated: %v", http.ListenAndServe(listenAddress, router))
+	log.Fatalf("terminated config listener: %v", http.ListenAndServe(configAddress, router))
 }
 
 func replacePathPrefix(url *url.URL, from string, to string) *string {
@@ -207,487 +231,6 @@ func getTenantThenCall(f func(string, http.ResponseWriter, *http.Request)) func(
 		}
 		f(tenantName, w, r)
 	}
-}
-
-// Information about a credential. Custom type which omits the tenant field.
-// This also given some extra protection that the value isn't disclosed,
-// even if it was mistakenly added to the underlying graphql interface.
-type CredentialInfo struct {
-	Name      string `yaml:"name"`
-	Type      string `yaml:"type,omitempty"`
-	CreatedAt string `yaml:"created_at,omitempty"`
-	UpdatedAt string `yaml:"updated_at,omitempty"`
-}
-
-func listCredentials(tenant string, w http.ResponseWriter, r *http.Request) {
-	resp, err := credentialAccess.List(tenant)
-	if err != nil {
-		log.Warnf("Listing credentials failed: %s", err)
-		http.Error(w, fmt.Sprintf("Listing credentials failed: %s", err), http.StatusInternalServerError)
-		return
-	}
-
-	log.Debugf("Listing %d credentials", len(resp.Credential))
-
-	encoder := yaml.NewEncoder(w)
-	for _, credential := range resp.Credential {
-		encoder.Encode(CredentialInfo{
-			Name:      credential.Name,
-			Type:      credential.Type,
-			CreatedAt: credential.CreatedAt,
-			UpdatedAt: credential.UpdatedAt,
-		})
-	}
-}
-
-// Full credential entry (with secret value) received from a POST request.
-type Credential struct {
-	Name  string      `yaml:"name"`
-	Type  string      `yaml:"type"`
-	Value interface{} `yaml:"value"` // nested yaml, or payload string, depending on type
-}
-
-func writeCredentials(tenant string, w http.ResponseWriter, r *http.Request) {
-	decoder := yaml.NewDecoder(r.Body)
-	// Return error for unrecognized or duplicate fields in the input
-	decoder.SetStrict(true)
-
-	// Collect list of existing names so that we can decide between insert vs update
-	existingTypes := make(map[string]string)
-	resp, err := credentialAccess.List(tenant)
-	if err != nil {
-		log.Warnf("Listing credentials failed: %s", err)
-		http.Error(w, fmt.Sprintf("Listing credentials failed: %s", err), http.StatusInternalServerError)
-		return
-	}
-	for _, credential := range resp.Credential {
-		existingTypes[credential.Name] = credential.Type
-	}
-
-	now := nowTimestamp()
-
-	var inserts []graphql.CredentialInsertInput
-	var updates []graphql.UpdateCredentialVariables
-	for {
-		var yamlCredential Credential
-		err := decoder.Decode(&yamlCredential)
-		if err != nil {
-			if err != io.EOF {
-				log.Debugf("Decoding credential input at index=%d failed: %s", len(inserts)+len(updates), err)
-				http.Error(w, fmt.Sprintf(
-					"Decoding credential input at index=%d failed: %s", len(inserts)+len(updates), err,
-				), http.StatusBadRequest)
-				return
-			}
-			break
-		}
-		name := graphql.String(yamlCredential.Name)
-		credType := graphql.String(yamlCredential.Type)
-		value, err := convertCredValue(yamlCredential.Name, yamlCredential.Type, yamlCredential.Value)
-		if err != nil {
-			log.Debugf("Invalid credential value format: %s", err)
-			http.Error(w, fmt.Sprintf("Credential format validation failed: %s", err), http.StatusBadRequest)
-			return
-		}
-		if existingType, ok := existingTypes[yamlCredential.Name]; ok {
-			// Explicitly check and complain if the user tries to change the credential type
-			if yamlCredential.Type != "" && existingType != yamlCredential.Type {
-				log.Debugf("Invalid credential '%s' type change", yamlCredential.Name)
-				http.Error(w, fmt.Sprintf(
-					"Credential '%s' type cannot be updated (current=%s, updated=%s)",
-					yamlCredential.Name, existingType, yamlCredential.Type,
-				), http.StatusBadRequest)
-				return
-			}
-			// TODO check for no-op updates and skip them (and avoid unnecessary changes to UpdatedAt)
-			updates = append(updates, graphql.UpdateCredentialVariables{
-				Name:      name,
-				Value:     *value,
-				UpdatedAt: now,
-			})
-		} else {
-			inserts = append(inserts, graphql.CredentialInsertInput{
-				Name:      &name,
-				Type:      &credType,
-				Value:     value,
-				CreatedAt: &now,
-				UpdatedAt: &now,
-			})
-		}
-	}
-
-	if len(inserts)+len(updates) == 0 {
-		log.Debugf("Writing credentials: No data provided")
-		http.Error(w, "Missing credential YAML data in request body", http.StatusBadRequest)
-		return
-	}
-
-	log.Debugf("Writing credentials: %d insert, %d update", len(inserts), len(updates))
-
-	if len(inserts) != 0 {
-		err := credentialAccess.Insert(tenant, inserts)
-		if err != nil {
-			log.Warnf("Insert: %d credentials failed: %s", len(inserts), err)
-			http.Error(w, fmt.Sprintf("Creating %d credentials failed: %s", len(inserts), err), http.StatusInternalServerError)
-			return
-		}
-	}
-	if len(updates) != 0 {
-		for _, update := range updates {
-			err := credentialAccess.Update(tenant, update)
-			if err != nil {
-				log.Warnf("Update: Credential %s failed: %s", update.Name, err)
-				http.Error(w, fmt.Sprintf("Updating credential %s failed: %s", update.Name, err), http.StatusInternalServerError)
-				return
-			}
-		}
-	}
-}
-
-type AWSCredentialValue struct {
-	AwsAccessKeyID     string `json:"AWS_ACCESS_KEY_ID"`
-	AwsSecretAccessKey string `json:"AWS_SECRET_ACCESS_KEY"`
-}
-
-func getCredential(tenant string, w http.ResponseWriter, r *http.Request) {
-	name := mux.Vars(r)["name"]
-	log.Debugf("Getting credential: %s", name)
-
-	resp, err := credentialAccess.Get(tenant, name)
-	if err != nil {
-		log.Warnf("Get: Credential %s failed: %s", name, err)
-		http.Error(w, fmt.Sprintf("Getting credential failed: %s", err), http.StatusInternalServerError)
-		return
-	}
-	if resp == nil {
-		log.Debugf("Get: Credential %s not found", name)
-		http.Error(w, fmt.Sprintf("Credential not found: %s", name), http.StatusNotFound)
-		return
-	}
-
-	encoder := yaml.NewEncoder(w)
-	encoder.Encode(CredentialInfo{
-		Name:      resp.CredentialByPk.Name,
-		Type:      resp.CredentialByPk.Type,
-		CreatedAt: resp.CredentialByPk.CreatedAt,
-		UpdatedAt: resp.CredentialByPk.UpdatedAt,
-	})
-}
-
-func deleteCredential(tenant string, w http.ResponseWriter, r *http.Request) {
-	name := mux.Vars(r)["name"]
-	log.Debugf("Deleting credential: %s", name)
-
-	resp, err := credentialAccess.Delete(tenant, name)
-	if err != nil {
-		log.Warnf("Delete: Credential %s failed: %s", name, err)
-		http.Error(w, fmt.Sprintf("Deleting credential failed: %s", err), http.StatusInternalServerError)
-		return
-	}
-	if resp == nil {
-		log.Debugf("Delete: Credential %s not found", name)
-		http.Error(w, fmt.Sprintf("Credential not found: %s", name), http.StatusNotFound)
-		return
-	}
-
-	encoder := yaml.NewEncoder(w)
-	encoder.Encode(CredentialInfo{Name: resp.DeleteCredentialByPk.Name})
-}
-
-// Information about an exporter. Custom type which omits the tenant field.
-type ExporterInfo struct {
-	Name       string      `yaml:"name"`
-	Type       string      `yaml:"type,omitempty"`
-	Credential string      `yaml:"credential,omitempty"`
-	Config     interface{} `yaml:"config,omitempty"`
-	CreatedAt  string      `yaml:"created_at,omitempty"`
-	UpdatedAt  string      `yaml:"updated_at,omitempty"`
-}
-
-func listExporters(tenant string, w http.ResponseWriter, r *http.Request) {
-	resp, err := exporterAccess.List(tenant)
-	if err != nil {
-		log.Warnf("Listing exporters failed: %s", err)
-		http.Error(w, fmt.Sprintf("Listing exporters failed: %s", err), http.StatusInternalServerError)
-		return
-	}
-
-	log.Debugf("Listing %d exporters", len(resp.Exporter))
-
-	encoder := yaml.NewEncoder(w)
-	for _, exporter := range resp.Exporter {
-		configJSON := make(map[string]interface{})
-		err := json.Unmarshal([]byte(exporter.Config), &configJSON)
-		if err != nil {
-			// give up and pass-through the json
-			log.Warnf("Failed to decode JSON config for exporter %s (err: %s): %s", exporter.Name, err, exporter.Config)
-			configJSON["json"] = exporter.Config
-		}
-		encoder.Encode(ExporterInfo{
-			Name:       exporter.Name,
-			Type:       exporter.Type,
-			Credential: exporter.Credential,
-			Config:     configJSON,
-			CreatedAt:  exporter.CreatedAt,
-			UpdatedAt:  exporter.UpdatedAt,
-		})
-	}
-}
-
-// Exporter entry received from a POST request.
-type Exporter struct {
-	Name       string      `yaml:"name"`
-	Type       string      `yaml:"type"`
-	Credential string      `yaml:"credential,omitempty"`
-	Config     interface{} `yaml:"config"` // nested yaml
-}
-
-func writeExporters(tenant string, w http.ResponseWriter, r *http.Request) {
-	decoder := yaml.NewDecoder(r.Body)
-	// Return error for unrecognized or duplicate fields in the input
-	decoder.SetStrict(true)
-
-	// Collect list of existing names so that we can decide between insert vs update
-	existingTypes := make(map[string]string)
-	resp, err := exporterAccess.List(tenant)
-	if err != nil {
-		log.Warnf("Listing exporters failed: %s", err)
-		http.Error(w, fmt.Sprintf("Listing exporters failed: %s", err), http.StatusInternalServerError)
-		return
-	}
-	for _, exporter := range resp.Exporter {
-		existingTypes[exporter.Name] = exporter.Type
-	}
-
-	now := nowTimestamp()
-
-	var inserts []graphql.ExporterInsertInput
-	var updates []graphql.UpdateExporterVariables
-	for {
-		var yamlExporter Exporter
-		if err := decoder.Decode(&yamlExporter); err != nil {
-			if err != io.EOF {
-				msg := fmt.Sprintf("Decoding exporter input at index=%d failed: %s", len(inserts)+len(updates), err)
-				log.Debug(msg)
-				http.Error(w, msg, http.StatusBadRequest)
-				return
-			}
-			break
-		}
-
-		var credential *graphql.String
-		if yamlExporter.Credential == "" {
-			if err := validateExporterTypes(yamlExporter.Type, nil); err != nil {
-				msg := fmt.Sprintf("Invalid exporter input %s: %s", yamlExporter.Name, err)
-				log.Debug(msg)
-				http.Error(w, msg, http.StatusBadRequest)
-				return
-			}
-			credential = nil
-		} else {
-			// Check that the credential exists and a compatible type.
-			// If the credential didn't exist, then the graphql insert would fail anyway due to a missing relation,
-			// but type mismatches are not validated by graphql.
-			cred, err := credentialAccess.Get(tenant, yamlExporter.Credential)
-			if err != nil {
-				msg := fmt.Sprintf(
-					"Failed to read credential %s referenced in new exporter %s",
-					yamlExporter.Credential, yamlExporter.Name,
-				)
-				log.Debug(msg)
-				http.Error(w, msg, http.StatusBadRequest)
-				return
-			} else if cred == nil {
-				msg := fmt.Sprintf("Missing credential %s referenced in exporter %s", yamlExporter.Credential, yamlExporter.Name)
-				log.Debug(msg)
-				http.Error(w, msg, http.StatusBadRequest)
-				return
-			} else if err := validateExporterTypes(yamlExporter.Type, &cred.CredentialByPk.Type); err != nil {
-				msg := fmt.Sprintf("Invalid exporter input %s: %s", yamlExporter.Name, err)
-				log.Debug(msg)
-				http.Error(w, msg, http.StatusBadRequest)
-				return
-			}
-			gcredential := graphql.String(yamlExporter.Credential)
-			credential = &gcredential
-		}
-
-		var gconfig graphql.Json
-		switch yamlMap := yamlExporter.Config.(type) {
-		case map[interface{}]interface{}:
-			// Encode the parsed YAML config tree as JSON
-			convMap, err := recurseMapStringKeys(yamlMap)
-			if err != nil {
-				log.Debugf("Unable to serialize exporter '%s' config as JSON: %s", yamlExporter.Name, err)
-				http.Error(w, fmt.Sprintf(
-					"Exporter '%s' config could not be encoded as JSON: %s", yamlExporter.Name, err,
-				), http.StatusBadRequest)
-				return
-			}
-			json, err := json.Marshal(convMap)
-			if err != nil {
-				log.Debugf("Unable to serialize exporter '%s' config as JSON: %s", yamlExporter.Name, err)
-				http.Error(w, fmt.Sprintf(
-					"Exporter '%s' config could not be encoded as JSON: %s", yamlExporter.Name, err,
-				), http.StatusBadRequest)
-				return
-			}
-			gconfig = graphql.Json(json)
-		default:
-			log.Debugf("Invalid exporter '%s' config type", yamlExporter.Name)
-			http.Error(w, fmt.Sprintf(
-				"Exporter '%s' config is invalid (must be YAML map)", yamlExporter.Name,
-			), http.StatusBadRequest)
-			return
-		}
-
-		name := graphql.String(yamlExporter.Name)
-		if existingType, ok := existingTypes[yamlExporter.Name]; ok {
-			// Explicitly check and complain if the user tries to change the exporter type
-			if yamlExporter.Type != "" && existingType != yamlExporter.Type {
-				log.Debugf("Invalid exporter '%s' type change", yamlExporter.Name)
-				http.Error(w, fmt.Sprintf(
-					"Exporter '%s' type cannot be updated (current=%s, updated=%s)",
-					yamlExporter.Name, existingType, yamlExporter.Type,
-				), http.StatusBadRequest)
-				return
-			}
-			// TODO check for no-op updates and skip them (and avoid unnecessary changes to UpdatedAt)
-			updates = append(updates, graphql.UpdateExporterVariables{
-				Name:       name,
-				Credential: credential,
-				Config:     gconfig,
-				UpdatedAt:  now,
-			})
-		} else {
-			expType := graphql.String(yamlExporter.Type)
-			inserts = append(inserts, graphql.ExporterInsertInput{
-				Name:       &name,
-				Type:       &expType,
-				Credential: credential,
-				Config:     &gconfig,
-				CreatedAt:  &now,
-				UpdatedAt:  &now,
-			})
-		}
-	}
-
-	if len(inserts)+len(updates) == 0 {
-		log.Debugf("Writing exporters: No data provided")
-		http.Error(w, "Missing exporter YAML data in request body", http.StatusBadRequest)
-		return
-	}
-
-	log.Debugf("Writing exporters: %d insert, %d update", len(inserts), len(updates))
-
-	if len(inserts) != 0 {
-		if err := exporterAccess.Insert(tenant, inserts); err != nil {
-			log.Warnf("Insert: %d exporters failed: %s", len(inserts), err)
-			http.Error(w, fmt.Sprintf("Creating %d exporters failed: %s", len(inserts), err), http.StatusInternalServerError)
-			return
-		}
-	}
-	if len(updates) != 0 {
-		for _, update := range updates {
-			if err := exporterAccess.Update(tenant, update); err != nil {
-				log.Warnf("Update: Exporter %s/%s failed: %s", tenant, update.Name, err)
-				http.Error(w, fmt.Sprintf("Updating exporter %s failed: %s", update.Name, err), http.StatusInternalServerError)
-				return
-			}
-		}
-	}
-}
-
-// Searches through the provided object tree for any maps with interface keys (from YAML),
-// and converts those keys to strings (required for JSON).
-func recurseMapStringKeys(in interface{}) (interface{}, error) {
-	switch inType := in.(type) {
-	case map[interface{}]interface{}: // yaml type for maps. needs string keys to work with JSON
-		// Ensure the map keys are converted, RECURSE into values to find nested maps
-		strMap := make(map[string]interface{})
-		for k, v := range inType {
-			switch kType := k.(type) {
-			case string:
-				conv, err := recurseMapStringKeys(v)
-				if err != nil {
-					return nil, err
-				}
-				strMap[kType] = conv
-			default:
-				return nil, errors.New("map is invalid (keys must be strings)")
-			}
-		}
-		return strMap, nil
-	case []interface{}:
-		// RECURSE into entries to convert any nested maps are converted
-		for i, v := range inType {
-			conv, err := recurseMapStringKeys(v)
-			if err != nil {
-				return nil, err
-			}
-			inType[i] = conv
-		}
-		return inType, nil
-	default:
-		return in, nil
-	}
-}
-
-func getExporter(tenant string, w http.ResponseWriter, r *http.Request) {
-	name := mux.Vars(r)["name"]
-	log.Debugf("Getting exporter: %s", name)
-
-	resp, err := exporterAccess.Get(tenant, name)
-	if err != nil {
-		log.Warnf("Get: Exporter %s/%s failed: %s", tenant, name, err)
-		http.Error(w, fmt.Sprintf("Getting exporter failed: %s", err), http.StatusInternalServerError)
-		return
-	}
-	if resp == nil {
-		log.Debugf("Get: Exporter %s/%s not found", tenant, name)
-		http.Error(w, fmt.Sprintf("Exporter not found: %s", name), http.StatusNotFound)
-		return
-	}
-
-	configJSON := make(map[string]interface{})
-	if err = json.Unmarshal([]byte(resp.ExporterByPk.Config), &configJSON); err != nil {
-		// give up and pass-through the json
-		log.Warnf(
-			"Failed to decode JSON config for exporter %s (err: %s): %s",
-			resp.ExporterByPk.Name, err, resp.ExporterByPk.Config,
-		)
-		configJSON["json"] = resp.ExporterByPk.Config
-	}
-
-	encoder := yaml.NewEncoder(w)
-	encoder.Encode(ExporterInfo{
-		Name:       resp.ExporterByPk.Name,
-		Type:       resp.ExporterByPk.Type,
-		Credential: resp.ExporterByPk.Credential,
-		Config:     configJSON,
-		CreatedAt:  resp.ExporterByPk.CreatedAt,
-		UpdatedAt:  resp.ExporterByPk.UpdatedAt,
-	})
-}
-
-func deleteExporter(tenant string, w http.ResponseWriter, r *http.Request) {
-	name := mux.Vars(r)["name"]
-	log.Debugf("Deleting exporter: %s/%s", tenant, name)
-
-	resp, err := exporterAccess.Delete(tenant, name)
-	if err != nil {
-		log.Warnf("Delete: Exporter %s/%s failed: %s", tenant, name, err)
-		http.Error(w, fmt.Sprintf("Deleting exporter failed: %s", err), http.StatusInternalServerError)
-		return
-	}
-	if resp == nil {
-		log.Debugf("Delete: Exporter %s/%s not found", tenant, name)
-		http.Error(w, fmt.Sprintf("Exporter not found: %s", name), http.StatusNotFound)
-		return
-	}
-
-	encoder := yaml.NewEncoder(w)
-	encoder.Encode(ExporterInfo{Name: resp.DeleteExporterByPk.Name})
 }
 
 // Returns a string representation of the current time in UTC, suitable for passing to Hasura as a timestamptz

--- a/packages/app/docker-compose.yml
+++ b/packages/app/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       ACTION_CONFIG_API_SECRET: myactionsecret
   # Config service for Hasura Actions that call into it
   config:
-    image: opstrace/config-api:1992483a5a20f01e818ad5d806015b8cbf84a54b
+    image: opstrace/config-api:64546e387bb9469f61fde1ca45ca726daada4417
     command:
       - -config=:8081
       - -action=:8082

--- a/packages/app/docker-compose.yml
+++ b/packages/app/docker-compose.yml
@@ -28,9 +28,9 @@ services:
   graphql:
     image: hasura/graphql-engine:v1.3.3.cli-migrations-v2
     ports:
-      - "8080:8080"
+      - 8080:8080
     depends_on:
-      - "postgres"
+      - postgres
     restart: always
     volumes:
       - ./migrations:/hasura-migrations
@@ -47,22 +47,49 @@ services:
       HASURA_GRAPHQL_ADMIN_SECRET: myadminsecret
       ## https://hasura.io/docs/1.0/graphql/core/guides/telemetry.html
       HASURA_GRAPHQL_ENABLE_TELEMETRY: "false"
+      ## Referenced by Hasura actions.yaml
+      ACTION_CONFIG_API_ENDPOINT: http://config:8082
+      ACTION_CONFIG_API_SECRET: myactionsecret
+  # Config service for Hasura Actions that call into it
+  config:
+    image: opstrace/config-api:1992483a5a20f01e818ad5d806015b8cbf84a54b
+    command:
+      - -config=:8081
+      - -action=:8082
+      - -disable-api-authn
+    ports:
+      - 8081:8081
+      - 8082:8082
+    environment:
+      GRAPHQL_ENDPOINT: http://graphql:8080
+      HASURA_GRAPHQL_ADMIN_SECRET: myadminsecret
+      HASURA_ACTION_SECRET: myactionsecret
+      # Some config APIs talk to cortex. Can optionally run a kubectl port-forward to test them:
+      #  kubectl port-forward -n cortex --address=0.0.0.0 deployment/ruler 9000:80
+      CORTEX_RULER_ENDPOINT: http://172.17.0.1:9000 # docker0 virtual interface ip
+      #  kubectl port-forward -n cortex --address=0.0.0.0 deployment/alertmanager 9001:80
+      CORTEX_ALERTMANAGER_ENDPOINT: http://172.17.0.1:9001 # docker0 virtual interface ip
   # S3 service for storing modules
   s3:
     image: minio/minio
     ports:
-      - "9000:9000"
+      - 9000:9000
     environment:
       MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
     command: server /data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test:
+        - CMD
+        - curl
+        - -f
+        - http://minio:9000/minio/health/live
       interval: 30s
       timeout: 20s
       retries: 3
     logging:
       driver: none
+  # Used by app directly
   redis:
     image: bitnami/redis:6.0.9
     environment:

--- a/packages/app/metadata/actions.graphql
+++ b/packages/app/metadata/actions.graphql
@@ -1,2 +1,69 @@
+# Common types
 
+enum ErrorType {
+  # Failed to communicate with the underlying service
+  SERVICE_OFFLINE,
+  # Other error returned by the underlying service
+  SERVICE_ERROR,
+  # The underlying service rejected the configuration
+  VALIDATION_FAILED,
+}
 
+# getAlertmanager
+
+type Query {
+  getAlertmanager(tenant_id: String!): Alertmanager
+}
+
+type Alertmanager {
+  tenant_id: String!
+  config: String
+  online: Boolean!
+}
+
+# updateAlertmanager
+
+type Mutation {
+  updateAlertmanager(tenant_id: String!, input: AlertmanagerInput): AlertmanagerUpdateResponse
+}
+
+input AlertmanagerInput {
+  config: String!
+}
+
+# NOTE: Unable to use nested response types in Hasura Actions, so using a flat response for now.
+#       See also https://github.com/hasura/graphql-engine/issues/4796
+# TODO: Is this fixed by switching to Remote Schemas instead?
+type AlertmanagerUpdateResponse {
+  # False if the update failed for any reason, see error_* fields for details
+  success: Boolean!
+
+  # Must be set if success=false
+  error_type: ErrorType
+  # Must be set if success=false
+  error_message: String
+  # Optional if success=false, message returned by underlying service
+  error_raw_response: String
+}
+
+# validateCredential/validateExporter
+
+type Mutation {
+  validateCredential(tenant_id: String!, content: String!): ValidateOutput
+}
+
+type Mutation {
+  validateExporter(tenant_id: String!, content: String!): ValidateOutput
+}
+
+type ValidateOutput {
+  # False if the validation failed for any reason, see error_* fields for details
+  success: Boolean!
+
+  # Must be set if success=false
+  error_type: ErrorType
+  # Must be set if success=false
+  error_message: String
+  # Optional if success=false, message returned by underlying service
+  error_raw_response: String
+}

--- a/packages/app/metadata/actions.yaml
+++ b/packages/app/metadata/actions.yaml
@@ -1,6 +1,47 @@
-actions: []
+actions:
+- name: getAlertmanager
+  definition:
+    kind: synchronous
+    handler: '{{ACTION_CONFIG_API_ENDPOINT}}'
+    headers:
+    - name: X-Action-Secret
+      value_from_env: ACTION_CONFIG_API_SECRET
+  permissions:
+  - role: user_admin
+- name: updateAlertmanager
+  definition:
+    kind: synchronous
+    handler: '{{ACTION_CONFIG_API_ENDPOINT}}'
+    headers:
+    - name: X-Action-Secret
+      value_from_env: ACTION_CONFIG_API_SECRET
+  permissions:
+  - role: user_admin
+- name: validateCredential
+  definition:
+    kind: synchronous
+    handler: '{{ACTION_CONFIG_API_ENDPOINT}}'
+    headers:
+    - name: X-Action-Secret
+      value_from_env: ACTION_CONFIG_API_SECRET
+  permissions:
+  - role: user_admin
+- name: validateExporter
+  definition:
+    kind: synchronous
+    handler: '{{ACTION_CONFIG_API_ENDPOINT}}'
+    headers:
+    - name: X-Action-Secret
+      value_from_env: ACTION_CONFIG_API_SECRET
+  permissions:
+  - role: user_admin
 custom_types:
-  enums: []
-  input_objects: []
-  objects: []
+  enums:
+  - name: ErrorType
+  input_objects:
+  - name: AlertmanagerInput
+  objects:
+  - name: Alertmanager
+  - name: AlertmanagerUpdateResponse
+  - name: ValidateOutput
   scalars: []

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -2,7 +2,7 @@
   "addonResizer": "k8s.gcr.io/addon-resizer:1.8.4",
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.2.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
-  "configApi": "opstrace/config-api:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
+  "configApi": "opstrace/config-api:1992483a5a20f01e818ad5d806015b8cbf84a54b",
   "cortex": "cortexproject/cortex:v1.8.0-rc.0",
   "cortexApiProxy": "opstrace/cortex-api:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
   "ddApi": "opstrace/ddapi:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -23,8 +23,8 @@
   "nodeExporter": "quay.io/prometheus/node-exporter:v0.18.1",
   "prometheusAdapter": "quay.io/coreos/k8s-prometheus-adapter-amd64:v0.4.1",
   "prometheusOperator": "quay.io/prometheus-operator/prometheus-operator:v0.42.1",
-  "graphqlEngine": "opstrace/graphql:c09a69df189c78baad21401baa08e00f",
-  "app": "opstrace/app:c09a69df189c78baad21401baa08e00f",
+  "graphqlEngine": "opstrace/graphql:c50456d6e19ba4b5fd16779b38fd1d1d",
+  "app": "opstrace/app:c50456d6e19ba4b5fd16779b38fd1d1d",
   "redis": "bitnami/redis:6.0.9",
   "postgresClient": "tmaier/postgresql-client@sha256:3702d3bff09b18e1d173cdf5887d6e4fea5feac0a521becf4a27559992e44ff3"
 }

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -2,7 +2,7 @@
   "addonResizer": "k8s.gcr.io/addon-resizer:1.8.4",
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.2.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
-  "configApi": "opstrace/config-api:1992483a5a20f01e818ad5d806015b8cbf84a54b",
+  "configApi": "opstrace/config-api:64546e387bb9469f61fde1ca45ca726daada4417",
   "cortex": "cortexproject/cortex:v1.8.0-rc.0",
   "cortexApiProxy": "opstrace/cortex-api:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
   "ddApi": "opstrace/ddapi:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",

--- a/packages/controller/src/dbSDK.ts
+++ b/packages/controller/src/dbSDK.ts
@@ -1751,7 +1751,7 @@ export type Mutation_RootDelete_UserArgs = {
 
 /** mutation root */
 export type Mutation_RootDelete_User_By_PkArgs = {
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 };
 
 /** mutation root */
@@ -1761,7 +1761,7 @@ export type Mutation_RootDelete_User_PreferenceArgs = {
 
 /** mutation root */
 export type Mutation_RootDelete_User_Preference_By_PkArgs = {
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 };
 
 /** mutation root */
@@ -2252,7 +2252,7 @@ export type Query_RootUser_AggregateArgs = {
 
 /** query root */
 export type Query_RootUser_By_PkArgs = {
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 };
 
 /** query root */
@@ -2275,7 +2275,7 @@ export type Query_RootUser_Preference_AggregateArgs = {
 
 /** query root */
 export type Query_RootUser_Preference_By_PkArgs = {
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 };
 
 /** subscription root */
@@ -2524,7 +2524,7 @@ export type Subscription_RootUser_AggregateArgs = {
 
 /** subscription root */
 export type Subscription_RootUser_By_PkArgs = {
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 };
 
 /** subscription root */
@@ -2547,7 +2547,7 @@ export type Subscription_RootUser_Preference_AggregateArgs = {
 
 /** subscription root */
 export type Subscription_RootUser_Preference_By_PkArgs = {
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 };
 
 /** columns and relationships of "tenant" */
@@ -2782,34 +2782,12 @@ export type User = {
   avatar?: Maybe<Scalars["String"]>;
   created_at: Scalars["timestamptz"];
   email: Scalars["String"];
-  opaque_id: Scalars["uuid"];
+  id: Scalars["uuid"];
   /** An object relationship */
   preference?: Maybe<User_Preference>;
   role: Scalars["String"];
   session_last_updated?: Maybe<Scalars["timestamptz"]>;
-  /** An array relationship */
-  user_preferences: Array<User_Preference>;
-  /** An aggregated array relationship */
-  user_preferences_aggregate: User_Preference_Aggregate;
   username: Scalars["String"];
-};
-
-/** columns and relationships of "user" */
-export type UserUser_PreferencesArgs = {
-  distinct_on?: Maybe<Array<User_Preference_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
-  order_by?: Maybe<Array<User_Preference_Order_By>>;
-  where?: Maybe<User_Preference_Bool_Exp>;
-};
-
-/** columns and relationships of "user" */
-export type UserUser_Preferences_AggregateArgs = {
-  distinct_on?: Maybe<Array<User_Preference_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
-  order_by?: Maybe<Array<User_Preference_Order_By>>;
-  where?: Maybe<User_Preference_Bool_Exp>;
 };
 
 /** aggregated selection of "user" */
@@ -2853,16 +2831,19 @@ export type User_Bool_Exp = {
   avatar?: Maybe<String_Comparison_Exp>;
   created_at?: Maybe<Timestamptz_Comparison_Exp>;
   email?: Maybe<String_Comparison_Exp>;
-  opaque_id?: Maybe<Uuid_Comparison_Exp>;
+  id?: Maybe<Uuid_Comparison_Exp>;
   preference?: Maybe<User_Preference_Bool_Exp>;
   role?: Maybe<String_Comparison_Exp>;
   session_last_updated?: Maybe<Timestamptz_Comparison_Exp>;
-  user_preferences?: Maybe<User_Preference_Bool_Exp>;
   username?: Maybe<String_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "user" */
 export enum User_Constraint {
+  /** unique or primary key constraint */
+  UserEmailKey = "user_email_key",
+  /** unique or primary key constraint */
+  UserIdKey = "user_id_key",
   /** unique or primary key constraint */
   UserPkey = "user_pkey"
 }
@@ -2873,11 +2854,10 @@ export type User_Insert_Input = {
   avatar?: Maybe<Scalars["String"]>;
   created_at?: Maybe<Scalars["timestamptz"]>;
   email?: Maybe<Scalars["String"]>;
-  opaque_id?: Maybe<Scalars["uuid"]>;
+  id?: Maybe<Scalars["uuid"]>;
   preference?: Maybe<User_Preference_Obj_Rel_Insert_Input>;
   role?: Maybe<Scalars["String"]>;
   session_last_updated?: Maybe<Scalars["timestamptz"]>;
-  user_preferences?: Maybe<User_Preference_Arr_Rel_Insert_Input>;
   username?: Maybe<Scalars["String"]>;
 };
 
@@ -2886,7 +2866,7 @@ export type User_Max_Fields = {
   avatar?: Maybe<Scalars["String"]>;
   created_at?: Maybe<Scalars["timestamptz"]>;
   email?: Maybe<Scalars["String"]>;
-  opaque_id?: Maybe<Scalars["uuid"]>;
+  id?: Maybe<Scalars["uuid"]>;
   role?: Maybe<Scalars["String"]>;
   session_last_updated?: Maybe<Scalars["timestamptz"]>;
   username?: Maybe<Scalars["String"]>;
@@ -2897,7 +2877,7 @@ export type User_Max_Order_By = {
   avatar?: Maybe<Order_By>;
   created_at?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
-  opaque_id?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
   role?: Maybe<Order_By>;
   session_last_updated?: Maybe<Order_By>;
   username?: Maybe<Order_By>;
@@ -2908,7 +2888,7 @@ export type User_Min_Fields = {
   avatar?: Maybe<Scalars["String"]>;
   created_at?: Maybe<Scalars["timestamptz"]>;
   email?: Maybe<Scalars["String"]>;
-  opaque_id?: Maybe<Scalars["uuid"]>;
+  id?: Maybe<Scalars["uuid"]>;
   role?: Maybe<Scalars["String"]>;
   session_last_updated?: Maybe<Scalars["timestamptz"]>;
   username?: Maybe<Scalars["String"]>;
@@ -2919,7 +2899,7 @@ export type User_Min_Order_By = {
   avatar?: Maybe<Order_By>;
   created_at?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
-  opaque_id?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
   role?: Maybe<Order_By>;
   session_last_updated?: Maybe<Order_By>;
   username?: Maybe<Order_By>;
@@ -2952,25 +2932,25 @@ export type User_Order_By = {
   avatar?: Maybe<Order_By>;
   created_at?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
-  opaque_id?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
   preference?: Maybe<User_Preference_Order_By>;
   role?: Maybe<Order_By>;
   session_last_updated?: Maybe<Order_By>;
-  user_preferences_aggregate?: Maybe<User_Preference_Aggregate_Order_By>;
   username?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "user" */
 export type User_Pk_Columns_Input = {
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 };
 
 /** columns and relationships of "user_preference" */
 export type User_Preference = {
   dark_mode: Scalars["Boolean"];
-  email: Scalars["String"];
+  id: Scalars["uuid"];
   /** An object relationship */
-  user: User;
+  user?: Maybe<User>;
+  user_id?: Maybe<Scalars["uuid"]>;
 };
 
 /** aggregated selection of "user_preference" */
@@ -3011,41 +2991,51 @@ export type User_Preference_Bool_Exp = {
   _not?: Maybe<User_Preference_Bool_Exp>;
   _or?: Maybe<Array<Maybe<User_Preference_Bool_Exp>>>;
   dark_mode?: Maybe<Boolean_Comparison_Exp>;
-  email?: Maybe<String_Comparison_Exp>;
+  id?: Maybe<Uuid_Comparison_Exp>;
   user?: Maybe<User_Bool_Exp>;
+  user_id?: Maybe<Uuid_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "user_preference" */
 export enum User_Preference_Constraint {
   /** unique or primary key constraint */
-  UserPreferencePkey = "user_preference_pkey"
+  UserPreferenceIdKey = "user_preference_id_key",
+  /** unique or primary key constraint */
+  UserPreferencePkey = "user_preference_pkey",
+  /** unique or primary key constraint */
+  UserPreferenceUserIdKey = "user_preference_user_id_key"
 }
 
 /** input type for inserting data into table "user_preference" */
 export type User_Preference_Insert_Input = {
   dark_mode?: Maybe<Scalars["Boolean"]>;
-  email?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["uuid"]>;
   user?: Maybe<User_Obj_Rel_Insert_Input>;
+  user_id?: Maybe<Scalars["uuid"]>;
 };
 
 /** aggregate max on columns */
 export type User_Preference_Max_Fields = {
-  email?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["uuid"]>;
+  user_id?: Maybe<Scalars["uuid"]>;
 };
 
 /** order by max() on columns of table "user_preference" */
 export type User_Preference_Max_Order_By = {
-  email?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
+  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type User_Preference_Min_Fields = {
-  email?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["uuid"]>;
+  user_id?: Maybe<Scalars["uuid"]>;
 };
 
 /** order by min() on columns of table "user_preference" */
 export type User_Preference_Min_Order_By = {
-  email?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
+  user_id?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "user_preference" */
@@ -3072,13 +3062,14 @@ export type User_Preference_On_Conflict = {
 /** ordering options when selecting data from "user_preference" */
 export type User_Preference_Order_By = {
   dark_mode?: Maybe<Order_By>;
-  email?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
   user?: Maybe<User_Order_By>;
+  user_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "user_preference" */
 export type User_Preference_Pk_Columns_Input = {
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 };
 
 /** select columns of table "user_preference" */
@@ -3086,13 +3077,16 @@ export enum User_Preference_Select_Column {
   /** column name */
   DarkMode = "dark_mode",
   /** column name */
-  Email = "email"
+  Id = "id",
+  /** column name */
+  UserId = "user_id"
 }
 
 /** input type for updating data in table "user_preference" */
 export type User_Preference_Set_Input = {
   dark_mode?: Maybe<Scalars["Boolean"]>;
-  email?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["uuid"]>;
+  user_id?: Maybe<Scalars["uuid"]>;
 };
 
 /** update columns of table "user_preference" */
@@ -3100,7 +3094,9 @@ export enum User_Preference_Update_Column {
   /** column name */
   DarkMode = "dark_mode",
   /** column name */
-  Email = "email"
+  Id = "id",
+  /** column name */
+  UserId = "user_id"
 }
 
 /** select columns of table "user" */
@@ -3114,7 +3110,7 @@ export enum User_Select_Column {
   /** column name */
   Email = "email",
   /** column name */
-  OpaqueId = "opaque_id",
+  Id = "id",
   /** column name */
   Role = "role",
   /** column name */
@@ -3129,7 +3125,7 @@ export type User_Set_Input = {
   avatar?: Maybe<Scalars["String"]>;
   created_at?: Maybe<Scalars["timestamptz"]>;
   email?: Maybe<Scalars["String"]>;
-  opaque_id?: Maybe<Scalars["uuid"]>;
+  id?: Maybe<Scalars["uuid"]>;
   role?: Maybe<Scalars["String"]>;
   session_last_updated?: Maybe<Scalars["timestamptz"]>;
   username?: Maybe<Scalars["String"]>;
@@ -3146,7 +3142,7 @@ export enum User_Update_Column {
   /** column name */
   Email = "email",
   /** column name */
-  OpaqueId = "opaque_id",
+  Id = "id",
   /** column name */
   Role = "role",
   /** column name */
@@ -3566,51 +3562,81 @@ export type CreateUserMutationVariables = Exact<{
 }>;
 
 export type CreateUserMutation = {
-  insert_user_preference_one?: Maybe<Pick<User_Preference, "email">>;
+  insert_user_preference_one?: Maybe<{
+    user?: Maybe<
+      Pick<
+        User,
+        | "id"
+        | "email"
+        | "username"
+        | "role"
+        | "active"
+        | "avatar"
+        | "created_at"
+        | "session_last_updated"
+      >
+    >;
+  }>;
 };
 
-export type DeleteUserMutationVariables = Exact<{
+export type DeactivateUserMutationVariables = Exact<{
+  id: Scalars["uuid"];
+}>;
+
+export type DeactivateUserMutation = {
+  update_user_by_pk?: Maybe<Pick<User, "id" | "active">>;
+};
+
+export type GetActiveUserForAuthQueryVariables = Exact<{
   email: Scalars["String"];
 }>;
 
-export type DeleteUserMutation = {
-  update_user_by_pk?: Maybe<Pick<User, "email" | "opaque_id">>;
+export type GetActiveUserForAuthQuery = {
+  user: Array<Pick<User, "id" | "email" | "avatar" | "username" | "active">>;
+  active_user_count: {
+    aggregate?: Maybe<Pick<User_Aggregate_Fields, "count">>;
+  };
 };
 
 export type GetCurrentUserQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetCurrentUserQuery = {
   user: Array<
-    Pick<User, "email" | "avatar" | "username" | "active"> & {
+    Pick<User, "id" | "email" | "avatar" | "username" | "active"> & {
       preference?: Maybe<Pick<User_Preference, "dark_mode">>;
     }
   >;
 };
 
 export type GetUserQueryVariables = Exact<{
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 }>;
 
 export type GetUserQuery = {
-  user_by_pk?: Maybe<Pick<User, "email" | "avatar" | "username" | "active">>;
-  user_aggregate: { aggregate?: Maybe<Pick<User_Aggregate_Fields, "count">> };
+  user_by_pk?: Maybe<
+    Pick<User, "id" | "email" | "avatar" | "username" | "active"> & {
+      preference?: Maybe<Pick<User_Preference, "dark_mode">>;
+    }
+  >;
 };
 
 export type ReactivateUserMutationVariables = Exact<{
-  email: Scalars["String"];
+  id: Scalars["uuid"];
 }>;
 
 export type ReactivateUserMutation = {
-  update_user_by_pk?: Maybe<Pick<User, "email" | "opaque_id">>;
+  update_user_by_pk?: Maybe<Pick<User, "id" | "active">>;
 };
 
 export type SetDarkModeMutationVariables = Exact<{
-  email: Scalars["String"];
-  darkMode: Scalars["Boolean"];
+  user_id: Scalars["uuid"];
+  dark_mode?: Maybe<Scalars["Boolean"]>;
 }>;
 
 export type SetDarkModeMutation = {
-  update_user_preference_by_pk?: Maybe<Pick<User_Preference, "dark_mode">>;
+  update_user_preference?: Maybe<{
+    returning: Array<Pick<User_Preference, "dark_mode">>;
+  }>;
 };
 
 export type SubscribeToUserListSubscriptionVariables = Exact<{
@@ -3621,27 +3647,38 @@ export type SubscribeToUserListSubscription = {
   user: Array<
     Pick<
       User,
-      | "role"
+      | "id"
       | "email"
-      | "avatar"
-      | "active"
       | "username"
       | "session_last_updated"
+      | "role"
+      | "active"
+      | "avatar"
       | "created_at"
-      | "opaque_id"
     > & { preference?: Maybe<Pick<User_Preference, "dark_mode">> }
   >;
 };
 
 export type UpdateUserMutationVariables = Exact<{
+  id: Scalars["uuid"];
   email: Scalars["String"];
-  username: Scalars["String"];
   avatar: Scalars["String"];
-  time: Scalars["timestamptz"];
+  username: Scalars["String"];
 }>;
 
 export type UpdateUserMutation = {
-  update_user_by_pk?: Maybe<Pick<User, "email" | "opaque_id">>;
+  update_user_by_pk?: Maybe<
+    Pick<User, "id" | "email" | "username" | "avatar" | "session_last_updated">
+  >;
+};
+
+export type UpdateUserSessionMutationVariables = Exact<{
+  id: Scalars["uuid"];
+  timestamp: Scalars["timestamptz"];
+}>;
+
+export type UpdateUserSessionMutation = {
+  update_user_by_pk?: Maybe<Pick<User, "id" | "session_last_updated">>;
 };
 
 export const CreateBranchDocument = gql`
@@ -4117,24 +4154,61 @@ export const CreateUserDocument = gql`
     insert_user_preference_one(
       object: {
         dark_mode: true
-        user: { data: { avatar: $avatar, email: $email, username: $username } }
+        user: {
+          data: {
+            email: $email
+            username: $username
+            active: true
+            avatar: $avatar
+          }
+        }
       }
     ) {
-      email
+      user {
+        id
+        email
+        username
+        role
+        active
+        avatar
+        created_at
+        session_last_updated
+      }
     }
   }
 `;
-export const DeleteUserDocument = gql`
-  mutation DeleteUser($email: String!) {
-    update_user_by_pk(_set: { active: false }, pk_columns: { email: $email }) {
+export const DeactivateUserDocument = gql`
+  mutation DeactivateUser($id: uuid!) {
+    update_user_by_pk(_set: { active: false }, pk_columns: { id: $id }) {
+      id
+      active
+    }
+  }
+`;
+export const GetActiveUserForAuthDocument = gql`
+  query GetActiveUserForAuth($email: String!) {
+    user(
+      where: { email: { _eq: $email }, active: { _eq: true } }
+      limit: 1
+      order_by: { created_at: asc }
+    ) {
+      id
       email
-      opaque_id
+      avatar
+      username
+      active
+    }
+    active_user_count: user_aggregate(where: { active: { _eq: true } }) {
+      aggregate {
+        count
+      }
     }
   }
 `;
 export const GetCurrentUserDocument = gql`
   query GetCurrentUser {
     user {
+      id
       email
       avatar
       username
@@ -4146,73 +4220,83 @@ export const GetCurrentUserDocument = gql`
   }
 `;
 export const GetUserDocument = gql`
-  query GetUser($email: String!) {
-    user_by_pk(email: $email) {
+  query GetUser($id: uuid!) {
+    user_by_pk(id: $id) {
+      id
       email
       avatar
       username
       active
-    }
-    user_aggregate(where: { active: { _eq: true } }) {
-      aggregate {
-        count
-      }
-    }
-  }
-`;
-export const ReactivateUserDocument = gql`
-  mutation ReactivateUser($email: String!) {
-    update_user_by_pk(_set: { active: true }, pk_columns: { email: $email }) {
-      email
-      opaque_id
-    }
-  }
-`;
-export const SetDarkModeDocument = gql`
-  mutation SetDarkMode($email: String!, $darkMode: Boolean!) {
-    update_user_preference_by_pk(
-      pk_columns: { email: $email }
-      _set: { dark_mode: $darkMode }
-    ) {
-      dark_mode
-    }
-  }
-`;
-export const SubscribeToUserListDocument = gql`
-  subscription SubscribeToUserList {
-    user {
-      role
-      email
-      avatar
-      active
-      username
-      session_last_updated
-      created_at
-      opaque_id
       preference {
         dark_mode
       }
     }
   }
 `;
+export const ReactivateUserDocument = gql`
+  mutation ReactivateUser($id: uuid!) {
+    update_user_by_pk(pk_columns: { id: $id }, _set: { active: true }) {
+      id
+      active
+    }
+  }
+`;
+export const SetDarkModeDocument = gql`
+  mutation SetDarkMode($user_id: uuid!, $dark_mode: Boolean = true) {
+    update_user_preference(
+      where: { user_id: { _eq: $user_id } }
+      _set: { dark_mode: $dark_mode }
+    ) {
+      returning {
+        dark_mode
+      }
+    }
+  }
+`;
+export const SubscribeToUserListDocument = gql`
+  subscription SubscribeToUserList {
+    user {
+      id
+      email
+      username
+      session_last_updated
+      role
+      active
+      avatar
+      preference {
+        dark_mode
+      }
+      created_at
+    }
+  }
+`;
 export const UpdateUserDocument = gql`
   mutation UpdateUser(
+    $id: uuid!
     $email: String!
-    $username: String!
     $avatar: String!
-    $time: timestamptz!
+    $username: String!
   ) {
     update_user_by_pk(
-      _set: {
-        username: $username
-        email: $email
-        avatar: $avatar
-        session_last_updated: $time
-      }
-      pk_columns: { email: $email }
+      pk_columns: { id: $id }
+      _set: { email: $email, avatar: $avatar, username: $username }
     ) {
+      id
       email
-      opaque_id
+      username
+      avatar
+      session_last_updated
+    }
+  }
+`;
+export const UpdateUserSessionDocument = gql`
+  mutation UpdateUserSession($id: uuid!, $timestamp: timestamptz!) {
+    update_user_by_pk(
+      pk_columns: { id: $id }
+      _set: { session_last_updated: $timestamp }
+    ) {
+      id
+      session_last_updated
     }
   }
 `;
@@ -4741,18 +4825,34 @@ export function getSdk(
         )
       );
     },
-    DeleteUser(
-      variables: DeleteUserMutationVariables
+    DeactivateUser(
+      variables: DeactivateUserMutationVariables
     ): Promise<{
-      data?: DeleteUserMutation | undefined;
+      data?: DeactivateUserMutation | undefined;
       extensions?: any;
       headers: Headers;
       status: number;
       errors?: GraphQLError[] | undefined;
     }> {
       return withWrapper(() =>
-        client.rawRequest<DeleteUserMutation>(
-          print(DeleteUserDocument),
+        client.rawRequest<DeactivateUserMutation>(
+          print(DeactivateUserDocument),
+          variables
+        )
+      );
+    },
+    GetActiveUserForAuth(
+      variables: GetActiveUserForAuthQueryVariables
+    ): Promise<{
+      data?: GetActiveUserForAuthQuery | undefined;
+      extensions?: any;
+      headers: Headers;
+      status: number;
+      errors?: GraphQLError[] | undefined;
+    }> {
+      return withWrapper(() =>
+        client.rawRequest<GetActiveUserForAuthQuery>(
+          print(GetActiveUserForAuthDocument),
           variables
         )
       );
@@ -4846,6 +4946,22 @@ export function getSdk(
       return withWrapper(() =>
         client.rawRequest<UpdateUserMutation>(
           print(UpdateUserDocument),
+          variables
+        )
+      );
+    },
+    UpdateUserSession(
+      variables: UpdateUserSessionMutationVariables
+    ): Promise<{
+      data?: UpdateUserSessionMutation | undefined;
+      extensions?: any;
+      headers: Headers;
+      status: number;
+      errors?: GraphQLError[] | undefined;
+    }> {
+      return withWrapper(() =>
+        client.rawRequest<UpdateUserSessionMutation>(
+          print(UpdateUserSessionDocument),
           variables
         )
       );

--- a/packages/controller/src/resources/app/api.ts
+++ b/packages/controller/src/resources/app/api.ts
@@ -44,7 +44,7 @@ export function OpstraceAPIResources(
     httpGet: {
       path: "/metrics",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      port: 8080 as any,
+      port: "action" as any,
       scheme: "HTTP"
     },
     timeoutSeconds: 1,
@@ -53,7 +53,10 @@ export function OpstraceAPIResources(
     failureThreshold: 3
   };
 
-  const commandArgs = ["-listen=:8080"];
+  const commandArgs = [
+    "-config=:8080",
+    "-action=:8081",
+  ];
   const commandEnv: V1EnvVar[] = [
     {
       name: "GRAPHQL_ENDPOINT",
@@ -73,6 +76,15 @@ export function OpstraceAPIResources(
         secretKeyRef: {
           name: "hasura-admin-secret",
           key: "HASURA_ADMIN_SECRET"
+        }
+      }
+    },
+    {
+      name: "HASURA_ACTION_SECRET",
+      valueFrom: {
+        secretKeyRef: {
+          name: "hasura-action-secret",
+          key: "HASURA_CONFIG_API_SECRET"
         }
       }
     }
@@ -128,6 +140,11 @@ export function OpstraceAPIResources(
                       name: "http",
                       protocol: "TCP",
                       containerPort: 8080
+                    },
+                    {
+                      name: "action",
+                      protocol: "TCP",
+                      containerPort: 8081
                     }
                   ],
                   readinessProbe: probeConfig,
@@ -163,7 +180,14 @@ export function OpstraceAPIResources(
               port: 8080,
               protocol: "TCP",
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              targetPort: 8080 as any
+              targetPort: "http" as any
+            },
+            {
+              name: "action",
+              port: 8081,
+              protocol: "TCP",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              targetPort: "action" as any
             }
           ],
           selector: {
@@ -193,7 +217,7 @@ export function OpstraceAPIResources(
             {
               interval: "30s",
               path: "/metrics",
-              port: "http"
+              port: "action"
             }
           ],
           jobLabel: "job",


### PR DESCRIPTION
This should allow the UI to communicate with other things in the cluster, with Hasura/GraphQL acting as the common portal.

- Adds plumbing to Hasura for querying the config-api service, using a shared secret to authenticate Hasura to the service
- Implements calls for getting/setting the per-tenant alertmanager configuration in cortex
- Implements calls for validating credential/exporter configs

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
