### PR TITLE
looker: metrics mode: use custom GET func

### DIFF
--- a/test/test-remote/logstream-gen/index.ts
+++ b/test/test-remote/logstream-gen/index.ts
@@ -1187,6 +1187,9 @@ async function httpGETRetryUntil200OrError(
 
     // If desired, decorate HTTP request with authentication token.
     if (BEARER_TOKEN) {
+      if (gotRequestOptions.headers === undefined) {
+        gotRequestOptions.headers = {};
+      }
       gotRequestOptions.headers["Authorization"] = `Bearer ${BEARER_TOKEN}`;
     }
 

--- a/test/test-remote/loki-node-client-tools/dummystream.ts
+++ b/test/test-remote/loki-node-client-tools/dummystream.ts
@@ -55,11 +55,11 @@ type CustomQueryFuncSigType = (
   arg4: DummyStream
 ) => Promise<LokiQueryResult>;
 
-interface FetchAndValidateOpts {
+export interface DummyStreamFetchAndValidateOpts {
   querierBaseUrl: string;
   chunkSize?: number;
   inspectEveryNthEntry?: number | undefined;
-  customQueryFunc?: CustomQueryFuncSigType;
+  customLokiQueryFunc?: CustomQueryFuncSigType;
   additionalHeaders?: Record<string, string>;
 }
 
@@ -378,11 +378,13 @@ export class DummyStream {
     return queryParams;
   }
 
-  public async fetchAndValidate(opts: FetchAndValidateOpts): Promise<number> {
+  public async fetchAndValidate(
+    opts: DummyStreamFetchAndValidateOpts
+  ): Promise<number> {
     const lokiQuerierBaseURL = opts.querierBaseUrl;
     const chunkSize = opts.chunkSize || 20000;
     const inspectEveryNthEntry = opts.inspectEveryNthEntry || 0;
-    const customQueryFunc = opts.customQueryFunc;
+    const customLokiQueryFunc = opts.customLokiQueryFunc;
     // not yet built in
     // const additionalHeaders = opts.additionalHeaders;
 
@@ -424,11 +426,11 @@ export class DummyStream {
       );
 
       let result: LokiQueryResult;
-      if (customQueryFunc !== undefined) {
+      if (customLokiQueryFunc !== undefined) {
         // why would the compiler not know that in here customQueryFunc is indeed
         // _not_ undefined?
         //@ts-ignore: see comment above
-        result = await customQueryFunc(
+        result = await customLokiQueryFunc(
           lokiQuerierBaseURL,
           queryParams,
           expectedCount,


### PR DESCRIPTION
For metrics mode: for basic retrying support around query GET requests, and for emitting the corresponding looker metrics around transient problems.