### PR TITLE
installer: mark system-tenant-api-auth-token as managed

### DIFF
--- a/lib/kubernetes/src/reconciliation/reconcile.ts
+++ b/lib/kubernetes/src/reconciliation/reconcile.ts
@@ -509,7 +509,7 @@ function reconcileResourceType<T extends K8sResource>(
           updateCollection.push(r);
         } else {
           log.notice(
-            `Leaving existing ${existing.namespace}/${existing.name} as-is (missing 'opstrace' annotation)`
+            `Leaving existing ${existing.constructor.name} ${existing.namespace}/${existing.name} as-is (missing 'opstrace' annotation)`
           );
         }
       }


### PR DESCRIPTION
The `system-tenant-api-auth-token` secret lacked an `opstrace` annotation, so the controller would then log a (recently-added) notice about the secret not being a known/managed resource. Passing it via a `ResourceCollection` automatically configures the annotation. We also mark the secret as immutable since it's not explicitly included among the controller's expected resources.

As a minor change, the notice message is updated to include the type of the resource being logged (`Secret` in this example).

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
