### PR TITLE
ui: allow editing of alertmanager configuration yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ packages/buildinfo/src/buildinfo.ts
 
 *.jwt
 
-.env.client.development
+packages/app/.env
+packages/app/.env.client.development
 

--- a/go/pkg/graphql/client_generated.go
+++ b/go/pkg/graphql/client_generated.go
@@ -1860,6 +1860,74 @@ func (client *Client) DeleteTenant(vars *DeleteTenantVariables) (*DeleteTenantRe
 }
 
 //
+// query GetAlertmanager($tenant_id: String!)
+//
+
+type GetAlertmanagerVariables struct {
+	TenantId String `json:"tenant_id"`
+}
+
+type GetAlertmanagerResponse struct {
+	GetAlertmanager struct {
+		Config string `json:"Config"`
+		Online string `json:"Online"`
+	} `json:"GetAlertmanager"`
+}
+
+type GetAlertmanagerRequest struct {
+	*http.Request
+}
+
+func NewGetAlertmanagerRequest(url string, vars *GetAlertmanagerVariables) (*GetAlertmanagerRequest, error) {
+	variables, err := json.Marshal(vars)
+	if err != nil {
+		return nil, err
+	}
+	b, err := json.Marshal(&GraphQLOperation{
+		Variables: variables,
+		Query: `query GetAlertmanager($tenant_id: String!) {
+  getAlertmanager(tenant_id: $tenant_id) {
+    config
+    online
+  }
+}`,
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return &GetAlertmanagerRequest{req}, nil
+}
+
+func (req *GetAlertmanagerRequest) Execute(client *http.Client) (*GetAlertmanagerResponse, error) {
+	resp, err := execute(client, req.Request)
+	if err != nil {
+		return nil, err
+	}
+	var result GetAlertmanagerResponse
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func GetAlertmanager(url string, client *http.Client, vars *GetAlertmanagerVariables) (*GetAlertmanagerResponse, error) {
+	req, err := NewGetAlertmanagerRequest(url, vars)
+	if err != nil {
+		return nil, err
+	}
+	return req.Execute(client)
+}
+
+func (client *Client) GetAlertmanager(vars *GetAlertmanagerVariables) (*GetAlertmanagerResponse, error) {
+	return GetAlertmanager(client.Url, client.Client, vars)
+}
+
+//
 // query GetTenants
 //
 
@@ -1918,6 +1986,79 @@ func GetTenants(url string, client *http.Client) (*GetTenantsResponse, error) {
 
 func (client *Client) GetTenants() (*GetTenantsResponse, error) {
 	return GetTenants(client.Url, client.Client)
+}
+
+//
+// mutation UpdateAlertmanager($tenant_id: String!, $input: AlertmanagerInput!)
+//
+
+type UpdateAlertmanagerVariables struct {
+	TenantId String            `json:"tenant_id"`
+	Input    AlertmanagerInput `json:"input"`
+}
+
+type UpdateAlertmanagerResponse struct {
+	UpdateAlertmanager struct {
+		Success          string `json:"Success"`
+		ErrorType        string `json:"ErrorType"`
+		ErrorMessage     string `json:"ErrorMessage"`
+		ErrorRawResponse string `json:"ErrorRawResponse"`
+	} `json:"UpdateAlertmanager"`
+}
+
+type UpdateAlertmanagerRequest struct {
+	*http.Request
+}
+
+func NewUpdateAlertmanagerRequest(url string, vars *UpdateAlertmanagerVariables) (*UpdateAlertmanagerRequest, error) {
+	variables, err := json.Marshal(vars)
+	if err != nil {
+		return nil, err
+	}
+	b, err := json.Marshal(&GraphQLOperation{
+		Variables: variables,
+		Query: `mutation UpdateAlertmanager($tenant_id: String!, $input: AlertmanagerInput!) {
+  updateAlertmanager(tenant_id: $tenant_id, input: $input) {
+    success
+    error_type
+    error_message
+    error_raw_response
+  }
+}`,
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return &UpdateAlertmanagerRequest{req}, nil
+}
+
+func (req *UpdateAlertmanagerRequest) Execute(client *http.Client) (*UpdateAlertmanagerResponse, error) {
+	resp, err := execute(client, req.Request)
+	if err != nil {
+		return nil, err
+	}
+	var result UpdateAlertmanagerResponse
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func UpdateAlertmanager(url string, client *http.Client, vars *UpdateAlertmanagerVariables) (*UpdateAlertmanagerResponse, error) {
+	req, err := NewUpdateAlertmanagerRequest(url, vars)
+	if err != nil {
+		return nil, err
+	}
+	return req.Execute(client)
+}
+
+func (client *Client) UpdateAlertmanager(vars *UpdateAlertmanagerVariables) (*UpdateAlertmanagerResponse, error) {
+	return UpdateAlertmanager(client.Url, client.Client, vars)
 }
 
 //
@@ -2613,6 +2754,14 @@ type UUID string
 // Enums
 //
 
+type ErrorType string
+
+const (
+	ErrorTypeSERVICEERROR     ErrorType = "SERVICE_ERROR"
+	ErrorTypeSERVICEOFFLINE   ErrorType = "SERVICE_OFFLINE"
+	ErrorTypeVALIDATIONFAILED ErrorType = "VALIDATION_FAILED"
+)
+
 type BranchConstraint string
 
 const (
@@ -2887,6 +3036,10 @@ const (
 //
 // Inputs
 //
+
+type AlertmanagerInput struct {
+	Config String `json:"config"`
+}
 
 type BooleanComparisonExp struct {
 	Eq     *Boolean   `json:"_eq,omitempty"`
@@ -3811,6 +3964,26 @@ type UuidComparisonExp struct {
 // Objects
 //
 
+type Alertmanager struct {
+	Config   *String `json:"config,omitempty"`
+	Online   Boolean `json:"online"`
+	TenantId String  `json:"tenant_id"`
+}
+
+type AlertmanagerUpdateResponse struct {
+	ErrorMessage     *String    `json:"error_message,omitempty"`
+	ErrorRawResponse *String    `json:"error_raw_response,omitempty"`
+	ErrorType        *ErrorType `json:"error_type,omitempty"`
+	Success          Boolean    `json:"success"`
+}
+
+type ValidateOutput struct {
+	ErrorMessage     *String    `json:"error_message,omitempty"`
+	ErrorRawResponse *String    `json:"error_raw_response,omitempty"`
+	ErrorType        *ErrorType `json:"error_type,omitempty"`
+	Success          Boolean    `json:"success"`
+}
+
 type Branch struct {
 	CreatedAt         Timestamptz            `json:"created_at"`
 	Files             *[]File                `json:"files,omitempty"`
@@ -4132,6 +4305,7 @@ type MutationRoot struct {
 	InsertUserOne            *User                           `json:"insert_user_one,omitempty"`
 	InsertUserPreference     *UserPreferenceMutationResponse `json:"insert_user_preference,omitempty"`
 	InsertUserPreferenceOne  *UserPreference                 `json:"insert_user_preference_one,omitempty"`
+	UpdateAlertmanager       *AlertmanagerUpdateResponse     `json:"updateAlertmanager,omitempty"`
 	UpdateBranch             *BranchMutationResponse         `json:"update_branch,omitempty"`
 	UpdateBranchByPk         *Branch                         `json:"update_branch_by_pk,omitempty"`
 	UpdateCredential         *CredentialMutationResponse     `json:"update_credential,omitempty"`
@@ -4165,6 +4339,7 @@ type QueryRoot struct {
 	File                    *[]File                 `json:"file,omitempty"`
 	FileAggregate           FileAggregate           `json:"file_aggregate"`
 	FileByPk                *File                   `json:"file_by_pk,omitempty"`
+	GetAlertmanager         *Alertmanager           `json:"getAlertmanager,omitempty"`
 	Module                  *[]Module               `json:"module,omitempty"`
 	ModuleAggregate         ModuleAggregate         `json:"module_aggregate"`
 	ModuleByPk              *Module                 `json:"module_by_pk,omitempty"`
@@ -4180,6 +4355,8 @@ type QueryRoot struct {
 	UserPreference          *[]UserPreference       `json:"user_preference,omitempty"`
 	UserPreferenceAggregate UserPreferenceAggregate `json:"user_preference_aggregate"`
 	UserPreferenceByPk      *UserPreference         `json:"user_preference_by_pk,omitempty"`
+	ValidateCredential      *ValidateOutput         `json:"validateCredential,omitempty"`
+	ValidateExporter        *ValidateOutput         `json:"validateExporter,omitempty"`
 }
 
 type SubscriptionRoot struct {
@@ -4195,6 +4372,7 @@ type SubscriptionRoot struct {
 	File                    *[]File                 `json:"file,omitempty"`
 	FileAggregate           FileAggregate           `json:"file_aggregate"`
 	FileByPk                *File                   `json:"file_by_pk,omitempty"`
+	GetAlertmanager         *Alertmanager           `json:"getAlertmanager,omitempty"`
 	Module                  *[]Module               `json:"module,omitempty"`
 	ModuleAggregate         ModuleAggregate         `json:"module_aggregate"`
 	ModuleByPk              *Module                 `json:"module_by_pk,omitempty"`
@@ -4210,6 +4388,8 @@ type SubscriptionRoot struct {
 	UserPreference          *[]UserPreference       `json:"user_preference,omitempty"`
 	UserPreferenceAggregate UserPreferenceAggregate `json:"user_preference_aggregate"`
 	UserPreferenceByPk      *UserPreference         `json:"user_preference_by_pk,omitempty"`
+	ValidateCredential      *ValidateOutput         `json:"validateCredential,omitempty"`
+	ValidateExporter        *ValidateOutput         `json:"validateExporter,omitempty"`
 }
 
 type Tenant struct {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -78,6 +78,7 @@
     "hotkeys-js": "^3.8.1",
     "husky": "^4.3.0",
     "identity-obj-proxy": "3.0.0",
+    "js-yaml": "^4.0.0",
     "jwks-rsa": "^1.12.3",
     "lightship": "^6.1.0",
     "lodash": "^4.17.21",
@@ -86,6 +87,7 @@
     "monaco-editor": "0.21.3",
     "monaco-editor-core": "0.21.3",
     "monaco-editor-webpack-plugin": "^2.1.0",
+    "monaco-yaml": "^2.5.1",
     "new-github-issue-url": "^0.2.1",
     "polished": "^3.6.6",
     "qs": "^6.9.4",
@@ -117,7 +119,8 @@
     "typesafe-actions": "^5.1.0",
     "uuid": "^8.3.2",
     "winston": "^3.3.3",
-    "worker-loader": "^3.0.7"
+    "worker-loader": "^3.0.7",
+    "yup": "^0.32.9"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",
@@ -253,7 +256,10 @@
     "metadata:export": "yarn hasura metadata export --admin-secret myadminsecret",
     "types:watch": "HASURA_GRAPHQL_ADMIN_SECRET=myadminsecret graphql-codegen --config codegen.js --watch",
     "console": "hasura console --admin-secret myadminsecret",
+    "console:remote": "HASURA_GRAPHQL_ENDPOINT=http://127.0.0.1:8090 HASURA_GRAPHQL_ADMIN_SECRET=$(kubectl get secrets -n kube-system -o json hasura-admin-secret | jq -r .data.HASURA_ADMIN_SECRET | base64 -d) hasura console --no-browser",
     "services:start": "docker-compose up",
+    "server:start:remote": "GRAPHQL_ENDPOINT=http://127.0.0.1:8090/v1/graphql GRAPHQL_ENDPOINT_PORT=8090 HASURA_GRAPHQL_ADMIN_SECRET=$(kubectl get secrets -n kube-system -o json hasura-admin-secret | jq -r .data.HASURA_ADMIN_SECRET | base64 -d) NODE_ENV=development webpack --watch --config config/webpack.server.config.js",
+    "services:graphql:remote": "kubectl port-forward -n application deployment/graphql 8090:8080",
     "lib:gen": "ts-node src/sdk/compiler.ts",
     "lib:watch": "ts-node src/sdk/compiler.ts --watch"
   },

--- a/packages/app/src/client/components/Attribute/index.tsx
+++ b/packages/app/src/client/components/Attribute/index.tsx
@@ -13,23 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SubscribeToTenantListSubscription } from "state/clients/graphqlClient";
 
-export type Alertmanager = {
-  header: string;
-  config: string;
-  online?: boolean;
-};
+import React, { ReactNode } from "react";
 
-type TenantVirtualFields = {
-  alertmanager?: Alertmanager;
-};
+import { Box } from "client/components/Box";
 
-export type Tenant = SubscribeToTenantListSubscription["tenant"][0] &
-  TenantVirtualFields;
+import Typography from "client/components/Typography/Typography";
 
-export type Tenants = Tenant[];
-export type TenantRecords = Record<string, Tenant>;
+export const Key = (props: { children: ReactNode }) => (
+  <Box pt={2} pb={2}>
+    <Typography variant="h6" color="textSecondary">
+      {props.children}
+    </Typography>
+  </Box>
+);
 
-// use this same id to unsubscribe
-export type SubscriptionID = number;
+export const Value = (props: { children: ReactNode }) => (
+  <Box p={3} pt={2} pb={2}>
+    <Typography variant="h6">{props.children}</Typography>
+  </Box>
+);
+
+const attribute = { Key, Value };
+
+export default attribute;

--- a/packages/app/src/client/components/Editor/editors/YamlEditor.tsx
+++ b/packages/app/src/client/components/Editor/editors/YamlEditor.tsx
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useEffect, useRef } from "react";
+import { editor } from "monaco-editor/esm/vs/editor/editor.api";
+import { yaml } from "workers";
+
+import AutoSizer, { Size } from "react-virtualized-auto-sizer";
+import { YamlEditorProps } from "../lib/types";
+import { GlobalEditorCSS } from "../lib/themes";
+import { getTextEditorOptions } from "state/file/utils/monaco";
+
+const YamlEditor = ({
+  filename,
+  jsonSchema,
+  data,
+  onChange
+}: YamlEditorProps) => {
+  const modelRef = useRef<monaco.editor.IModel | null>(null);
+  const subscriptionRef = useRef<monaco.IDisposable | null>(null);
+
+  useEffect(() => {
+    yaml &&
+      yaml.yamlDefaults.setDiagnosticsOptions({
+        validate: true,
+        enableSchemaRequest: true,
+        hover: true,
+        completion: true,
+        schemas: [
+          {
+            uri: "http://opstrace.com/alertmanager-schema.json",
+            fileMatch: ["*"],
+            schema: jsonSchema
+          }
+        ]
+      });
+  }, [jsonSchema]);
+
+  useEffect(() => {
+    const fileUri = monaco.Uri.parse(filename);
+    modelRef.current =
+      monaco.editor.getModel(fileUri) ||
+      monaco.editor.createModel("", "yaml", fileUri);
+    // return () => {
+    //   modelRef.current?.dispose();
+    //   modelRef.current = null;
+    // };
+  }, [filename]);
+
+  useEffect(() => {
+    if (modelRef?.current && onChange) {
+      subscriptionRef.current = modelRef.current?.onDidChangeContent(() => {
+        if (modelRef?.current) onChange(modelRef.current.getValue(), filename);
+      });
+    }
+    return () => {
+      subscriptionRef.current?.dispose();
+      subscriptionRef.current = null;
+    };
+  }, [onChange, filename]);
+
+  useEffect(() => {
+    modelRef.current?.setValue(data);
+  }, [data]);
+
+  if (modelRef?.current) return <AutoSizingEditor model={modelRef.current} />;
+  else return null; // TODO: show loading component here?
+};
+
+function AutoSizingEditor({ model }: { model: editor.ITextModel }) {
+  return (
+    <AutoSizer>
+      {({ height, width }: Size) => {
+        return <BaseEditor height={height} width={width} model={model} />;
+      }}
+    </AutoSizer>
+  );
+}
+
+type BaseEditorProps = {
+  model: monaco.editor.ITextModel;
+};
+
+function BaseEditor({ height, width, model }: BaseEditorProps & Size) {
+  const editorRef = useRef<null | editor.ICodeEditor>(null);
+  const currentModelRef = useRef<editor.IModel>(model);
+
+  const editorContainer = useCallback(async node => {
+    if (node) {
+      editorRef.current = editor.create(
+        node,
+        getTextEditorOptions({
+          readOnly: false,
+          model: currentModelRef.current
+        })
+      );
+    } else {
+      editorRef.current?.dispose();
+      editorRef.current = null;
+    }
+  }, []);
+
+  // Update editor layout when width/height changes
+  useEffect(() => {
+    if (width !== undefined && height !== undefined && editorRef.current) {
+      editorRef.current.layout({ width, height });
+    }
+  }, [width, height]);
+
+  // Dispose all the things when this component unmounts
+  useEffect(() => {
+    return () => {
+      editorRef.current?.dispose();
+      editorRef.current = null;
+    };
+  }, []);
+
+  return (
+    <>
+      <GlobalEditorCSS />
+      <div
+        ref={editorContainer}
+        style={{
+          height,
+          width
+        }}
+      />
+    </>
+  );
+}
+
+export default YamlEditor;

--- a/packages/app/src/client/components/Editor/index.tsx
+++ b/packages/app/src/client/components/Editor/index.tsx
@@ -15,7 +15,7 @@
  */
 import React from "react";
 import { AsyncComponent } from "../Loadable";
-import type { ModuleEditorProps } from "./lib/types";
+import type { ModuleEditorProps, YamlEditorProps } from "./lib/types";
 import EditorSkeleton from "./lib/components/EditorSkeleton";
 
 export { default as EditorSkeleton } from "./lib/components/EditorSkeleton";
@@ -32,6 +32,13 @@ export const ModuleEditorGroup = AsyncComponent<{}>(
     import(
       /* webpackChunkName: "module-editor-group" */ "./editors/EditorGroup"
     ),
+  false,
+  <EditorSkeleton />
+);
+
+export const YamlEditor = AsyncComponent<YamlEditorProps>(
+  /* #__LOADABLE__ */ () =>
+    import(/* webpackChunkName: "yaml-editor" */ "./editors/YamlEditor"),
   false,
   <EditorSkeleton />
 );

--- a/packages/app/src/client/components/Editor/lib/types.ts
+++ b/packages/app/src/client/components/Editor/lib/types.ts
@@ -21,3 +21,10 @@ export type ModuleEditorProps = {
   height: number;
   width: number;
 };
+
+export type YamlEditorProps = {
+  filename: string;
+  jsonSchema?: object;
+  data: string;
+  onChange?: Function;
+};

--- a/packages/app/src/client/utils/regex.ts
+++ b/packages/app/src/client/utils/regex.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Opstrace, Inc.
+ * Copyright 2021 Opstrace, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,23 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SubscribeToTenantListSubscription } from "state/clients/graphqlClient";
 
-export type Alertmanager = {
-  header: string;
-  config: string;
-  online?: boolean;
-};
-
-type TenantVirtualFields = {
-  alertmanager?: Alertmanager;
-};
-
-export type Tenant = SubscribeToTenantListSubscription["tenant"][0] &
-  TenantVirtualFields;
-
-export type Tenants = Tenant[];
-export type TenantRecords = Record<string, Tenant>;
-
-// use this same id to unsubscribe
-export type SubscriptionID = number;
+// eslint-disable-next-line no-useless-escape
+export const subdomainValidator = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$/;

--- a/packages/app/src/client/validation/alertmanagerConfig/README.md
+++ b/packages/app/src/client/validation/alertmanagerConfig/README.md
@@ -1,0 +1,11 @@
+# Generating JSON Schema
+
+The `schema.json` file was orginially generated from the Typescript definitions in `types.ts` with the following package:
+
+> npm install typescript-json-schema -g
+
+Once installed, the this command will generate a new schema:
+
+> typescript-json-schema types.ts AlertmanagerConfig --ignoreErrors > schema.json
+
+It was then hand edited DRYing up common definitions such as `http_config` and splitting receiver configs out to make it easier to manager.

--- a/packages/app/src/client/validation/alertmanagerConfig/common.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/common.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { subdomainValidator } from "client/utils/regex";
+import { TlsConfig, BasicAuth, HttpConfig } from "./types";
+
+export const tlsConfigSchema: yup.SchemaOf<TlsConfig> = yup
+  .object({
+    ca_file: yup.string().meta({
+      comment: "CA certificate to validate the server certificate with."
+    }),
+    cert_file: yup.string().meta({
+      comment: "CA certificate to validate the server certificate with."
+    }),
+    key_file: yup.string().meta({
+      comment:
+        "Certificate and key files for client cert authentication to the server."
+    }),
+    server_name: yup
+      .string()
+      .matches(subdomainValidator, { excludeEmptyString: true })
+      .meta({
+        comment: "ServerName extension to indicate the name of the server.",
+        url: "http://tools.ietf.org/html/rfc4366#section-3.1"
+      }),
+    insecure_skip_verify: yup.boolean().default(false)
+  })
+  .noUnknown();
+
+export const labelNameSchema = yup.string().matches(/[a-zA-Z_][a-zA-Z0-9_]*/);
+
+const basicAuthSchema: yup.SchemaOf<BasicAuth> = yup
+  .object({
+    username: yup.string(),
+    password: yup.string(),
+    password_file: yup.string()
+  })
+  .meta({
+    comment:
+      "Sets the `Authorization` header with the configured username and password."
+  });
+
+export const httpConfigSchema: yup.SchemaOf<HttpConfig> = yup
+  .object({
+    basic_auth: basicAuthSchema.notRequired(),
+    bearer_token: yup.string().meta({
+      comment:
+        "Sets the `Authorization` header with the configured bearer token."
+    }),
+    bearer_token_file: yup.string().meta({
+      comment:
+        "Sets the `Authorization` header with the bearer token read from the configured file."
+    }),
+    tls_config: tlsConfigSchema.notRequired(),
+    proxy_url: yup.string()
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/emailConfig.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/emailConfig.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { EmailConfig } from "./types";
+import { tlsConfigSchema } from "./common";
+
+export const emailConfigSchema: yup.SchemaOf<EmailConfig> = yup
+  .object({
+    send_resolved: yup.boolean().default(false).meta({
+      comment: "Whether or not to notify about resolved alerts."
+    }),
+    to: yup.string().defined(),
+    from: yup.string().meta({
+      comment: "The sender address.",
+      default: "default = global.smtp_from"
+    }),
+    smarthost: yup.string().meta({
+      comment:
+        "The SMTP host through which email are sent, including port number",
+      default: "default = global.smtp_smarthost"
+    }),
+    hello: yup.string().meta({
+      comment: "The hostname to identify to the SMTP server.",
+      default: "default = global.smtp_hello"
+    }),
+    auth_username: yup
+      .string()
+      .meta({ default: "default = global.smtp_auth_username" }),
+    auth_password: yup
+      .string()
+      .meta({ default: "default = global.smtp_auth_password" }),
+    auth_secret: yup
+      .string()
+      .meta({ default: "default = global.smtp_auth_secret" }),
+    auth_identity: yup
+      .string()
+      .meta({ default: "default = global.smtp_auth_identity" }),
+    require_tls: yup.boolean().meta({
+      default: "default = global.smtp_require_tls",
+      comment:
+        "The SMTP TLS requirement. Note that Go does not support unencrypted connections to remote SMTP endpoints."
+    }),
+    tls_config: tlsConfigSchema.notRequired(),
+    html: yup
+      .string()
+      .default('{{ template "email.default.html" . }}')
+      .meta({ comment: "The HTML body of the email notification." }),
+    text: yup.string(),
+    headers: yup.object().meta({
+      comment:
+        "Further headers email header key/value pairs. Overrides any headers previously set by the notification implementation.",
+      example: "{ <string>: <tmpl_string>, ... }"
+    })
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/index.tsx
+++ b/packages/app/src/client/validation/alertmanagerConfig/index.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { Global, AlertmanagerConfig } from "./types";
+import { httpConfigSchema } from "./common";
+import { routeSchema } from "./route";
+import { receiverSchema } from "./receiver";
+import { inhibitRuleSchema } from "./inhibitRule";
+
+import jsonSchema from "client/validation/alertmanagerConfig/schema.json";
+
+const globalSchema: yup.SchemaOf<Global> = yup
+  .object({
+    smtp_from: yup
+      .string()
+      .meta({ comment: "The default SMTP From header field." }),
+    smtp_smarthost: yup.string().meta({
+      comment:
+        "The default SMTP smarthost used for sending emails, including port number. Port number usually is 25, or 587 for SMTP over TLS (sometimes referred to as STARTTLS).",
+      example: "smtp.example.org:587"
+    }),
+    smtp_hello: yup.string().default("localhost").meta({
+      comment: "The default hostname to identify to the SMTP server."
+    }),
+    smtp_auth_username: yup.string().meta({
+      comment:
+        "SMTP Auth using CRAM-MD5, LOGIN and PLAIN. If empty, Alertmanager doesn't authenticate to the SMTP server."
+    }),
+    smtp_auth_password: yup
+      .string()
+      .meta({ comment: "SMTP Auth using LOGIN and PLAIN." }),
+    smtp_auth_identity: yup
+      .string()
+      .meta({ comment: "SMTP Auth using PLAIN." }),
+    smtp_auth_secret: yup
+      .string()
+      .meta({ comment: "SMTP Auth using CRAM-MD5." }),
+    smtp_require_tls: yup.boolean().default(true).meta({
+      comment:
+        "The SMTP TLS requirement. Note that Go does not support unencrypted connections to remote SMTP endpoints."
+    }),
+
+    slack_api_url: yup.string().url(),
+    victorops_api_key: yup.string(),
+    victorops_api_url: yup
+      .string()
+      .url()
+      .default(
+        "https://alert.victorops.com/integrations/generic/20131114/alert/"
+      ),
+    pagerduty_url: yup
+      .string()
+      .url()
+      .default("https://events.pagerduty.com/v2/enqueue"),
+    opsgenie_api_key: yup.string(),
+    opsgenie_api_url: yup.string().url().default("https://api.opsgenie.com/"),
+    wechat_api_url: yup
+      .string()
+      .url()
+      .default("https://qyapi.weixin.qq.com/cgi-bin/"),
+    wechat_api_secret: yup.string(),
+    wechat_api_corp_id: yup.string(),
+
+    http_config: httpConfigSchema
+      .meta({
+        comment: "The default HTTP client configuration"
+      })
+      .notRequired(),
+
+    resolve_timeout: yup.string().default("5m").meta({
+      comment:
+        "ResolveTimeout is the default value used by alertmanager if the alert does not include EndsAt, after this time passes it can declare the alert as resolved if it has not been updated. This has no impact on alerts from Prometheus, as they always include EndsAt."
+    })
+  })
+  .noUnknown();
+
+const alertmanagerConfigSchema: yup.SchemaOf<AlertmanagerConfig> = yup
+  .object({
+    global: globalSchema.notRequired(),
+    templates: yup
+      .array()
+      .of(yup.string())
+      .meta({
+        comment:
+          "Files from which custom notification template definitions are read. # The last component may use a wildcard matcher, e.g. 'templates/*.tmpl'."
+      })
+      .notRequired(),
+    route: routeSchema
+      .defined()
+      .meta({ comment: "The root node of the routing tree." }),
+    // @ts-ignore
+    receivers: yup.array().of(receiverSchema).defined(),
+    inhibit_rules: yup.array().of(inhibitRuleSchema).notRequired()
+  })
+  .meta({
+    url: "https://www.prometheus.io/docs/alerting/latest/configuration/"
+  })
+  .noUnknown();
+
+export { alertmanagerConfigSchema, jsonSchema };

--- a/packages/app/src/client/validation/alertmanagerConfig/inhibitRule.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/inhibitRule.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { InhibitRule } from "./types";
+import { labelNameSchema } from "./common";
+
+export const inhibitRuleSchema: yup.SchemaOf<InhibitRule> = yup
+  .object({
+    target_match: yup
+      .object()
+      .meta({
+        comment:
+          "Matchers that have to be fulfilled in the alerts to be muted.",
+        example: "<labelname>: <labelvalue>"
+      })
+      .notRequired(),
+    target_match_re: yup
+      .object()
+      .meta({
+        comment:
+          "Regex matchers that have to be fulfilled in the alerts to be muted.",
+        example: "<labelname>: <regex>"
+      })
+      .notRequired(),
+    source_match: yup
+      .object()
+      .meta({
+        comment:
+          "Matchers for which one or more alerts have to exist for the inhibition to take effect.",
+        example: "<labelname>: <labelvalue>"
+      })
+      .notRequired(),
+    source_match_re: yup
+      .object()
+      .meta({
+        comment:
+          "Regex matchers for which one or more alerts have to exist for the inhibition to take effect.",
+        example: "<labelname>: <regex>"
+      })
+      .notRequired(),
+    equal: yup
+      .array()
+      .of(labelNameSchema)
+      .meta({
+        comment:
+          "Labels that must have an equal value in the source and target alert for the inhibition to take effect."
+      })
+      .notRequired()
+  })
+  .meta({
+    url:
+      "https://www.prometheus.io/docs/alerting/latest/configuration/#inhibit_rule"
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/opsgenieConfig.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/opsgenieConfig.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { OpsgenieResponderConfig, OpsgenieConfig } from "./types";
+import { httpConfigSchema } from "./common";
+
+const opsgenieResponderConfig: yup.SchemaOf<OpsgenieResponderConfig> = yup
+  .object({
+    id: yup.string(),
+    name: yup.string(),
+    username: yup.string(),
+    type: yup
+      .mixed()
+      .oneOf(["team", "user", "escalation", "schedule"])
+      .defined()
+  })
+  .meta({
+    comment: "Exactly one of id, name and username should be defined."
+  })
+  .noUnknown();
+
+export const opsgenieConfigSchema: yup.SchemaOf<OpsgenieConfig> = yup
+  .object({
+    send_resolved: yup.boolean().default(true).meta({
+      comment: "Whether or not to notify about resolved alerts."
+    }),
+    api_key: yup.string().default("global.opsgenie_api_key").meta({
+      comment: "The API key to use when talking to the OpsGenie API."
+    }),
+    api_url: yup.string().url().meta({
+      comment: "The host to send OpsGenie API requests to.",
+      default: "global.opsgenie_api_url"
+    }),
+    message: yup
+      .string()
+      .max(130)
+      .meta({ comment: "Alert text limited to 130 characters." }),
+    description: yup
+      .string()
+      .default('{{ template "opsgenie.default.description" . }}')
+      .meta({ comment: "A description of the incident." }),
+    source: yup
+      .string()
+      .default('{{ template "opsgenie.default.source" . }}')
+      .meta({ comment: "" }),
+    details: yup
+      .object()
+      .meta({
+        comment:
+          "A set of arbitrary key/value pairs that provide further detail about the incident.",
+        example: "<string>: <tmpl_string>"
+      })
+      .notRequired(),
+    responders: yup
+      .array()
+      .of(opsgenieResponderConfig)
+      .meta({
+        comment: "List of responders responsible for notifications."
+      })
+      .notRequired(),
+    tags: yup.string().meta({
+      comment: "Comma separated list of tags attached to the notifications."
+    }),
+    note: yup.string().meta({ comment: "Additional alert note." }),
+    priority: yup.string().meta({
+      comment:
+        "Priority level of alert. Possible values are P1, P2, P3, P4, and P5."
+    }),
+    http_config: httpConfigSchema
+      .meta({
+        comment: "The HTTP client's configuration.",
+        default: "global.http_config"
+      })
+      .notRequired()
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/pagerdutyConfig.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/pagerdutyConfig.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import {
+  PagerdutyImageConfig,
+  PagerdutyLinkConfig,
+  PagerdutyConfig
+} from "./types";
+import { httpConfigSchema } from "./common";
+
+const pagerdutyImageConfigSchema: yup.SchemaOf<PagerdutyImageConfig> = yup
+  .object({
+    href: yup.string(),
+    source: yup.string(),
+    alt: yup.string()
+  })
+  .noUnknown();
+
+const pagerdutyLinkConfigSchema: yup.SchemaOf<PagerdutyLinkConfig> = yup
+  .object({
+    href: yup.string(),
+    text: yup.string()
+  })
+  .noUnknown();
+
+export const pagerdutyConfigSchema: yup.SchemaOf<PagerdutyConfig> = yup
+  .object({
+    send_resolved: yup.boolean().default(true).meta({
+      comment: "Whether or not to notify about resolved alerts."
+    }),
+    routing_key: yup.string().meta({
+      comment:
+        "The PagerDuty integration key (when using PagerDuty integration type `Events API v2`). Mutually exclusive from `service_key`."
+    }),
+    service_key: yup.string().meta({
+      comment:
+        "The PagerDuty integration key (when using PagerDuty integration type `Prometheus`). Mutually exclusive from `routing_key`."
+    }),
+    url: yup.string().url().meta({
+      comment: "The URL to send API requests to",
+      default: "global.pagerduty_url"
+    }),
+    client: yup
+      .string()
+      .default('{{ template "pagerduty.default.client" . }}')
+      .meta({
+        comment: "The client identification of the Alertmanager."
+      }),
+    client_url: yup
+      .string()
+      .default('{{ template "pagerduty.default.clientURL" . }}')
+      .meta({
+        comment: "A backlink to the sender of the notification."
+      }),
+    description: yup
+      .string()
+      .default('{{ template "pagerduty.default.description" .}}')
+      .meta({ comment: "A description of the incident." }),
+    severity: yup
+      .string()
+      .default("error")
+      .meta({ comment: "A description of the incident." }),
+    details: yup
+      .object()
+      .default({
+        firing: '{{ template "pagerduty.default.instances" .Alerts.Firing }}',
+        resolved:
+          '{{ template "pagerduty.default.instances" .Alerts.Resolved }}',
+        num_firing: "{{ .Alerts.Firing | len }}",
+        num_resolved: "{{ .Alerts.Resolved | len }}"
+      })
+      .meta({
+        comment:
+          "A set of arbitrary key/value pairs that provide further detail about the incident.",
+        example: "<string>: <tmpl_string>"
+      })
+      .notRequired(),
+    images: yup
+      .array()
+      .of(pagerdutyImageConfigSchema)
+      .meta({ comment: "Images to attach to the incident." })
+      .notRequired(),
+    links: yup
+      .array()
+      .of(pagerdutyLinkConfigSchema)
+      .meta({ comment: "Links to attach to the incident." })
+      .notRequired(),
+    http_config: httpConfigSchema
+      .meta({
+        comment: "The HTTP client's configuration.",
+        default: "global.http_config"
+      })
+      .notRequired()
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/pushoverConfig.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/pushoverConfig.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { PushoverConfig } from "./types";
+import { httpConfigSchema } from "./common";
+
+export const pushoverConfigSchema: yup.SchemaOf<PushoverConfig> = yup
+  .object({
+    send_resolved: yup.boolean().default(true).meta({
+      comment: "Whether or not to notify about resolved alerts."
+    }),
+    user_key: yup
+      .string()
+      .defined()
+      .meta({ comment: "The recipient user’s user key." }),
+    token: yup.string().defined().meta({
+      comment: "Your registered application’s API token",
+      url: "https://pushover.net/apps"
+    }),
+    title: yup
+      .string()
+      .default('{{ template "pushover.default.title" . }}')
+      .meta({ comment: "Notification title." }),
+    message: yup
+      .string()
+      .default('{{ template "pushover.default.message" . }}')
+      .meta({ comment: "Notification message." }),
+    url: yup.string().default('{{ template "pushover.default.url" . }}').meta({
+      comment: "A supplementary URL shown alongside the message."
+    }),
+    priority: yup
+      .string()
+      .default('{{ if eq .Status "firing" }}2{{ else }}0{{ end }}')
+      .meta({ url: "https://pushover.net/api#priority" }),
+    retry: yup.string().default("1m").meta({
+      comment:
+        "How often the Pushover servers will send the same notification to the user. Must be at least 30 seconds."
+    }),
+    expire: yup.string().default("1h").meta({
+      comment:
+        "How long your notification will continue to be retried for, unless the user acknowledges the notification."
+    }),
+    http_config: httpConfigSchema
+      .meta({
+        comment: "The HTTP client's configuration.",
+        default: "global.http_config"
+      })
+      .notRequired()
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/receiver.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/receiver.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { Receiver } from "./types";
+
+import { emailConfigSchema } from "./emailConfig";
+import { slackConfigSchema } from "./slackConfig";
+import { pagerdutyConfigSchema } from "./pagerdutyConfig";
+import { pushoverConfigSchema } from "./pushoverConfig";
+import { opsgenieConfigSchema } from "./opsgenieConfig";
+import { victoropsConfigSchema } from "./victoropsConfig";
+import { webhookConfigSchema } from "./webhookConfig";
+import { wechatConfigSchema } from "./wechatConfig";
+
+export const receiverSchema: yup.SchemaOf<Receiver> = yup
+  .object({
+    name: yup.string().defined(),
+    email_configs: yup.array().of(emailConfigSchema).notRequired(),
+    slack_configs: yup.array().of(slackConfigSchema).notRequired(),
+    pagerduty_configs: yup.array().of(pagerdutyConfigSchema).notRequired(),
+    pushover_configs: yup.array().of(pushoverConfigSchema).notRequired(),
+    opsgenie_configs: yup.array().of(opsgenieConfigSchema).notRequired(),
+    victorops_configs: yup.array().of(victoropsConfigSchema).notRequired(),
+    webhook_configs: yup.array().of(webhookConfigSchema).notRequired(),
+    wechat_configs: yup.array().of(wechatConfigSchema).notRequired()
+  })
+  .meta({
+    url:
+      "https://www.prometheus.io/docs/alerting/latest/configuration/#receiver"
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/route.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { Route } from "./types";
+import { labelNameSchema } from "./common";
+
+const routeSchema: yup.SchemaOf<Route> = yup
+  .object({
+    receiver: yup.string(),
+    group_by: yup
+      .array()
+      .of(labelNameSchema)
+      .meta({
+        comment: `
+The labels by which incoming alerts are grouped together. For example, multiple alerts coming in for cluster=A and alertname=LatencyHigh would be batched into a single group.
+
+To aggregate by all possible labels use the special value '...' as the sole label name, for example: group_by: ['...']
+
+This effectively disables aggregation entirely, passing through all alerts as-is. This is unlikely to be what you want, unless you have a very low alert volume or your upstream notification system performs its own grouping.
+  `
+      })
+      .notRequired(),
+    continue: yup.boolean().default(false).meta({
+      comment:
+        "Whether an alert should continue matching subsequent sibling nodes."
+    }),
+    match: yup
+      .object()
+      .meta({
+        comment:
+          "A set of equality matchers an alert has to fulfill to match the node.",
+        example: "<labelname>: <labelvalue>"
+      })
+      .notRequired(),
+    match_re: yup
+      .object()
+      .meta({
+        comment:
+          "A set of regex-matchers an alert has to fulfill to match the node.",
+        example: "<labelname>: <regex>"
+      })
+      .notRequired(),
+    group_wait: yup.string().default("30s").meta({
+      comment:
+        "How long to initially wait to send a notification for a group of alerts. Allows to wait for an inhibiting alert to arrive or collect more initial alerts for the same group. (Usually ~0s to few minutes.)"
+    }),
+    group_interval: yup.string().default("5m").meta({
+      comment:
+        "How long to wait before sending a notification about new alerts that are added to a group of alerts for which an initial notification has already been sent. (Usually ~5m or more.)"
+    }),
+    repeat_interval: yup.string().default("4h").meta({
+      comment:
+        "How long to wait before sending a notification again if it has already been sent successfully for an alert. (Usually ~3h or more)."
+    }),
+    routes: yup.lazy(() =>
+      yup
+        .array()
+        .of(routeSchema)
+        .default(undefined)
+        .meta({ comment: "Zero or more child routes." })
+        .notRequired()
+    )
+  })
+  .meta({
+    url: "https://www.prometheus.io/docs/alerting/latest/configuration/#route"
+  })
+  .noUnknown();
+
+// can't use "route" in the definition of route :-)
+// routeSchema = routeSchema.shape({
+//   routes: yup
+//     .array()
+//     .of(routeSchema)
+//     .meta({ comment: "Zero or more child routes." })
+//     .notRequired()
+// });
+
+export { routeSchema };

--- a/packages/app/src/client/validation/alertmanagerConfig/schema.json
+++ b/packages/app/src/client/validation/alertmanagerConfig/schema.json
@@ -1,0 +1,635 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Record<string,string>": {
+      "description": "Construct a type with a set of properties K of type T",
+      "type": "object"
+    },
+    "tls_config": {
+      "properties": {
+        "ca_file": {
+          "type": "string"
+        },
+        "cert_file": {
+          "type": "string"
+        },
+        "insecure_skip_verify": {
+          "type": "boolean"
+        },
+        "key_file": {
+          "type": "string"
+        },
+        "server_name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "basic_auth": {
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "password_file": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "http_config": {
+      "properties": {
+        "basic_auth": { "$ref": "#/definitions/basic_auth" },
+        "bearer_token": {
+          "type": "string"
+        },
+        "bearer_token_file": {
+          "type": "string"
+        },
+        "proxy_url": {
+          "type": "string"
+        },
+        "tls_config": { "$ref": "#/definitions/tls_config" }
+      },
+      "type": "object"
+    },
+    "inhibit_rules": {
+      "properties": {
+        "equal": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "source_match": {
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "source_match_re": {
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "target_match": {
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "target_match_re": {
+          "$ref": "#/definitions/Record<string,string>"
+        }
+      },
+      "type": "object"
+    },
+    "email_config": {
+      "properties": {
+        "auth_identity": {
+          "type": "string"
+        },
+        "auth_password": {
+          "type": "string"
+        },
+        "auth_secret": {
+          "type": "string"
+        },
+        "auth_username": {
+          "type": "string"
+        },
+        "from": {
+          "type": "string"
+        },
+        "headers": {
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "hello": {
+          "type": "string"
+        },
+        "html": {
+          "type": "string"
+        },
+        "require_tls": {
+          "type": "boolean"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "smarthost": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "tls_config": { "$ref": "#/definitions/tls_config" },
+        "to": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "opsgenie_config": {
+      "properties": {
+        "api_key": {
+          "type": "string"
+        },
+        "api_url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "details": {
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "http_config": { "$ref": "#/definitions/http_config" },
+        "message": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "string"
+        },
+        "responders": {
+          "items": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "enum": ["escalation", "schedule", "team", "user"],
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "pagerduty_config": {
+      "properties": {
+        "client": {
+          "type": "string"
+        },
+        "client_url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "details": {
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "http_config": { "$ref": "#/definitions/http_config" },
+        "images": {
+          "items": {
+            "properties": {
+              "alt": {
+                "type": "string"
+              },
+              "href": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "links": {
+          "items": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "text": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "routing_key": {
+          "type": "string"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "service_key": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "pushover_config": {
+      "properties": {
+        "expire": {
+          "type": "string"
+        },
+        "http_config": { "$ref": "#/definitions/http_config" },
+        "message": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "string"
+        },
+        "retry": {
+          "type": "string"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user_key": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "slack_config": {
+      "properties": {
+        "actions": {
+          "items": {
+            "properties": {
+              "confirm": {
+                "properties": {
+                  "dismiss_text": {
+                    "type": "string"
+                  },
+                  "ok_text": {
+                    "type": "string"
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              },
+              "style": {
+                "type": "string"
+              },
+              "text": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "api_url": {
+          "type": "string"
+        },
+        "callback_id": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "fallback": {
+          "type": "string"
+        },
+        "fields": {
+          "items": {
+            "properties": {
+              "short": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "footer": {
+          "type": "string"
+        },
+        "http_config": { "$ref": "#/definitions/http_config" },
+        "icon_emoji": {
+          "type": "string"
+        },
+        "icon_url": {
+          "type": "string"
+        },
+        "image_url": {
+          "type": "string"
+        },
+        "link_names": {
+          "type": "boolean"
+        },
+        "mrkdwn_in": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "pretext": {
+          "type": "string"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "short_fields": {
+          "type": "boolean"
+        },
+        "text": {
+          "type": "string"
+        },
+        "thumb_url": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "title_link": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "victorops_config": {
+      "properties": {
+        "api_key": {
+          "type": "string"
+        },
+        "api_url": {
+          "type": "string"
+        },
+        "entity_display_name": {
+          "type": "string"
+        },
+        "http_config": { "$ref": "#/definitions/http_config" },
+        "message_type": {
+          "type": "string"
+        },
+        "monitoring_tool": {
+          "type": "string"
+        },
+        "routing_key": {
+          "type": "string"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "state_message": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "webhook_config": {
+      "properties": {
+        "http_config": { "$ref": "#/definitions/http_config" },
+        "max_alerts": {
+          "type": "number"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "wechat_config": {
+      "properties": {
+        "agent_id": {
+          "type": "string"
+        },
+        "api_secret": {
+          "type": "string"
+        },
+        "api_url": {
+          "type": "string"
+        },
+        "corp_id": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "to_party": {
+          "type": "string"
+        },
+        "to_tag": {
+          "type": "string"
+        },
+        "to_user": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "route": {
+      "properties": {
+        "continue": {
+          "type": "boolean"
+        },
+        "group_by": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "group_interval": {
+          "type": "string"
+        },
+        "group_wait": {
+          "type": "string"
+        },
+        "match": {
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "match_re": {
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "receiver": {
+          "type": "string"
+        },
+        "repeat_interval": {
+          "type": "string"
+        },
+        "routes": {
+          "items": { "$ref": "#/definitions/route" },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "description": "Copyright 2021 Opstrace, Inc.\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n     http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
+  "properties": {
+    "global": {
+      "properties": {
+        "http_config": { "$ref": "#/definitions/http_config" },
+        "opsgenie_api_key": {
+          "type": "string"
+        },
+        "opsgenie_api_url": {
+          "type": "string"
+        },
+        "pagerduty_url": {
+          "type": "string"
+        },
+        "resolve_timeout": {
+          "type": "string"
+        },
+        "slack_api_url": {
+          "type": "string"
+        },
+        "smtp_auth_identity": {
+          "type": "string"
+        },
+        "smtp_auth_password": {
+          "type": "string"
+        },
+        "smtp_auth_secret": {
+          "type": "string"
+        },
+        "smtp_auth_username": {
+          "type": "string"
+        },
+        "smtp_from": {
+          "type": "string"
+        },
+        "smtp_hello": {
+          "type": "string"
+        },
+        "smtp_require_tls": {
+          "type": "boolean"
+        },
+        "smtp_smarthost": {
+          "type": "string"
+        },
+        "victorops_api_key": {
+          "type": "string"
+        },
+        "victorops_api_url": {
+          "type": "string"
+        },
+        "wechat_api_corp_id": {
+          "type": "string"
+        },
+        "wechat_api_secret": {
+          "type": "string"
+        },
+        "wechat_api_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "inhibit_rules": {
+      "items": { "$ref": "#/definitions/inhibit_rules" },
+      "type": "array"
+    },
+    "receivers": {
+      "items": {
+        "properties": {
+          "email_configs": {
+            "items": { "$ref": "#/definitions/email_config" },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "opsgenie_configs": {
+            "items": { "$ref": "#/definitions/opsgenie_config" },
+            "type": "array"
+          },
+          "pagerduty_configs": {
+            "items": { "$ref": "#/definitions/pagerduty_config" },
+            "type": "array"
+          },
+          "pushover_configs": {
+            "items": { "$ref": "#/definitions/pushover_config" },
+            "type": "array"
+          },
+          "slack_configs": {
+            "items": { "$ref": "#/definitions/slack_config" },
+            "type": "array"
+          },
+          "victorops_configs": {
+            "items": { "$ref": "#/definitions/victorops_config" },
+            "type": "array"
+          },
+          "webhook_configs": {
+            "items": { "$ref": "#/definitions/webhook_config" },
+            "type": "array"
+          },
+          "wechat_configs": {
+            "items": { "$ref": "#/definitions/wechat_config" },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "route": { "$ref": "#/definitions/route" },
+    "templates": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object"
+}

--- a/packages/app/src/client/validation/alertmanagerConfig/slackConfig.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/slackConfig.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import {
+  SlackConfigActionConfirm,
+  SlackConfigAction,
+  SlackConfigField,
+  SlackConfig
+} from "./types";
+import { httpConfigSchema } from "./common";
+
+const slackConfigActionConfirmSchema: yup.SchemaOf<SlackConfigActionConfirm> = yup
+  .object({
+    text: yup.string().defined(),
+    dismiss_text: yup.string().default(""),
+    ok_text: yup.string().default(""),
+    title: yup.string().default("")
+  })
+  .noUnknown();
+
+const slackConfigActionSchema: yup.SchemaOf<SlackConfigAction> = yup.object({
+  text: yup.string().defined(),
+  type: yup.string().defined(),
+  url: yup.string(),
+  name: yup.string(),
+  value: yup.string(),
+  confirm: slackConfigActionConfirmSchema.notRequired(),
+  style: yup.string().default("")
+});
+
+const slackConfigFieldSchema: yup.SchemaOf<SlackConfigField> = yup
+  .object({
+    title: yup.string().defined(),
+    value: yup.string().defined(),
+    short: yup.boolean().meta({ default: "slack_config.short_fields" })
+  })
+  .noUnknown();
+
+export const slackConfigSchema: yup.SchemaOf<SlackConfig> = yup
+  .object({
+    send_resolved: yup.boolean().default(false).meta({
+      comment: "Whether or not to notify about resolved alerts."
+    }),
+    api_url: yup.string().url().meta({
+      comment: "The Slack webhook URL.",
+      default: "global.slack_api_url"
+    }),
+    channel: yup.string().defined().meta({
+      comment: "The channel or user to send notifications to."
+    }),
+    icon_emoji: yup.string(),
+    icon_url: yup.string(),
+    link_names: yup.boolean().default(false),
+    username: yup.string().default('{{ template "slack.default.username" . }}'),
+    actions: yup.array().of(slackConfigActionSchema).notRequired(),
+    callback_id: yup
+      .string()
+      .default('{{ template "slack.default.callbackid" . }}'),
+    color: yup
+      .string()
+      .default('{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}'),
+    fallback: yup.string().default('{{ template "slack.default.fallback" . }}'),
+    fields: yup.array().of(slackConfigFieldSchema).notRequired(),
+    footer: yup.string().default('{{ template "slack.default.footer" . }}'),
+    mrkdwn_in: yup
+      .array()
+      .of(yup.string())
+      .default(["fallback", "pretext", "text"]),
+    pretext: yup.string().default('{{ template "slack.default.pretext" . }}'),
+    short_fields: yup.boolean().default(false),
+    text: yup.string().default('{{ template "slack.default.text" . }}'),
+    title: yup.string().default('{{ template "slack.default.title" . }}'),
+    title_link: yup
+      .string()
+      .default('{{ template "slack.default.titlelink" . }}'),
+    image_url: yup.string(),
+    thumb_url: yup.string(),
+    http_config: httpConfigSchema
+      .meta({
+        comment: "The HTTP client's configuration.",
+        default: "global.http_config"
+      })
+      .notRequired()
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/types.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/types.ts
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type AlertmanagerConfig = {
+  global?: Global;
+  templates?: string[];
+  route: Route;
+  receivers: Receiver[];
+  inhibit_rules?: InhibitRule[];
+};
+
+export type Global = {
+  smtp_from?: string;
+  smtp_smarthost?: string;
+  smtp_hello?: string;
+  smtp_auth_username?: string;
+  smtp_auth_password?: string;
+  smtp_auth_identity?: string;
+  smtp_auth_secret?: string;
+  smtp_require_tls?: boolean;
+  slack_api_url?: string;
+  victorops_api_key?: string;
+  victorops_api_url?: string;
+  pagerduty_url?: string;
+  opsgenie_api_key?: string;
+  opsgenie_api_url?: string;
+  wechat_api_url?: string;
+  wechat_api_secret?: string;
+  wechat_api_corp_id?: string;
+  http_config?: HttpConfig;
+  resolve_timeout?: string;
+};
+
+export type HttpConfig = {
+  basic_auth?: BasicAuth;
+  bearer_token?: string;
+  bearer_token_file?: string;
+  tls_config?: TlsConfig;
+  proxy_url?: string;
+};
+
+export type BasicAuth = {
+  username?: string;
+  password?: string;
+  password_file?: string;
+};
+
+export type TlsConfig = {
+  ca_file?: string;
+  cert_file?: string;
+  key_file?: string;
+  server_name?: string;
+  insecure_skip_verify?: boolean;
+};
+
+export type Route = {
+  receiver?: string;
+  group_by?: string[];
+  continue?: boolean;
+  match?: Record<string, string>;
+  match_re?: Record<string, string>;
+  group_wait?: string;
+  group_interval?: string;
+  repeat_interval?: string;
+};
+
+export type Receiver = {
+  name: string;
+  email_configs?: EmailConfig[];
+  slack_configs?: SlackConfig[];
+  pagerduty_configs?: PagerdutyConfig[];
+  pushover_configs?: PushoverConfig[];
+  opsgenie_configs?: OpsgenieConfig[];
+  victorops_configs?: VictorOps[];
+  webhook_configs?: WebhookConfig[];
+  wechat_configs?: WechatConfig[];
+};
+
+export type EmailConfig = {
+  send_resolved?: boolean;
+  to: string;
+  from?: string;
+  smarthost?: string;
+  hello?: string;
+  auth_username?: string;
+  auth_password?: string;
+  auth_secret?: string;
+  auth_identity?: string;
+  require_tls?: boolean;
+  tls_config?: TlsConfig;
+  html?: string;
+  text?: string;
+  headers?: Record<string, string>;
+};
+
+export type OpsgenieResponderConfig = {
+  id?: string;
+  name?: string;
+  username?: string;
+  type: "team" | "user" | "escalation" | "schedule";
+};
+
+export type OpsgenieConfig = {
+  send_resolved?: boolean;
+  api_key?: string;
+  api_url?: string;
+  message?: string;
+  description?: string;
+  source?: string;
+  details?: Record<string, string>;
+  responders: OpsgenieResponderConfig[];
+  tags?: string;
+  note?: string;
+  priority?: string;
+  http_config?: HttpConfig;
+};
+
+export type PagerdutyImageConfig = {
+  href?: string;
+  source?: string;
+  alt?: string;
+};
+
+export type PagerdutyLinkConfig = {
+  href?: string;
+  text?: string;
+};
+
+export type PagerdutyConfig = {
+  send_resolved?: boolean;
+  routing_key?: string;
+  service_key?: string;
+  url?: string;
+  client?: string;
+  client_url?: string;
+  description?: string;
+  severity?: string;
+  details?: Record<string, string>;
+  images?: PagerdutyImageConfig[];
+  links?: PagerdutyLinkConfig[];
+  http_config?: HttpConfig;
+};
+
+export type PushoverConfig = {
+  send_resolved?: boolean;
+  user_key: string;
+  title?: string;
+  message?: string;
+  url?: string;
+  priority?: string;
+  retry?: string;
+  expire?: string;
+  http_config?: HttpConfig;
+};
+
+export type SlackConfigActionConfirm = {
+  text: string;
+  dismiss_text?: string;
+  ok_text?: string;
+  title?: string;
+};
+
+export type SlackConfigAction = {
+  text: string;
+  type: string;
+  url?: string;
+  name?: string;
+  value?: string;
+  confirm?: SlackConfigActionConfirm;
+  style?: string;
+};
+
+export type SlackConfigField = {
+  title: string;
+  value: string;
+  short?: boolean;
+};
+export type SlackConfig = {
+  send_resolved?: boolean;
+  api_url?: string;
+  channel: string;
+  icon_emoji?: string;
+  icon_url?: string;
+  link_names?: boolean;
+  username?: string;
+  actions?: SlackConfigAction[];
+  callback_id?: string;
+  color?: string;
+  fallback?: string;
+  fields?: SlackConfigField[];
+  footer?: string;
+  mrkdwn_in?: string[];
+  pretext?: string;
+  short_fields?: boolean;
+  text?: string;
+  title?: string;
+  title_link?: string;
+  image_url?: string;
+  thumb_url?: string;
+  http_config?: HttpConfig;
+};
+
+export type VictorOps = {
+  send_resolved?: boolean;
+  api_key?: string;
+  api_url?: string;
+  routing_key: string;
+  message_type?: string;
+  entity_display_name?: string;
+  state_message?: string;
+  monitoring_tool?: string;
+  http_config?: HttpConfig;
+};
+
+export type WebhookConfig = {
+  send_resolved?: boolean;
+  url?: string;
+  max_alerts?: number;
+  http_config?: HttpConfig;
+};
+
+export type WechatConfig = {
+  send_resolved?: boolean;
+  api_secret?: string;
+  api_url?: string;
+  corp_id?: string;
+  message?: string;
+  agent_id?: string;
+  to_user?: string;
+  to_party?: string;
+  to_tag?: string;
+};
+
+export type InhibitRule = {
+  target_match?: Record<string, string>;
+  target_match_re?: Record<string, string>;
+  source_match?: Record<string, string>;
+  source_match_re?: Record<string, string>;
+  equal?: string[];
+};

--- a/packages/app/src/client/validation/alertmanagerConfig/victoropsConfig.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/victoropsConfig.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { VictorOps } from "./types";
+import { httpConfigSchema } from "./common";
+
+export const victoropsConfigSchema: yup.SchemaOf<VictorOps> = yup
+  .object({
+    send_resolved: yup.boolean().default(true).meta({
+      comment: "Whether or not to notify about resolved alerts."
+    }),
+    api_key: yup.string().meta({
+      comment: "The API key to use when talking to the VictorOps API.",
+      default: "global.victorops_api_key"
+    }),
+    api_url: yup.string().url().meta({
+      comment: "The VictorOps API URL.",
+      default: "global.victorops_api_url"
+    }),
+    routing_key: yup
+      .string()
+      .defined()
+      .meta({ comment: "A key used to map the alert to a team." }),
+    message_type: yup.string().default("CRITICAL").meta({
+      comment: "Describes the behavior of the alert (CRITICAL, WARNING, INFO)."
+    }),
+    entity_display_name: yup
+      .string()
+      .default('{{ template "victorops.default.entity_display_name" . }}')
+      .meta({ comment: "Contains summary of the alerted problem." }),
+    state_message: yup
+      .string()
+      .default('{{ template "victorops.default.state_message" . }}')
+      .meta({
+        comment: "Contains long explanation of the alerted problem."
+      }),
+    monitoring_tool: yup
+      .string()
+      .default('{{ template "victorops.default.monitoring_tool" . }}')
+      .meta({
+        comment: "The monitoring tool the state message is from."
+      }),
+    http_config: httpConfigSchema
+      .meta({
+        comment: "The HTTP client's configuration.",
+        default: "global.http_config"
+      })
+      .notRequired()
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/webhookConfig.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/webhookConfig.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { WebhookConfig } from "./types";
+import { httpConfigSchema } from "./common";
+
+export const webhookConfigSchema: yup.SchemaOf<WebhookConfig> = yup
+  .object({
+    send_resolved: yup.boolean().default(true).meta({
+      comment: "Whether or not to notify about resolved alerts."
+    }),
+    url: yup.string().url().meta({
+      comment: "The endpoint to send HTTP POST requests to."
+    }),
+    max_alerts: yup.number().integer().positive().default(0).meta({
+      comment:
+        "The maximum number of alerts to include in a single webhook message. Alerts above this threshold are truncated. When leaving this at its default value of 0, all alerts are included."
+    }),
+    http_config: httpConfigSchema
+      .meta({
+        comment: "The HTTP client's configuration.",
+        default: "default = global.http_config"
+      })
+      .notRequired()
+  })
+  .meta({
+    urls: [
+      "https://www.prometheus.io/docs/alerting/latest/configuration/#webhook_config",
+      "https://www.prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver"
+    ]
+  })
+  .noUnknown();

--- a/packages/app/src/client/validation/alertmanagerConfig/wechatConfig.ts
+++ b/packages/app/src/client/validation/alertmanagerConfig/wechatConfig.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+
+import { WechatConfig } from "./types";
+
+export const wechatConfigSchema: yup.SchemaOf<WechatConfig> = yup
+  .object({
+    send_resolved: yup.boolean().default(false).meta({
+      comment: "Whether or not to notify about resolved alerts."
+    }),
+    api_secret: yup.string().default("global.wechat_api_secret").meta({
+      commit: "The API key to use when talking to the WeChat API."
+    }),
+    api_url: yup
+      .string()
+      .url()
+      .default("global.wechat_api_url")
+      .meta({ commit: "The WeChat API URL." }),
+    corp_id: yup
+      .string()
+      .default("global.wechat_api_corp_id")
+      .meta({ commit: "The corp id for authentication." }),
+    message: yup.string().default('{{ template "wechat.default.message" . }}'),
+    agent_id: yup
+      .string()
+      .default('{{ template "wechat.default.agent_id" . }}'),
+    to_user: yup.string().default('{{ template "wechat.default.to_user" . }}'),
+    to_party: yup
+      .string()
+      .default('{{ template "wechat.default.to_party" . }}'),
+    to_tag: yup.string().default('{{ template "wechat.default.to_tag" . }}')
+  })
+  .noUnknown();

--- a/packages/app/src/client/views/cluster/AddTenantDialog.tsx
+++ b/packages/app/src/client/views/cluster/AddTenantDialog.tsx
@@ -20,9 +20,7 @@ import { usePickerService } from "client/services/Picker";
 import { useCommandService } from "client/services/Command";
 import { addTenant } from "state/tenant/actions";
 import { useDispatch } from "react-redux";
-
-// eslint-disable-next-line no-useless-escape
-const subdomainValidator = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$/;
+import { subdomainValidator } from "client/utils/regex";
 
 const AddTenantPicker = () => {
   const dispatch = useDispatch();

--- a/packages/app/src/client/views/cluster/AlertmanagerConfigEditor.tsx
+++ b/packages/app/src/client/views/cluster/AlertmanagerConfigEditor.tsx
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useRef, useCallback } from "react";
+import { useParams } from "react-router-dom";
+import { useDispatch } from "state/provider";
+import { editor } from "monaco-editor/esm/vs/editor/editor.api";
+import * as yamlParser from "js-yaml";
+
+import { debounce } from "lodash";
+
+import Skeleton from "@material-ui/lab/Skeleton";
+
+import { Box } from "client/components/Box";
+
+import Layout from "client/layout/MainContent";
+import SideBar from "./Sidebar";
+import { YamlEditor } from "client/components/Editor";
+
+import { Card, CardContent, CardHeader } from "client/components/Card";
+import { Button } from "client/components/Button";
+
+import { useTenant, useAlertmanager } from "state/tenant/hooks";
+import { updateAlertmanager } from "state/tenant/actions";
+
+import {
+  alertmanagerConfigSchema,
+  jsonSchema
+} from "client/validation/alertmanagerConfig";
+
+type validationCheckOptions = {
+  useModelMarkers: boolean;
+};
+
+const AlertmanagerConfigEditor = () => {
+  const { tenantId } = useParams<{ tenantId: string }>();
+  const tenant = useTenant(tenantId);
+  const alertmanager = useAlertmanager(tenantId);
+  const configRef = useRef<string>(alertmanager?.config || "");
+  const [configValid, setConfigValid] = useState<boolean | null>(null);
+  const dispatch = useDispatch();
+
+  const handleConfigChange = useCallback((newConfig, filename) => {
+    const validationCheck: (
+      filename: string,
+      options?: validationCheckOptions
+    ) => void = (filename, options) => {
+      const markers = options?.useModelMarkers
+        ? editor.getModelMarkers({
+            resource: monaco.Uri.parse(filename)
+          })
+        : [];
+
+      if (markers.length === 0) {
+        try {
+          const parsedData = yamlParser.load(configRef.current, {
+            schema: yamlParser.JSON_SCHEMA
+          });
+
+          alertmanagerConfigSchema
+            .validate(parsedData, { strict: true })
+            .then((value: object) => {
+              setConfigValid(true);
+            })
+            .catch((err: { name: string; errors: string[] }) => {
+              setConfigValid(false);
+            });
+        } catch (e) {
+          setConfigValid(false);
+        }
+      } else {
+        setConfigValid(false);
+      }
+    };
+
+    const validationCheckOnChangeStart = debounce(validationCheck, 300, {
+      leading: true,
+      trailing: false
+    });
+    const checkValidationOnChangePause = debounce(validationCheck, 500, {
+      maxWait: 5000
+    });
+
+    configRef.current = newConfig;
+    validationCheckOnChangeStart(filename);
+    checkValidationOnChangePause(filename);
+  }, []);
+
+  const handleSave = useCallback(() => {
+    if (tenant?.name) {
+      dispatch(
+        updateAlertmanager({
+          tenantId: tenant.name,
+          header: alertmanager?.header || "",
+          config: configRef.current
+        })
+      );
+    }
+  }, [tenant?.name, alertmanager?.header, dispatch]);
+
+  if (!tenant)
+    return (
+      <Layout sidebar={SideBar}>
+        <Skeleton variant="rect" width="100%" height="100%" animation="wave" />
+      </Layout>
+    );
+  else
+    return (
+      <Layout sidebar={SideBar}>
+        <Box
+          width="100%"
+          height="100%"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          flexWrap="wrap"
+          p={1}
+        >
+          <Box maxWidth={700}>
+            <Card p={3}>
+              <CardHeader
+                titleTypographyProps={{ variant: "h5" }}
+                title={`${tenant.name} / Alertmanager Configuration`}
+              />
+              <CardContent>
+                <Box display="flex" height="500px" width="700px">
+                  <YamlEditor
+                    filename="alertmanager-config.yaml"
+                    jsonSchema={jsonSchema}
+                    data={alertmanager?.config || ""}
+                    onChange={handleConfigChange}
+                  />
+                </Box>
+              </CardContent>
+              <Button
+                variant="contained"
+                state="primary"
+                disabled={!configValid}
+                onClick={handleSave}
+              >
+                publish
+              </Button>
+            </Card>
+          </Box>
+        </Box>
+      </Layout>
+    );
+};
+
+export default AlertmanagerConfigEditor;

--- a/packages/app/src/client/views/cluster/TenantDetail.tsx
+++ b/packages/app/src/client/views/cluster/TenantDetail.tsx
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import Skeleton from "@material-ui/lab/Skeleton";
+import { useDispatch } from "react-redux";
+
+import { Box } from "client/components/Box";
+import Attribute from "client/components/Attribute";
+
+import { deleteTenant } from "state/tenant/actions";
+
+import Layout from "client/layout/MainContent";
+import Typography from "client/components/Typography/Typography";
+import SideBar from "./Sidebar";
+
+import { Card, CardContent, CardHeader } from "client/components/Card";
+import { Button } from "client/components/Button";
+import { usePickerService } from "client/services/Picker";
+import { useHistory } from "react-router-dom";
+import useTenantList from "state/tenant/hooks/useTenantList";
+import { ExternalLink } from "client/components/Link";
+
+const TenantDetail = () => {
+  const params = useParams<{ tenant: string }>();
+  const history = useHistory();
+  const tenants = useTenantList();
+  const dispatch = useDispatch();
+
+  const selectedTenant = useMemo(
+    () => tenants.find(t => t.name === params.tenant),
+    [params.tenant, tenants]
+  );
+
+  const { activatePickerWithText } = usePickerService(
+    {
+      title: `Delete ${selectedTenant?.name}?`,
+      activationPrefix: "delete tenant directly?:",
+      disableFilter: true,
+      disableInput: true,
+      options: [
+        {
+          id: "yes",
+          text: `yes`
+        },
+        {
+          id: "no",
+          text: "no"
+        }
+      ],
+      onSelected: option => {
+        if (option.id === "yes" && selectedTenant?.name) {
+          dispatch(deleteTenant(selectedTenant?.name));
+        }
+      }
+    },
+    [selectedTenant?.name]
+  );
+
+  if (!selectedTenant)
+    return (
+      <Layout sidebar={SideBar}>
+        <Skeleton variant="rect" width="100%" height="100%" animation="wave" />
+      </Layout>
+    );
+  else
+    return (
+      <Layout sidebar={SideBar}>
+        <Box
+          width="100%"
+          height="100%"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          flexWrap="wrap"
+          p={1}
+        >
+          <Box maxWidth={700}>
+            <Card p={3}>
+              <CardHeader
+                titleTypographyProps={{ variant: "h5" }}
+                action={
+                  <Box ml={3} display="flex" flexWrap="wrap">
+                    <Box p={1}>
+                      <Button
+                        variant="outlined"
+                        size="medium"
+                        onClick={() =>
+                          history.push(
+                            `/cluster/tenants/${selectedTenant.name}/alert-manager-config`
+                          )
+                        }
+                      >
+                        Alerts
+                      </Button>
+                    </Box>
+                    <Box p={1}>
+                      <Button
+                        variant="outlined"
+                        size="medium"
+                        disabled={selectedTenant.type === "SYSTEM"}
+                        onClick={() =>
+                          activatePickerWithText("delete tenant directly?: ")
+                        }
+                      >
+                        Delete
+                      </Button>
+                    </Box>
+                  </Box>
+                }
+                title={selectedTenant.name}
+              />
+              <CardContent>
+                <Box display="flex">
+                  <Box display="flex" flexDirection="column">
+                    <Attribute.Key>Grafana:</Attribute.Key>
+                    <Attribute.Key>Created:</Attribute.Key>
+                  </Box>
+                  <Box display="flex" flexDirection="column" flexGrow={1}>
+                    <Attribute.Value>
+                      <ExternalLink
+                        href={`${window.location.protocol}//${selectedTenant.name}.${window.location.host}`}
+                      >
+                        {`${selectedTenant.name}.${window.location.host}`}
+                      </ExternalLink>
+                    </Attribute.Value>
+                    <Attribute.Value>
+                      {selectedTenant.created_at}
+                    </Attribute.Value>
+                  </Box>
+                </Box>
+              </CardContent>
+            </Card>
+            <Typography color="textSecondary">
+              New tenants can take 5 minutes to provision with dns propagation
+            </Typography>
+          </Box>
+        </Box>
+      </Layout>
+    );
+};
+
+export default TenantDetail;

--- a/packages/app/src/client/views/routes.tsx
+++ b/packages/app/src/client/views/routes.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Opstrace, Inc.
+ * Copyright 2021 Opstrace, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ import SelectedModule from "./module/SelectedModule";
 import Modules from "./module/Modules";
 import ChatView from "./chat";
 import HistoryView from "./history";
-import ClusterView from "./cluster";
+import UserDetail from "./cluster/UserDetail";
+import TenantDetail from "./cluster/TenantDetail";
+import AlertmanagerConfigEditor from "./cluster/AlertmanagerConfigEditor";
 import HelpDialog from "./help";
 import NotFound from "./404/404";
 import FullPage from "client/layout/FullPage";
@@ -105,12 +107,17 @@ const AuthenticatedRoutes = () => {
         <Route
           key="/cluster/users/:id"
           path="/cluster/users/:id"
-          component={ClusterView}
+          component={UserDetail}
+        />
+        <Route
+          key="/cluster/tenants/:tenantId/alert-manager-config"
+          path="/cluster/tenants/:tenantId/alert-manager-config"
+          component={AlertmanagerConfigEditor}
         />
         <Route
           key="/cluster/tenants/:tenant"
           path="/cluster/tenants/:tenant"
-          component={ClusterView}
+          component={TenantDetail}
         />
         <Route key="*" path="*" component={NotFound} />
       </Switch>

--- a/packages/app/src/state/graphql-api-types.ts
+++ b/packages/app/src/state/graphql-api-types.ts
@@ -41,6 +41,23 @@ export type Scalars = {
   uuid: any;
 };
 
+export type Alertmanager = {
+  config?: Maybe<Scalars["String"]>;
+  online: Scalars["Boolean"];
+  tenant_id: Scalars["String"];
+};
+
+export type AlertmanagerInput = {
+  config: Scalars["String"];
+};
+
+export type AlertmanagerUpdateResponse = {
+  error_message?: Maybe<Scalars["String"]>;
+  error_raw_response?: Maybe<Scalars["String"]>;
+  error_type?: Maybe<ErrorType>;
+  success: Scalars["Boolean"];
+};
+
 /** expression to compare columns of type Boolean. All fields are combined with logical 'AND'. */
 export type Boolean_Comparison_Exp = {
   _eq?: Maybe<Scalars["Boolean"]>;
@@ -53,6 +70,12 @@ export type Boolean_Comparison_Exp = {
   _neq?: Maybe<Scalars["Boolean"]>;
   _nin?: Maybe<Array<Scalars["Boolean"]>>;
 };
+
+export enum ErrorType {
+  ServiceError = "SERVICE_ERROR",
+  ServiceOffline = "SERVICE_OFFLINE",
+  ValidationFailed = "VALIDATION_FAILED"
+}
 
 /** expression to compare columns of type String. All fields are combined with logical 'AND'. */
 export type String_Comparison_Exp = {
@@ -71,6 +94,13 @@ export type String_Comparison_Exp = {
   _nlike?: Maybe<Scalars["String"]>;
   _nsimilar?: Maybe<Scalars["String"]>;
   _similar?: Maybe<Scalars["String"]>;
+};
+
+export type ValidateOutput = {
+  error_message?: Maybe<Scalars["String"]>;
+  error_raw_response?: Maybe<Scalars["String"]>;
+  error_type?: Maybe<ErrorType>;
+  success: Scalars["Boolean"];
 };
 
 /** columns and relationships of "branch" */
@@ -1629,6 +1659,8 @@ export type Mutation_Root = {
   insert_user_preference?: Maybe<User_Preference_Mutation_Response>;
   /** insert a single row into the table: "user_preference" */
   insert_user_preference_one?: Maybe<User_Preference>;
+  /** perform the action: "updateAlertmanager" */
+  updateAlertmanager?: Maybe<AlertmanagerUpdateResponse>;
   /** update data of the table: "branch" */
   update_branch?: Maybe<Branch_Mutation_Response>;
   /** update single row of the table: "branch" */
@@ -1873,6 +1905,12 @@ export type Mutation_RootInsert_User_Preference_OneArgs = {
 };
 
 /** mutation root */
+export type Mutation_RootUpdateAlertmanagerArgs = {
+  input?: Maybe<AlertmanagerInput>;
+  tenant_id: Scalars["String"];
+};
+
+/** mutation root */
 export type Mutation_RootUpdate_BranchArgs = {
   _set?: Maybe<Branch_Set_Input>;
   where: Branch_Bool_Exp;
@@ -2032,6 +2070,8 @@ export type Query_Root = {
   file_aggregate: File_Aggregate;
   /** fetch data from the table: "file" using primary key columns */
   file_by_pk?: Maybe<File>;
+  /** perform the action: "getAlertmanager" */
+  getAlertmanager?: Maybe<Alertmanager>;
   /** fetch data from the table: "module" */
   module: Array<Module>;
   /** fetch aggregated fields from the table: "module" */
@@ -2062,6 +2102,10 @@ export type Query_Root = {
   user_preference_aggregate: User_Preference_Aggregate;
   /** fetch data from the table: "user_preference" using primary key columns */
   user_preference_by_pk?: Maybe<User_Preference>;
+  /** perform the action: "validateCredential" */
+  validateCredential?: Maybe<ValidateOutput>;
+  /** perform the action: "validateExporter" */
+  validateExporter?: Maybe<ValidateOutput>;
 };
 
 /** query root */
@@ -2156,6 +2200,11 @@ export type Query_RootFile_AggregateArgs = {
 /** query root */
 export type Query_RootFile_By_PkArgs = {
   id: Scalars["uuid"];
+};
+
+/** query root */
+export type Query_RootGetAlertmanagerArgs = {
+  tenant_id: Scalars["String"];
 };
 
 /** query root */
@@ -2278,6 +2327,23 @@ export type Query_RootUser_Preference_By_PkArgs = {
   id: Scalars["uuid"];
 };
 
+/** query root */
+export type Query_RootValidateCredentialArgs = {
+  name: Scalars["String"];
+  tenant_id: Scalars["String"];
+  type: Scalars["String"];
+  value: Scalars["json"];
+};
+
+/** query root */
+export type Query_RootValidateExporterArgs = {
+  config: Scalars["json"];
+  credential: Scalars["String"];
+  name: Scalars["String"];
+  tenant_id: Scalars["String"];
+  type: Scalars["String"];
+};
+
 /** subscription root */
 export type Subscription_Root = {
   /** fetch data from the table: "branch" */
@@ -2304,6 +2370,8 @@ export type Subscription_Root = {
   file_aggregate: File_Aggregate;
   /** fetch data from the table: "file" using primary key columns */
   file_by_pk?: Maybe<File>;
+  /** perform the action: "getAlertmanager" */
+  getAlertmanager?: Maybe<Alertmanager>;
   /** fetch data from the table: "module" */
   module: Array<Module>;
   /** fetch aggregated fields from the table: "module" */
@@ -2334,6 +2402,10 @@ export type Subscription_Root = {
   user_preference_aggregate: User_Preference_Aggregate;
   /** fetch data from the table: "user_preference" using primary key columns */
   user_preference_by_pk?: Maybe<User_Preference>;
+  /** perform the action: "validateCredential" */
+  validateCredential?: Maybe<ValidateOutput>;
+  /** perform the action: "validateExporter" */
+  validateExporter?: Maybe<ValidateOutput>;
 };
 
 /** subscription root */
@@ -2428,6 +2500,11 @@ export type Subscription_RootFile_AggregateArgs = {
 /** subscription root */
 export type Subscription_RootFile_By_PkArgs = {
   id: Scalars["uuid"];
+};
+
+/** subscription root */
+export type Subscription_RootGetAlertmanagerArgs = {
+  tenant_id: Scalars["String"];
 };
 
 /** subscription root */
@@ -2548,6 +2625,23 @@ export type Subscription_RootUser_Preference_AggregateArgs = {
 /** subscription root */
 export type Subscription_RootUser_Preference_By_PkArgs = {
   id: Scalars["uuid"];
+};
+
+/** subscription root */
+export type Subscription_RootValidateCredentialArgs = {
+  name: Scalars["String"];
+  tenant_id: Scalars["String"];
+  type: Scalars["String"];
+  value: Scalars["json"];
+};
+
+/** subscription root */
+export type Subscription_RootValidateExporterArgs = {
+  config: Scalars["json"];
+  credential: Scalars["String"];
+  name: Scalars["String"];
+  tenant_id: Scalars["String"];
+  type: Scalars["String"];
 };
 
 /** columns and relationships of "tenant" */
@@ -3541,6 +3635,14 @@ export type DeleteTenantMutation = {
   delete_tenant_by_pk?: Maybe<Pick<Tenant, "name">>;
 };
 
+export type GetAlertmanagerQueryVariables = Exact<{
+  tenant_id: Scalars["String"];
+}>;
+
+export type GetAlertmanagerQuery = {
+  getAlertmanager?: Maybe<Pick<Alertmanager, "config" | "online">>;
+};
+
 export type GetTenantsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetTenantsQuery = {
@@ -3553,6 +3655,20 @@ export type SubscribeToTenantListSubscriptionVariables = Exact<{
 
 export type SubscribeToTenantListSubscription = {
   tenant: Array<Pick<Tenant, "name" | "created_at" | "type">>;
+};
+
+export type UpdateAlertmanagerMutationVariables = Exact<{
+  tenant_id: Scalars["String"];
+  input: AlertmanagerInput;
+}>;
+
+export type UpdateAlertmanagerMutation = {
+  updateAlertmanager?: Maybe<
+    Pick<
+      AlertmanagerUpdateResponse,
+      "success" | "error_type" | "error_message" | "error_raw_response"
+    >
+  >;
 };
 
 export type CreateUserMutationVariables = Exact<{
@@ -4131,6 +4247,14 @@ export const DeleteTenantDocument = gql`
     }
   }
 `;
+export const GetAlertmanagerDocument = gql`
+  query GetAlertmanager($tenant_id: String!) {
+    getAlertmanager(tenant_id: $tenant_id) {
+      config
+      online
+    }
+  }
+`;
 export const GetTenantsDocument = gql`
   query GetTenants {
     tenant {
@@ -4146,6 +4270,16 @@ export const SubscribeToTenantListDocument = gql`
       name
       created_at
       type
+    }
+  }
+`;
+export const UpdateAlertmanagerDocument = gql`
+  mutation UpdateAlertmanager($tenant_id: String!, $input: AlertmanagerInput!) {
+    updateAlertmanager(tenant_id: $tenant_id, input: $input) {
+      success
+      error_type
+      error_message
+      error_raw_response
     }
   }
 `;
@@ -4780,6 +4914,22 @@ export function getSdk(
         )
       );
     },
+    GetAlertmanager(
+      variables: GetAlertmanagerQueryVariables
+    ): Promise<{
+      data?: GetAlertmanagerQuery | undefined;
+      extensions?: any;
+      headers: Headers;
+      status: number;
+      errors?: GraphQLError[] | undefined;
+    }> {
+      return withWrapper(() =>
+        client.rawRequest<GetAlertmanagerQuery>(
+          print(GetAlertmanagerDocument),
+          variables
+        )
+      );
+    },
     GetTenants(
       variables?: GetTenantsQueryVariables
     ): Promise<{
@@ -4805,6 +4955,22 @@ export function getSdk(
       return withWrapper(() =>
         client.rawRequest<SubscribeToTenantListSubscription>(
           print(SubscribeToTenantListDocument),
+          variables
+        )
+      );
+    },
+    UpdateAlertmanager(
+      variables: UpdateAlertmanagerMutationVariables
+    ): Promise<{
+      data?: UpdateAlertmanagerMutation | undefined;
+      extensions?: any;
+      headers: Headers;
+      status: number;
+      errors?: GraphQLError[] | undefined;
+    }> {
+      return withWrapper(() =>
+        client.rawRequest<UpdateAlertmanagerMutation>(
+          print(UpdateAlertmanagerDocument),
           variables
         )
       );

--- a/packages/app/src/state/tenant/actions.ts
+++ b/packages/app/src/state/tenant/actions.ts
@@ -16,9 +16,9 @@
 import { createAction } from "typesafe-actions";
 import { SubscriptionID, Tenants } from "./types";
 
-export const subscribeToTenantList = createAction("SUBSCRIBE_TENANT_LIST")<
-  SubscriptionID
->();
+export const subscribeToTenantList = createAction(
+  "SUBSCRIBE_TENANT_LIST"
+)<SubscriptionID>();
 
 export const unsubscribeFromTenantList = createAction(
   "UNSUBSCRIBE_TENANT_LIST"
@@ -26,3 +26,16 @@ export const unsubscribeFromTenantList = createAction(
 export const setTenantList = createAction("SET_TENANT_LIST")<Tenants>();
 export const deleteTenant = createAction("DELETE_TENANT")<string>();
 export const addTenant = createAction("ADD_TENANT")<string>();
+
+export const getAlertmanager = createAction("GET_ALERTMANAGER")<string>();
+export const alertmanagerLoaded = createAction("ALERTMANAGER_LOADED")<{
+  tenantId: string;
+  header: string;
+  config: string;
+  online: boolean;
+}>();
+export const updateAlertmanager = createAction("UPDATE_ALERTMANAGER")<{
+  tenantId: string;
+  header: string;
+  config: string;
+}>();

--- a/packages/app/src/state/tenant/hooks/index.ts
+++ b/packages/app/src/state/tenant/hooks/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Opstrace, Inc.
+ * Copyright 2021 Opstrace, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,23 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SubscribeToTenantListSubscription } from "state/clients/graphqlClient";
 
-export type Alertmanager = {
-  header: string;
-  config: string;
-  online?: boolean;
-};
-
-type TenantVirtualFields = {
-  alertmanager?: Alertmanager;
-};
-
-export type Tenant = SubscribeToTenantListSubscription["tenant"][0] &
-  TenantVirtualFields;
-
-export type Tenants = Tenant[];
-export type TenantRecords = Record<string, Tenant>;
-
-// use this same id to unsubscribe
-export type SubscriptionID = number;
+export { default as useAlertmanager } from "./useAlertmanager";
+export { default as useTenant } from "./useTenant";

--- a/packages/app/src/state/tenant/hooks/useAlertmanager.ts
+++ b/packages/app/src/state/tenant/hooks/useAlertmanager.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSelector } from "reselect";
+import { useSelector, useDispatch, State } from "state/provider";
+
+import { selectTenant } from "./useTenant";
+import { getAlertmanager } from "state/tenant/actions";
+
+export const selectAlertmanager = createSelector(
+  selectTenant,
+  tenant => tenant?.alertmanager
+);
+
+export default function useAlertmanager(tenantName: string) {
+  const data = useSelector((state: State) =>
+    selectAlertmanager(state, tenantName)
+  );
+
+  const dispatch = useDispatch();
+
+  if (!data) dispatch(getAlertmanager(tenantName));
+
+  return data;
+}

--- a/packages/app/src/state/tenant/hooks/useTenant.ts
+++ b/packages/app/src/state/tenant/hooks/useTenant.ts
@@ -18,9 +18,11 @@ import { createSelector } from "reselect";
 import { useSelector, State } from "state/provider";
 
 export const selectTenant = createSelector(
+  (state: State) => state.tenants.loading,
   (state, _) => state.tenants.tenants,
   (_: State, tenantName: string) => tenantName,
-  (tenants, tenantName: string) => tenants[tenantName]
+  (loading, tenants, tenantName: string) =>
+    loading ? null : tenants[tenantName]
 );
 
 export default function useTenant(tenantName: string) {

--- a/packages/app/src/state/tenant/hooks/useTenant.ts
+++ b/packages/app/src/state/tenant/hooks/useTenant.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Opstrace, Inc.
+ * Copyright 2021 Opstrace, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,23 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SubscribeToTenantListSubscription } from "state/clients/graphqlClient";
 
-export type Alertmanager = {
-  header: string;
-  config: string;
-  online?: boolean;
-};
+import { createSelector } from "reselect";
+import { useSelector, State } from "state/provider";
 
-type TenantVirtualFields = {
-  alertmanager?: Alertmanager;
-};
+export const selectTenant = createSelector(
+  (state, _) => state.tenants.tenants,
+  (_: State, tenantName: string) => tenantName,
+  (tenants, tenantName: string) => tenants[tenantName]
+);
 
-export type Tenant = SubscribeToTenantListSubscription["tenant"][0] &
-  TenantVirtualFields;
-
-export type Tenants = Tenant[];
-export type TenantRecords = Record<string, Tenant>;
-
-// use this same id to unsubscribe
-export type SubscriptionID = number;
+export default function useTenant(tenantName: string) {
+  return useSelector((state: State) => selectTenant(state, tenantName));
+}

--- a/packages/app/src/state/tenant/hooks/useTenantList.ts
+++ b/packages/app/src/state/tenant/hooks/useTenantList.ts
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 import { useEffect } from "react";
+import { values } from "ramda";
+import { createSelector } from "reselect";
 import { useDispatch, useSelector, State } from "state/provider";
+
 import { subscribeToTenantList, unsubscribeFromTenantList } from "../actions";
 import getSubscriptionID from "state/utils/getSubscriptionID";
-import { Tenants } from "state/tenant/types";
-import { values } from "ramda";
 
-export const getTenantList = (state: State) =>
-  values(state.tenants.tenants) as Tenants;
+const selectTenantList = createSelector(
+  (state: State) => state.tenants.tenants,
+  tenants => values(tenants)
+);
 
 /**
  * Subscribes to tenants and will update on
@@ -29,7 +32,7 @@ export const getTenantList = (state: State) =>
  * on unmount.
  */
 export default function useTenantList() {
-  const tenants = useSelector(getTenantList);
+  const tenants = useSelector(selectTenantList);
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/packages/app/src/state/tenant/hooks/useTenantList.ts
+++ b/packages/app/src/state/tenant/hooks/useTenantList.ts
@@ -22,8 +22,9 @@ import { subscribeToTenantList, unsubscribeFromTenantList } from "../actions";
 import getSubscriptionID from "state/utils/getSubscriptionID";
 
 const selectTenantList = createSelector(
+  (state: State) => state.tenants.loading,
   (state: State) => state.tenants.tenants,
-  tenants => values(tenants)
+  (loading, tenants) => (loading ? [] : values(tenants))
 );
 
 /**

--- a/packages/app/src/state/tenant/queries/getAlertmanager.gql
+++ b/packages/app/src/state/tenant/queries/getAlertmanager.gql
@@ -1,0 +1,6 @@
+query GetAlertmanager($tenant_id: String!) {
+  getAlertmanager(tenant_id: $tenant_id) {
+    config
+    online
+  }
+}

--- a/packages/app/src/state/tenant/queries/updateAlertmanager.gql
+++ b/packages/app/src/state/tenant/queries/updateAlertmanager.gql
@@ -1,0 +1,8 @@
+mutation UpdateAlertmanager($tenant_id: String!, $input: AlertmanagerInput!) {
+  updateAlertmanager(tenant_id: $tenant_id, input: $input) {
+    success
+    error_type
+    error_message
+    error_raw_response
+  }
+}

--- a/packages/app/src/workers/index.ts
+++ b/packages/app/src/workers/index.ts
@@ -17,11 +17,19 @@
 import "monaco-editor/esm/vs/editor/editor.api";
 import "monaco-editor/esm/vs/editor/edcore.main";
 import "monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution";
+import "monaco-yaml/lib/esm/monaco.contribution";
 /* eslint-disable import/no-webpack-loader-syntax */
+/*
+  ts-ignore these imports that use worker-loader:
+  Cannot find module 'worker-loader!monaco-yaml/lib/esm/yaml.worker' or its corresponding type declarations
+*/
 //@ts-ignore
 import EditorWorker from "worker-loader!monaco-editor/esm/vs/editor/editor.worker.js";
 //@ts-ignore
 import OpScriptWebWorker from "worker-loader!./opscript/opscript.worker";
+//@ts-ignore
+import YamlWorker from "worker-loader!monaco-yaml/lib/esm/yaml.worker";
+
 // Register our typescript language features
 import {
   getTypeScriptWorker,
@@ -32,6 +40,8 @@ import {
   ModuleResolutionKind
 } from "./monaco-typescript-4.1.1/monaco.contribution";
 
+import { languages } from "monaco-editor/esm/vs/editor/editor.api";
+
 import type { OpScriptWorker } from "./opscript/opscriptWorker";
 import buildTime from "client/buildInfo";
 
@@ -41,6 +51,8 @@ export const getOpScriptWorker = async (): Promise<OpScriptWorker> => {
   return client as OpScriptWorker;
 };
 export const opScriptDefaults = typescriptDefaults;
+// @ts-ignore
+export const { yaml } = languages || {};
 
 (async function fetchSDKTypings() {
   if (process.env.RUNTIME === "sandbox") {
@@ -76,6 +88,9 @@ opScriptDefaults.setCompilerOptions({
   getWorker: function (_: any, label: string) {
     if (label === "typescript") {
       return new OpScriptWebWorker();
+    }
+    if (label === "yaml") {
+      return new YamlWorker();
     }
     return new EditorWorker();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4342,7 +4342,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/lodash@^4.14.149":
+"@types/lodash@^4.14.149", "@types/lodash@^4.14.165":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
@@ -5502,6 +5502,13 @@ adjust-sourcemap-loader@3.0.0:
   dependencies:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
+
+agent-base@4, agent-base@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+  dependencies:
+    es6-promisify "^5.0.0"
 
 agent-base@5:
   version "5.1.1"
@@ -8511,6 +8518,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@3.1.0, debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@4, debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@~4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
@@ -8518,14 +8532,7 @@ debug@4, debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, de
   dependencies:
     ms "2.1.2"
 
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@^3.0.0, debug@^3.0.1, debug@^3.1.1, debug@^3.2.6:
+debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -9417,10 +9424,17 @@ es6-iterator@2.0.3, es6-iterator@^2.0.3, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-promise@^4.1.1:
+es6-promise@^4.0.3, es6-promise@^4.1.1:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
+  dependencies:
+    es6-promise "^4.0.3"
 
 es6-shim@^0.35.5:
   version "0.35.6"
@@ -11754,6 +11768,14 @@ http-parser-js@>=0.5.1:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.3.tgz#01d2709c79d41698bb01d4decc5e9da4e4a033d9"
   integrity sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==
 
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
+  dependencies:
+    agent-base "4"
+    debug "3.1.0"
+
 http-proxy-agent@^4.0.0, http-proxy-agent@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
@@ -11811,6 +11833,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+https-proxy-agent@^2.2.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
+  integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
+  dependencies:
+    agent-base "^4.3.0"
+    debug "^3.1.0"
 
 https-proxy-agent@^4.0.0:
   version "4.0.0"
@@ -13381,7 +13411,7 @@ jpeg-js@^0.4.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.0.0:
+js-yaml@4.0.0, js-yaml@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
   integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
@@ -13654,7 +13684,12 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@~3.0.0:
+jsonc-parser@^2.2.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.3.1.tgz#59549150b133f2efacca48fe9ce1ec0659af2342"
+  integrity sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==
+
+jsonc-parser@^3.0.0, jsonc-parser@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
   integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
@@ -15030,6 +15065,13 @@ monaco-editor@0.21.3:
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.3.tgz#3381b66614b64d1c5e3b77dd5564ad496d1b4e5d"
   integrity sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==
 
+monaco-yaml@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/monaco-yaml/-/monaco-yaml-2.5.1.tgz#af9303a4aa6e3b94db62b8a8659362f31944590d"
+  integrity sha512-U+zIAcwnQzlUgy6vdzFdNf5PToFzuz099FxYmUxIeen9GTiq6XYDX9mmXSR31mMrgiSaU5a2bGEyG4p2fbW/7A==
+  dependencies:
+    yaml-language-server "^0.11.1"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -15106,6 +15148,11 @@ nan@^2.12.1, nan@^2.14.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@3.1.20:
   version "3.1.20"
@@ -17031,6 +17078,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier@2.0.5, prettier@~2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
@@ -17040,11 +17092,6 @@ prettier@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
-
-prettier@~2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
-  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"
@@ -17189,7 +17236,7 @@ proper-lockfile@^4.1.1:
     retry "^0.12.0"
     signal-exit "^3.0.2"
 
-property-expr@^2.0.2:
+property-expr@^2.0.2, property-expr@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.4.tgz#37b925478e58965031bb612ec5b3260f8241e910"
   integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
@@ -18345,6 +18392,15 @@ replaceall@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/replaceall/-/replaceall-0.1.6.tgz#81d81ac7aeb72d7f5c4942adf2697a3220688d8e"
   integrity sha1-gdgax663LX9cSUKt8ml6MiBojY4=
+
+request-light@^0.2.4:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.2.5.tgz#38a3da7b2e56f7af8cbba57e8a94930ee2380746"
+  integrity sha512-eBEh+GzJAftUnex6tcL6eV2JCifY0+sZMIUpUPOVXbs2nV5hla4ZMmO3icYKGuGVuQ2zHE9evh4OrRcH4iyYYw==
+  dependencies:
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.3"
+    vscode-nls "^4.1.1"
 
 request-progress@^3.0.0:
   version "3.0.0"
@@ -21331,6 +21387,78 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+vscode-json-languageservice@^3.6.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.11.0.tgz#ad574b36c4346bd7830f1d34b5a5213d3af8d232"
+  integrity sha512-QxI+qV97uD7HHOCjh3MrM1TfbdwmTXrMckri5Tus1/FQiG3baDZb2C9Y0y8QThs7PwHYBIQXcAc59ZveCRZKPA==
+  dependencies:
+    jsonc-parser "^3.0.0"
+    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-types "3.16.0-next.2"
+    vscode-nls "^5.0.0"
+    vscode-uri "^2.1.2"
+
+vscode-jsonrpc@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
+  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
+
+vscode-languageserver-protocol@3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
+  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
+  dependencies:
+    vscode-jsonrpc "^4.0.0"
+    vscode-languageserver-types "3.14.0"
+
+vscode-languageserver-textdocument@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
+  integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
+
+vscode-languageserver-types@3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
+  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
+
+vscode-languageserver-types@3.16.0-next.2:
+  version "3.16.0-next.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz#940bd15c992295a65eae8ab6b8568a1e8daa3083"
+  integrity sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==
+
+vscode-languageserver-types@^3.15.1:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
+  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
+
+vscode-languageserver@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz#0d2feddd33f92aadf5da32450df498d52f6f14eb"
+  integrity sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==
+  dependencies:
+    vscode-languageserver-protocol "3.14.1"
+    vscode-uri "^1.0.6"
+
+vscode-nls@^4.1.1, vscode-nls@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-4.1.2.tgz#ca8bf8bb82a0987b32801f9fddfdd2fb9fd3c167"
+  integrity sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==
+
+vscode-nls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
+  integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
+
+vscode-uri@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
+  integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
+
+vscode-uri@^2.1.1, vscode-uri@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
+  integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
+
 w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
@@ -22079,10 +22207,32 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml-ast-parser-custom-tags@0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/yaml-ast-parser-custom-tags/-/yaml-ast-parser-custom-tags-0.0.43.tgz#46968145ce4e24cb03c3312057f0f141b93a7d02"
+  integrity sha512-R5063FF/JSAN6qXCmylwjt9PcDH6M0ExEme/nJBzLspc6FJDmHHIqM7xh2WfEmsTJqClF79A9VkXjkAqmZw9SQ==
+
 yaml-ast-parser@^0.0.43:
   version "0.0.43"
   resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
   integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
+
+yaml-language-server@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/yaml-language-server/-/yaml-language-server-0.11.1.tgz#4ddc72eb9a6dd7dc41f31af2a8f5c72cce456cc9"
+  integrity sha512-N3Tu3g4O6ZWV7W0LVsNk62DtKJDQkbnPZRDd7ntaAeEl8QkxL1vnMunI26uzDU4PwwG4tPJ8g/VRS6U+fVp/6A==
+  dependencies:
+    js-yaml "^3.13.1"
+    jsonc-parser "^2.2.1"
+    request-light "^0.2.4"
+    vscode-json-languageservice "^3.6.0"
+    vscode-languageserver "^5.2.1"
+    vscode-languageserver-types "^3.15.1"
+    vscode-nls "^4.1.2"
+    vscode-uri "^2.1.1"
+    yaml-ast-parser-custom-tags "0.0.43"
+  optionalDependencies:
+    prettier "2.0.5"
 
 yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"
@@ -22189,6 +22339,19 @@ yup@^0.28.5:
     lodash-es "^4.17.11"
     property-expr "^2.0.2"
     synchronous-promise "^2.0.10"
+    toposort "^2.0.2"
+
+yup@^0.32.9:
+  version "0.32.9"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.9.tgz#9367bec6b1b0e39211ecbca598702e106019d872"
+  integrity sha512-Ci1qN+i2H0XpY7syDQ0k5zKQ/DoxO0LzPg8PAR/X4Mpj6DqaeCoIYEEjDJwhArh3Fa7GWbQQVDZKeXYlSH4JMg==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
+    "@types/lodash" "^4.14.165"
+    lodash "^4.17.20"
+    lodash-es "^4.17.15"
+    nanoclone "^0.2.1"
+    property-expr "^2.0.4"
     toposort "^2.0.2"
 
 zen-observable@^0.8.14:


### PR DESCRIPTION
note: this is a redo of the https://github.com/opstrace/opstrace/pull/436 PR due to a bad merge breaking things.

This PR adds an Alertmanager page for each Tenant that allows directly editing the promethous alertmanager yaml. The new Harusa actions for interacting with the Cortext alertmanager are used with additionaly configuration silently handled.

While there is client side yaml validation enabling/disabling the Publish button there is no feedback to the user if that process fails (this is my next task). Syntax highlighting is still a WIP.
