### PR TITLE
looker: ts fragment pusher: sleep between 5xx retries

### DIFF
--- a/test/test-remote/prom-node-client-tools/index.ts
+++ b/test/test-remote/prom-node-client-tools/index.ts
@@ -253,7 +253,8 @@ export class TimeseriesFragmentPushMessage {
       }
 
       // All other HTTP responses: treat as transient problems
-      log.info("Treat as transient problem, retry");
+      log.info("Treat as transient problem. Wait shortly, and retry");
+      await sleep(3.0);
     }
     throw new Error(`Failed to POST ${this} after ${maxRetries} attempts`);
   }


### PR DESCRIPTION
Fixes an issue in looker's `TimeseriesFragmentPushMessage.postWithRetryOrError()` where no waiting time was spent between POST HTTP request attempts when retrying was triggered by 5xx type responses (that really was an oversight, think of it as a missing sleep() statement). This is to address #480. This instability newly showed itself as of the 429 response rewriting implemented via #464.

429 responses were handled by design (with a small wait step inbetween attempts).