### PR TITLE
config: Update config-api readme, update validateCredential/validateExporter

### DIFF
--- a/go/cmd/config/README.md
+++ b/go/cmd/config/README.md
@@ -1,10 +1,11 @@
 # HTTP Config API service
 
-Serves HTTP CRUD interfaces for editing credentials and exporters, possibly other things in the future.
+Serves HTTP interfaces for the following operations:
+1. Serving Hasura Actions for getting and setting Alertmanager configurations in cortex
+2. Serving Hasura Actions for validating credentials and exporters so that the UI can check validity before sending them to Hasura directly
+3. Reading/updating/creating/deleting Credentials and Exporters via Hasura from an HTTP client like curl
 
-```
-[HTTP clients] -http-> [THIS SERVICE] -graphql-> [Hasura/GraphQL] -postgres-> [PostgreSQL]
-```
+The Hasura Actions support is on a separate port from the "main" config API port. This ensures that Hasura Actions support is kept private while the config API is exposed to the internet via an Ingress.
 
 ## Test environment
 
@@ -30,13 +31,123 @@ HASURA_GRAPHQL_ADMIN_SECRET=myadminsecret \
   --disable-api-authn
 ```
 
+## Hasura Actions: getAlertmanager/updateAlertmanager
+
+These actions allow the UI to retrieve and store Alertmanager configurations in Cortex by talking to Hasura, rather than needing to talk to Cortex directly.
+
+### Example usage
+
+Here is an example GraphQL flow communicating with Hasura, which then routes the queries to the config service:
+
+Getting config that doesn't exist yet
+```
+query MyQuery {
+  getAlertmanager(tenant_id: "dev") {
+    config
+    online
+    tenant_id
+  }
+}
+
+{
+  "data": {
+    "getAlertmanager": {
+      "config": "",
+      "online": true,
+      "tenant_id": "dev"
+    }
+  }
+}
+```
+
+Setting invalid config
+```
+mutation MyMutation {
+  updateAlertmanager(tenant_id: "dev", input: {config: "this is very yaml"}) {
+    error_message
+    error_raw_response
+    success
+    error_type
+  }
+}
+
+{
+  "data": {
+    "updateAlertmanager": {
+      "error_message": "Alertmanager config validation failed",
+      "error_raw_response": "error marshalling YAML Alertmanager config: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `this is...` into alertmanager.UserConfig\n",
+      "success": false,
+      "error_type": "VALIDATION_FAILED"
+    }
+  }
+}
+```
+
+Setting valid config
+```
+mutation MyMutation {
+  updateAlertmanager(tenant_id: "dev", input: {config: "alertmanager_config: |\n  global:\n    smtp_smarthost: 'localhost:25'\n    smtp_from: 'youraddress@example.org'\n  route:\n    receiver: example-email\n  receivers:\n    - name: example-email\n      email_configs:\n      - to: 'youraddress@example.org'\n"}) {
+    error_message
+    error_raw_response
+    success
+    error_type
+  }
+}
+
+{
+  "data": {
+    "updateAlertmanager": {
+      "error_message": null,
+      "error_raw_response": null,
+      "success": true,
+      "error_type": null
+    }
+  }
+}
+```
+
+Getting config that was just set (note: isn't exact string match, cortex seems to insert blank `template_files` at root)
+```
+query MyQuery {
+  getAlertmanager(tenant_id: "dev") {
+    config
+    online
+    tenant_id
+  }
+}
+
+{
+  "data": {
+    "getAlertmanager": {
+      "config": "template_files: {}\nalertmanager_config: |\n  global:\n    smtp_smarthost: 'localhost:25'\n    smtp_from: 'youraddress@example.org'\n  route:\n    receiver: example-email\n  receivers:\n    - name: example-email\n      email_configs:\n      - to: 'youraddress@example.org'\n",
+      "online": true,
+      "tenant_id": "dev"
+    }
+  }
+}
+```
+
+## Hasura Actions: validateCredential/validateExporter
+
+These actions allow the UI to execute the validation code implemented in the Go service. This is effectively "honor system" and just avoids the UI needing to reimplement validation in the UI directly. Once validation has passed, the UI can then update the Credential or Exporter via Hasura directly.
+
+The HTTP endpoints `/api/v1/credentials` and `/api/v1/exporters` run the same validation internally, and will reject `POST` submissions that do not pass validation.
+
+## HTTP Credentials and Exporters APIs
+
+This interface allows a customer to manually update objects in Hasura using curl or another HTTP client. Meanwhile the UI talks to Hasura directly.
+
+```
+[HTTP clients] -http-> [THIS SERVICE] -graphql-> [Hasura/GraphQL] -postgres-> [PostgreSQL]
+```
+
 In normal use, the config service extracts the tenant name from the bearer token that must be provided with requests. When instead testing with `--disable-api-authn`, the service requires that we provide the tenant name using an `X-Scope-OrgID` header, as provided in the examples below.
 
-## Example usage
+### Example usage
 
 The credential and exporter APIs are nearly identical, but with different payloads.
 
-### Credentials
+#### Credentials
 
 Upsert (will fail if types are unsupported or invalid format)
 ```
@@ -70,7 +181,7 @@ Delete foo
 curl -v -H "X-Scope-OrgID: tenant-foo" -XDELETE http://127.0.0.1:8989/api/v1/credentials/foo
 ```
 
-### Exporters
+#### Exporters
 
 Upsert (will fail if referenced `credential`s aren't present or are incompatible types)
 ```

--- a/go/cmd/config/README.md
+++ b/go/cmd/config/README.md
@@ -31,13 +31,25 @@ HASURA_GRAPHQL_ADMIN_SECRET=myadminsecret \
   --disable-api-authn
 ```
 
-## Hasura Actions: getAlertmanager/updateAlertmanager
+The `config` and `action` arguments are for two different ports:
+- The `config` port is meant to be visible to the public internet via an Ingress and is meant for users to directly apply configuration to the system. This port requires authentication via bearer token. The config service extracts the tenant name from the signed bearer token.
+- The `action` port is for direct access by Hasura via Hasura Actions. This port is not exposed to the internet and is only meant for direct queries from the `graphql` Hasura pod. This port also requires authentication via a random token in an `X-Action-Secret` header. This secret token is shared between the `graphql` pod and the `config-api` pod.
 
-These actions allow the UI to retrieve and store Alertmanager configurations in Cortex by talking to Hasura, rather than needing to talk to Cortex directly.
+## Alertmanager configs
 
-### Example usage
+The config-api service supports fetching and setting the alertmanager configuration for a given tenant. This support is implemented in two places:
+- The `action` port implements Hasura Actions named `getAlertmanager` and `updateAlertmanager`. These are ultimately for the UI to display configuration for setting and getting the per-tenant alertmanager configurations. The UI queries Hasura, which then routes the queries to the config-api service via Hasura Actions.
+- The public `config` port meanwhile implements HTTP passthrough endpoints that forward directly to Cortex. The config-api service extracts the tenant name from the signed bearer token, then provides the tenant name to Cortex via a `X-Scope-OrgID` header.
+
+In both cases, the config-api service is acting as a frontend to Cortex, which internally stores the alertmanager and ruler configs in a configured S3 or GCS bucket.
+
+### Alertmanager Hasura Actions: getAlertmanager/updateAlertmanager
+
+These actions allow the UI to retrieve and store Alertmanager configurations in Cortex by just talking to Hasura, rather than needing to talk to Cortex directly.
 
 Here is an example GraphQL flow communicating with Hasura, which then routes the queries to the config service:
+
+#### Alertmanager GraphQL examples
 
 Getting config that doesn't exist yet
 ```
@@ -127,27 +139,96 @@ query MyQuery {
 }
 ```
 
-## Hasura Actions: validateCredential/validateExporter
+### Alertmanager HTTP endpoints
 
-These actions allow the UI to execute the validation code implemented in the Go service. This is effectively "honor system" and just avoids the UI needing to reimplement validation in the UI directly. Once validation has passed, the UI can then update the Credential or Exporter via Hasura directly.
+The `config-api` service directly exposes `/api/v1/alerts`, `/api/v1/alertmanager` and `/api/v1/multitenant_alertmanager` endpoints, which pass-through to the equivalent Cortex endpoints. Requests must include the bearer token. The tenant name is extracted from the signed bearer token in the request, and provided to Cortex via an `X-Scope-OrgID` header. The most useful endpoint is `/api/v1/alerts`, which allows setting the alertmanager config. The others are mainly for providing system status.
 
-The HTTP endpoints `/api/v1/credentials` and `/api/v1/exporters` run the same validation internally, and will reject `POST` submissions that do not pass validation.
+#### Alertmanager HTTP examples
 
-## HTTP Credentials and Exporters APIs
+Setting config via `/api/v1/alerts` using `dev` token file. See [Cortex API reference](https://cortexmetrics.io/docs/api/#set-alertmanager-configuration).
+```
+$ cat valid-test.yaml
+alertmanager_config: |
+  route:
+    receiver: 'default-receiver'
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    group_by: [cluster, alertname]
+  receivers:
+    - name: default-receiver
+
+$ curl -k -H "Authorization: Bearer $(cat tenant-api-token-dev)" --data-binary @valid-test.yaml https://MYCLUSTER.opstrace.io/api/v1/alerts
+```
+
+Fetching config via `/api/v1/alerts` using `dev` token file. See [Cortex API reference](https://cortexmetrics.io/docs/api/#get-alertmanager-configuration).
+```
+$ curl -k -H "Authorization: Bearer $(cat tenant-api-token-dev)" https://MYCLUSTER.opstrace.io/api/v1/alerts
+template_files: {}
+alertmanager_config: |
+  route:
+    receiver: 'default-receiver'
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    group_by: [cluster, alertname]
+  receivers:
+    - name: default-receiver
+```
+
+## Alert rules
+
+The `config-api` service directly exposes `/api/v1/rules` and `/api/v1/ruler` endpoints, which pass-through to the equivalent Cortex endpoints. Unlike with the Alertmanager configs which can be controlled either via GraphQL/Hasura Actions or via HTTP, alert rules are only accessible via these HTTP passthrough endpoints. The endpoints forward directly to Cortex, with the tenant name extracted from the signed bearer token in the request, and provided to Cortex via an `X-Scope-OrgID` header. The most useful endpoints are under `/api/v1/rules`, which allows configuring alerting rules. Meanwhile `/api/v1/ruler` is mainly for providing system status.
+
+#### Alert rules HTTP examples
+
+Setting an alert rule group named `bar` under namespace `foo` via `/api/v1/rules/foo`. See [Cortex API reference](https://cortexmetrics.io/docs/api/#set-rule-group) for this and other available calls under `/api/v1/rules`.
+```
+echo '
+name: bar
+rules:
+- alert: DeadMansSwitch
+  annotations:
+      description: "This is a DeadMansSwitch meant to ensure that the entire Alerting pipeline is functional. See https://deadmanssnitch.com/snitches/e759300835/"
+      summary: "Alerting DeadMansSwitch"
+  expr: vector(1)
+  labels:
+      severity: warning
+
+- alert: InstanceDown
+  expr: up == 0
+  for: 7m
+  labels:
+      severity: warning
+  annotations:
+      summary: "Instance {{ $labels.instance }} down"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 7 minutes."
+' | curl -v -k -H "Authorization: Bearer $(cat tenant-api-token-dev)" -H "Content-Type: application/yaml" --data-binary @- https://MYCLUSTER.opstrace.io/api/v1/rules/foo
+```
+
+## Cloud credentials and Exporter configs
+
+Cloud credentials and exporter configs are stored directly in Hasura/Postgres. The `config-api` service provides HTTP endpoints for users to configure their credentials and exporters, while also providing Hasura endpoints for validating them.
+
+### Credential and Exporter Hasura Actions: validateCredential/validateExporter
+
+These actions allow the UI to execute the validation code implemented in the Go service. This is effectively "honor system" and just avoids the UI needing to reimplement validation in the UI directly. Once validation has passed, the UI can then update the validated Credential or Exporter in question via Hasura directly.
+
+The HTTP endpoints described in the next section perform the same validation internally, and will reject `POST` submissions that do not pass validation.
+
+NOTE: As of this writing (March 2021) these endpoints are not yet fully functional and are still subject to change pending the UI starting to need them. As such we do not document any examples here since they are likely to change anyway.
+
+### Credential and Exporter HTTP endpoints
 
 This interface allows a customer to manually update objects in Hasura using curl or another HTTP client. Meanwhile the UI talks to Hasura directly.
 
 ```
-[HTTP clients] -http-> [THIS SERVICE] -graphql-> [Hasura/GraphQL] -postgres-> [PostgreSQL]
+[HTTP clients] -http-> [config-api service] -graphql-> [Hasura/GraphQL] -postgres-> [PostgreSQL]
 ```
 
 In normal use, the config service extracts the tenant name from the bearer token that must be provided with requests. When instead testing with `--disable-api-authn`, the service requires that we provide the tenant name using an `X-Scope-OrgID` header, as provided in the examples below.
 
-### Example usage
-
-The credential and exporter APIs are nearly identical, but with different payloads.
-
-#### Credentials
+#### Credential HTTP examples
 
 Upsert (will fail if types are unsupported or invalid format)
 ```
@@ -181,7 +262,7 @@ Delete foo
 curl -v -H "X-Scope-OrgID: tenant-foo" -XDELETE http://127.0.0.1:8989/api/v1/credentials/foo
 ```
 
-#### Exporters
+#### Exporter HTTP examples
 
 Upsert (will fail if referenced `credential`s aren't present or are incompatible types)
 ```

--- a/go/cmd/config/actions/types.go
+++ b/go/cmd/config/actions/types.go
@@ -61,12 +61,17 @@ type UpdateAlertmanagerArgs struct {
 
 type ValidateCredentialArgs struct {
 	TenantID string `json:"tenant_id"`
-	Content  string `json:"content"`
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Value    string `json:"value"`
 }
 
 type ValidateExporterArgs struct {
-	TenantID string `json:"tenant_id"`
-	Content  string `json:"content"`
+	TenantID   string  `json:"tenant_id"`
+	Name       string  `json:"name"`
+	Type       string  `json:"type"`
+	Config     string  `json:"config"`
+	Credential *string `json:"credential,omitempty"`
 }
 
 type GetAlertmanagerPayload struct {

--- a/go/cmd/config/config_types.go
+++ b/go/cmd/config/config_types.go
@@ -39,12 +39,12 @@ type AWSCredentialValue struct {
 	AwsSecretAccessKey string `json:"AWS_SECRET_ACCESS_KEY"`
 }
 
-// Accepts and validates a credential YAML value for writing to graphql as JSON.
+// Accepts and validates a credential value for writing to graphql as JSON.
 func convertCredValue(credName string, credType string, credValue interface{}) (*graphql.Json, error) {
 	switch credType {
 	case "aws-key":
-		// Expect regular YAML fields (not as a nested string)
-		errfmt := "expected %s credential '%s' value to contain YAML string fields: " +
+		// Expect regular object fields (not as a nested string)
+		errfmt := "expected %s credential '%s' value to contain string fields: " +
 			"AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (%s)"
 		switch v := credValue.(type) {
 		case map[interface{}]interface{}:
@@ -71,7 +71,7 @@ func convertCredValue(credName string, credType string, credValue interface{}) (
 			gjson := graphql.Json(json)
 			return &gjson, nil
 		default:
-			return nil, fmt.Errorf(errfmt, credType, credName, "expected a map")
+			return nil, fmt.Errorf(errfmt, credType, credName, fmt.Sprintf("expected a map, got %s", v))
 		}
 	case "gcp-service-account":
 		// Expect string containing a valid JSON payload
@@ -83,7 +83,7 @@ func convertCredValue(credName string, credType string, credValue interface{}) (
 			gjson := graphql.Json(v)
 			return &gjson, nil
 		default:
-			return nil, fmt.Errorf("expected %s credential '%s' value to be a JSON string", credType, credName)
+			return nil, fmt.Errorf("expected %s credential '%s' value to be a JSON string, got %s", credType, credName, v)
 		}
 	default:
 		keys := make([]string, len(validCredentialTypes))

--- a/packages/app/docker-compose.yml
+++ b/packages/app/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       ACTION_CONFIG_API_SECRET: myactionsecret
   # Config service for Hasura Actions that call into it
   config:
-    image: opstrace/config-api:64546e387bb9469f61fde1ca45ca726daada4417
+    image: opstrace/config-api:b0f4503b501762fefd542afa43a4e975ed844d79
     command:
       - -config=:8081
       - -action=:8082

--- a/packages/app/metadata/actions.graphql
+++ b/packages/app/metadata/actions.graphql
@@ -48,12 +48,12 @@ type AlertmanagerUpdateResponse {
 
 # validateCredential/validateExporter
 
-type Mutation {
-  validateCredential(tenant_id: String!, content: String!): ValidateOutput
+type Query {
+  validateCredential(tenant_id: String!, name: String!, type: String!, value: json!): ValidateOutput
 }
 
-type Mutation {
-  validateExporter(tenant_id: String!, content: String!): ValidateOutput
+type Query {
+  validateExporter(tenant_id: String!, name: String!, type: String!, config: json!, credential: String!): ValidateOutput
 }
 
 type ValidateOutput {

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -2,7 +2,7 @@
   "addonResizer": "k8s.gcr.io/addon-resizer:1.8.4",
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.2.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
-  "configApi": "opstrace/config-api:64546e387bb9469f61fde1ca45ca726daada4417",
+  "configApi": "opstrace/config-api:b0f4503b501762fefd542afa43a4e975ed844d79",
   "cortex": "cortexproject/cortex:v1.8.0-rc.0",
   "cortexApiProxy": "opstrace/cortex-api:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
   "ddApi": "opstrace/ddapi:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
@@ -23,7 +23,7 @@
   "nodeExporter": "quay.io/prometheus/node-exporter:v0.18.1",
   "prometheusAdapter": "quay.io/coreos/k8s-prometheus-adapter-amd64:v0.4.1",
   "prometheusOperator": "quay.io/prometheus-operator/prometheus-operator:v0.42.1",
-  "graphqlEngine": "opstrace/graphql:c50456d6e19ba4b5fd16779b38fd1d1d",
+  "graphqlEngine": "opstrace/graphql:90728314221f5fc8acd14037f919bd75",
   "app": "opstrace/app:c50456d6e19ba4b5fd16779b38fd1d1d",
   "redis": "bitnami/redis:6.0.9",
   "postgresClient": "tmaier/postgresql-client@sha256:3702d3bff09b18e1d173cdf5887d6e4fea5feac0a521becf4a27559992e44ff3"


### PR DESCRIPTION
- Update config-api README: Adds examples for the other endpoints that the service now has.
- Switch `validateCredential` and `validateExporter` to be Queries: They aren't modifying anything server-side, so calling them Mutations doesn't really make sense. Mainly just a style thing.
- Update `validateCredential` and `validateExporter` parameters to align with the GraphQL queries for creating/updating credentials and exporters.

Note that `validateCredential` and `validateExporter` currently don't really work yet. There's some parser errors on the provided value/config input even if it's valid. This shouldn't take too long to fix, but the calls aren't being used yet, and there isn't a particular plan to start using them in the near future, so I'm going to leave them alone for now until they're needed. They were mainly added as an exercise to ensure that the Hasura Actions support wasn't too alertmanager-centric.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
