### PR TITLE
config: Hasura Actions for accessing cortex rules (#517)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ pkg/datadog/datadog
 pkg/fluent-http/fluent-http
 pkg/loki/loki
 
+go/config-api
 go/cortex-api
 go/ddapi
 go/loki-api

--- a/go/cmd/config/actions/types.go
+++ b/go/cmd/config/actions/types.go
@@ -18,6 +18,8 @@ type GraphQLError struct {
 	Message string `json:"message"`
 }
 
+// Common types.
+
 type ErrorType string
 
 const (
@@ -26,38 +28,107 @@ const (
 	ValidationFailedType ErrorType = "VALIDATION_FAILED"
 )
 
-type Alertmanager struct {
-	TenantID string  `json:"tenant_id"`
-	Config   *string `json:"config"`
-	Online   bool    `json:"online"`
-}
-
-type AlertmanagerUpdateResponse struct {
+type StatusResponse struct {
 	Success          bool       `json:"success"`
 	ErrorType        *ErrorType `json:"error_type"`
 	ErrorMessage     *string    `json:"error_message"`
 	ErrorRawResponse *string    `json:"error_raw_response"`
 }
 
-type ValidateOutput struct {
-	Success          bool       `json:"success"`
-	ErrorType        *ErrorType `json:"error_type"`
-	ErrorMessage     *string    `json:"error_message"`
-	ErrorRawResponse *string    `json:"error_raw_response"`
-}
-
-type AlertmanagerInput struct {
-	Config string `json:"config"`
-}
+// Alertmanager types.
 
 type GetAlertmanagerArgs struct {
 	TenantID string `json:"tenant_id"`
+}
+
+type GetAlertmanagerPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            GetAlertmanagerArgs    `json:"input"`
 }
 
 type UpdateAlertmanagerArgs struct {
 	TenantID string             `json:"tenant_id"`
 	Input    *AlertmanagerInput `json:"input"`
 }
+
+type UpdateAlertmanagerPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            UpdateAlertmanagerArgs `json:"input"`
+}
+
+type Alertmanager struct {
+	TenantID string  `json:"tenant_id"`
+	Config   *string `json:"config"`
+	Online   bool    `json:"online"`
+}
+
+type AlertmanagerInput struct {
+	Config string `json:"config"`
+}
+
+// Rules types.
+
+type ListRulesArgs struct {
+	TenantID string `json:"tenant_id"`
+}
+
+type GetRuleGroupArgs struct {
+	TenantID      string `json:"tenant_id"`
+	Namespace     string `json:"namespace"`
+	RuleGroupName string `json:"rule_group_name"`
+}
+
+type UpdateRuleGroupArgs struct {
+	TenantID  string         `json:"tenant_id"`
+	Namespace string         `json:"namespace"`
+	RuleGroup RuleGroupInput `json:"rule_group"`
+}
+
+type DeleteRuleGroupArgs struct {
+	TenantID      string `json:"tenant_id"`
+	Namespace     string `json:"namespace"`
+	RuleGroupName string `json:"rule_group_name"`
+}
+
+type ListRulesPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            ListRulesArgs          `json:"input"`
+}
+
+type GetRuleGroupPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            GetRuleGroupArgs       `json:"input"`
+}
+
+type UpdateRuleGroupPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            UpdateRuleGroupArgs    `json:"input"`
+}
+
+type DeleteRuleGroupPayload struct {
+	SessionVariables map[string]interface{} `json:"session_variables"`
+	Input            DeleteRuleGroupArgs    `json:"input"`
+}
+
+type Rules struct {
+	TenantID string  `json:"tenant_id"`
+	Rules    *string `json:"rules"`
+	Online   bool    `json:"online"`
+}
+
+type RuleGroup struct {
+	TenantID      string  `json:"tenant_id"`
+	Namespace     string  `json:"namespace"`
+	RuleGroupName string  `json:"rule_group_name"`
+	RuleGroup     *string `json:"rule_group"`
+	Online        bool    `json:"online"`
+}
+
+type RuleGroupInput struct {
+	RuleGroup string `json:"rule_group"`
+}
+
+// Credential/Exporter types.
 
 type ValidateCredentialArgs struct {
 	TenantID string `json:"tenant_id"`
@@ -72,16 +143,6 @@ type ValidateExporterArgs struct {
 	Type       string  `json:"type"`
 	Config     string  `json:"config"`
 	Credential *string `json:"credential,omitempty"`
-}
-
-type GetAlertmanagerPayload struct {
-	SessionVariables map[string]interface{} `json:"session_variables"`
-	Input            GetAlertmanagerArgs    `json:"input"`
-}
-
-type UpdateAlertmanagerPayload struct {
-	SessionVariables map[string]interface{} `json:"session_variables"`
-	Input            UpdateAlertmanagerArgs `json:"input"`
 }
 
 type ValidateCredentialPayload struct {

--- a/go/pkg/graphql/client_generated.go
+++ b/go/pkg/graphql/client_generated.go
@@ -3053,6 +3053,10 @@ type BooleanComparisonExp struct {
 	Nin    *[]Boolean `json:"_nin,omitempty"`
 }
 
+type RuleGroupInput struct {
+	RuleGroup String `json:"rule_group"`
+}
+
 type StringComparisonExp struct {
 	Eq       *String   `json:"_eq,omitempty"`
 	Gt       *String   `json:"_gt,omitempty"`
@@ -3970,14 +3974,21 @@ type Alertmanager struct {
 	TenantId String  `json:"tenant_id"`
 }
 
-type AlertmanagerUpdateResponse struct {
-	ErrorMessage     *String    `json:"error_message,omitempty"`
-	ErrorRawResponse *String    `json:"error_raw_response,omitempty"`
-	ErrorType        *ErrorType `json:"error_type,omitempty"`
-	Success          Boolean    `json:"success"`
+type RuleGroup struct {
+	Namespace     String  `json:"namespace"`
+	Online        Boolean `json:"online"`
+	RuleGroup     *String `json:"rule_group,omitempty"`
+	RuleGroupName String  `json:"rule_group_name"`
+	TenantId      String  `json:"tenant_id"`
 }
 
-type ValidateOutput struct {
+type Rules struct {
+	Online   Boolean `json:"online"`
+	Rules    *String `json:"rules,omitempty"`
+	TenantId String  `json:"tenant_id"`
+}
+
+type StatusResponse struct {
 	ErrorMessage     *String    `json:"error_message,omitempty"`
 	ErrorRawResponse *String    `json:"error_raw_response,omitempty"`
 	ErrorType        *ErrorType `json:"error_type,omitempty"`
@@ -4269,6 +4280,7 @@ type ModuleVersionMutationResponse struct {
 }
 
 type MutationRoot struct {
+	DeleteRuleGroup          *StatusResponse                 `json:"deleteRuleGroup,omitempty"`
 	DeleteBranch             *BranchMutationResponse         `json:"delete_branch,omitempty"`
 	DeleteBranchByPk         *Branch                         `json:"delete_branch_by_pk,omitempty"`
 	DeleteCredential         *CredentialMutationResponse     `json:"delete_credential,omitempty"`
@@ -4305,7 +4317,8 @@ type MutationRoot struct {
 	InsertUserOne            *User                           `json:"insert_user_one,omitempty"`
 	InsertUserPreference     *UserPreferenceMutationResponse `json:"insert_user_preference,omitempty"`
 	InsertUserPreferenceOne  *UserPreference                 `json:"insert_user_preference_one,omitempty"`
-	UpdateAlertmanager       *AlertmanagerUpdateResponse     `json:"updateAlertmanager,omitempty"`
+	UpdateAlertmanager       *StatusResponse                 `json:"updateAlertmanager,omitempty"`
+	UpdateRuleGroup          *StatusResponse                 `json:"updateRuleGroup,omitempty"`
 	UpdateBranch             *BranchMutationResponse         `json:"update_branch,omitempty"`
 	UpdateBranchByPk         *Branch                         `json:"update_branch_by_pk,omitempty"`
 	UpdateCredential         *CredentialMutationResponse     `json:"update_credential,omitempty"`
@@ -4340,6 +4353,8 @@ type QueryRoot struct {
 	FileAggregate           FileAggregate           `json:"file_aggregate"`
 	FileByPk                *File                   `json:"file_by_pk,omitempty"`
 	GetAlertmanager         *Alertmanager           `json:"getAlertmanager,omitempty"`
+	GetRuleGroup            *RuleGroup              `json:"getRuleGroup,omitempty"`
+	ListRules               *Rules                  `json:"listRules,omitempty"`
 	Module                  *[]Module               `json:"module,omitempty"`
 	ModuleAggregate         ModuleAggregate         `json:"module_aggregate"`
 	ModuleByPk              *Module                 `json:"module_by_pk,omitempty"`
@@ -4355,8 +4370,8 @@ type QueryRoot struct {
 	UserPreference          *[]UserPreference       `json:"user_preference,omitempty"`
 	UserPreferenceAggregate UserPreferenceAggregate `json:"user_preference_aggregate"`
 	UserPreferenceByPk      *UserPreference         `json:"user_preference_by_pk,omitempty"`
-	ValidateCredential      *ValidateOutput         `json:"validateCredential,omitempty"`
-	ValidateExporter        *ValidateOutput         `json:"validateExporter,omitempty"`
+	ValidateCredential      *StatusResponse         `json:"validateCredential,omitempty"`
+	ValidateExporter        *StatusResponse         `json:"validateExporter,omitempty"`
 }
 
 type SubscriptionRoot struct {
@@ -4373,6 +4388,8 @@ type SubscriptionRoot struct {
 	FileAggregate           FileAggregate           `json:"file_aggregate"`
 	FileByPk                *File                   `json:"file_by_pk,omitempty"`
 	GetAlertmanager         *Alertmanager           `json:"getAlertmanager,omitempty"`
+	GetRuleGroup            *RuleGroup              `json:"getRuleGroup,omitempty"`
+	ListRules               *Rules                  `json:"listRules,omitempty"`
 	Module                  *[]Module               `json:"module,omitempty"`
 	ModuleAggregate         ModuleAggregate         `json:"module_aggregate"`
 	ModuleByPk              *Module                 `json:"module_by_pk,omitempty"`
@@ -4388,8 +4405,8 @@ type SubscriptionRoot struct {
 	UserPreference          *[]UserPreference       `json:"user_preference,omitempty"`
 	UserPreferenceAggregate UserPreferenceAggregate `json:"user_preference_aggregate"`
 	UserPreferenceByPk      *UserPreference         `json:"user_preference_by_pk,omitempty"`
-	ValidateCredential      *ValidateOutput         `json:"validateCredential,omitempty"`
-	ValidateExporter        *ValidateOutput         `json:"validateExporter,omitempty"`
+	ValidateCredential      *StatusResponse         `json:"validateCredential,omitempty"`
+	ValidateExporter        *StatusResponse         `json:"validateExporter,omitempty"`
 }
 
 type Tenant struct {

--- a/packages/app/metadata/actions.graphql
+++ b/packages/app/metadata/actions.graphql
@@ -9,32 +9,10 @@ enum ErrorType {
   VALIDATION_FAILED,
 }
 
-# getAlertmanager
-
-type Query {
-  getAlertmanager(tenant_id: String!): Alertmanager
-}
-
-type Alertmanager {
-  tenant_id: String!
-  config: String
-  online: Boolean!
-}
-
-# updateAlertmanager
-
-type Mutation {
-  updateAlertmanager(tenant_id: String!, input: AlertmanagerInput): AlertmanagerUpdateResponse
-}
-
-input AlertmanagerInput {
-  config: String!
-}
-
 # NOTE: Unable to use nested response types in Hasura Actions, so using a flat response for now.
 #       See also https://github.com/hasura/graphql-engine/issues/4796
 # TODO: Is this fixed by switching to Remote Schemas instead?
-type AlertmanagerUpdateResponse {
+type StatusResponse {
   # False if the update failed for any reason, see error_* fields for details
   success: Boolean!
 
@@ -46,24 +24,131 @@ type AlertmanagerUpdateResponse {
   error_raw_response: String
 }
 
+# getAlertmanager/updateAlertmanager
+
+type Query {
+  getAlertmanager(tenant_id: String!): Alertmanager
+}
+type Mutation {
+  updateAlertmanager(tenant_id: String!, input: AlertmanagerInput): StatusResponse
+}
+
+type Alertmanager {
+  tenant_id: String!
+  config: String
+  online: Boolean!
+}
+
+input AlertmanagerInput {
+  config: String!
+}
+
+# Rules access
+# Within each tenant, rules are under this hierarchy: namespace -> rulegroup -> rules
+
+# Returns all rules across all namespaces/rulegroups. Example:
+type Query {
+  listRules(tenant_id: String!): Rules
+}
+
+type Rules {
+  tenant_id: String!
+
+  # List of all rules across all namespaces/rulegroups. Example:
+  #   namespace-1:
+  #    - name: group-1
+  #      interval: duration
+  #      rules:
+  #      - alert: alert-A
+  #        expr: vector(1)
+  #        labels:
+  #          severity: warning
+  #        annotations:
+  #          description: alertA
+  #          summary: alertA
+  #      - alert: alert-B
+  #        expr: vector(1)
+  #        labels:
+  #          severity: warning
+  #        annotations:
+  #          description: alertB
+  #          summary: alertB
+  #    - name: group-2
+  #      rules:
+  #      - alert: alert-C
+  #        expr: vector(1)
+  #        labels:
+  #          severity: warning
+  #        annotations:
+  #          description: alertC
+  #          summary: alertC
+  #
+  # If nothing was found but the query succeeded, this value is an empty string.
+  # If the query failed or the service was offline, this value is unset.
+  rules: String
+
+  # If rules is unset, this may be checked to determine if the data is miss
+  online: Boolean!
+}
+
+type Query {
+  getRuleGroup(tenant_id: String!, namespace: String!, rule_group_name: String!): RuleGroup
+}
+
+type RuleGroup {
+  tenant_id: String!
+  namespace: String!
+  # The name that was requested. This is also provided via a 'name' field in the rule_group payload.
+  rule_group_name: String!
+
+  # Same format as RuleGroupInput.rule_group
+  # If nothing was found but the query succeeded, this value is an empty string.
+  # If the query failed or the service was offline, this value is unset.
+  rule_group: String
+
+  online: Boolean!
+}
+
+type Mutation {
+  updateRuleGroup(tenant_id: String!, namespace: String!, rule_group: RuleGroupInput!): StatusResponse
+}
+
+input RuleGroupInput {
+  # YAML payload containing the name of the rule group and the rules it should have assigned to it. Example:
+  #   name: group-1
+  #   interval: duration
+  #   rules:
+  #   - alert: alert-A
+  #     expr: vector(1)
+  #     labels:
+  #       severity: warning
+  #     annotations:
+  #       description: alertA
+  #       summary: alertA
+  #   - alert: alert-B
+  #     expr: vector(1)
+  #     labels:
+  #       severity: warning
+  #     annotations:
+  #       description: alertB
+  #       summary: alertB
+  #
+  # If the list of rules is unset or empty (Cortex treats as invalid), the rule group is deleted. Example:
+  #   name: group-1
+  # If the deleted rule group was the only one left in the namespace, then the namespace is also deleted automatically.
+  rule_group: String!
+}
+
+type Mutation {
+  deleteRuleGroup(tenant_id: String!, namespace: String!, rule_group_name: String!): StatusResponse
+}
+
 # validateCredential/validateExporter
 
 type Query {
-  validateCredential(tenant_id: String!, name: String!, type: String!, value: json!): ValidateOutput
+  validateCredential(tenant_id: String!, name: String!, type: String!, value: json!): StatusResponse
 }
 
 type Query {
-  validateExporter(tenant_id: String!, name: String!, type: String!, config: json!, credential: String!): ValidateOutput
-}
-
-type ValidateOutput {
-  # False if the validation failed for any reason, see error_* fields for details
-  success: Boolean!
-
-  # Must be set if success=false
-  error_type: ErrorType
-  # Must be set if success=false
-  error_message: String
-  # Optional if success=false, message returned by underlying service
-  error_raw_response: String
+  validateExporter(tenant_id: String!, name: String!, type: String!, config: json!, credential: String): StatusResponse
 }

--- a/packages/app/metadata/actions.yaml
+++ b/packages/app/metadata/actions.yaml
@@ -17,6 +17,42 @@ actions:
       value_from_env: ACTION_CONFIG_API_SECRET
   permissions:
   - role: user_admin
+- name: listRules
+  definition:
+    kind: synchronous
+    handler: '{{ACTION_CONFIG_API_ENDPOINT}}'
+    headers:
+    - name: X-Action-Secret
+      value_from_env: ACTION_CONFIG_API_SECRET
+  permissions:
+  - role: user_admin
+- name: getRuleGroup
+  definition:
+    kind: synchronous
+    handler: '{{ACTION_CONFIG_API_ENDPOINT}}'
+    headers:
+    - name: X-Action-Secret
+      value_from_env: ACTION_CONFIG_API_SECRET
+  permissions:
+  - role: user_admin
+- name: updateRuleGroup
+  definition:
+    kind: synchronous
+    handler: '{{ACTION_CONFIG_API_ENDPOINT}}'
+    headers:
+    - name: X-Action-Secret
+      value_from_env: ACTION_CONFIG_API_SECRET
+  permissions:
+  - role: user_admin
+- name: deleteRuleGroup
+  definition:
+    kind: synchronous
+    handler: '{{ACTION_CONFIG_API_ENDPOINT}}'
+    headers:
+    - name: X-Action-Secret
+      value_from_env: ACTION_CONFIG_API_SECRET
+  permissions:
+  - role: user_admin
 - name: validateCredential
   definition:
     kind: synchronous
@@ -40,8 +76,10 @@ custom_types:
   - name: ErrorType
   input_objects:
   - name: AlertmanagerInput
+  - name: RuleGroupInput
   objects:
+  - name: StatusResponse
   - name: Alertmanager
-  - name: AlertmanagerUpdateResponse
-  - name: ValidateOutput
+  - name: Rules
+  - name: RuleGroup
   scalars: []

--- a/packages/app/src/client/views/tenant/alertmanagerConfig/editor/index.tsx
+++ b/packages/app/src/client/views/tenant/alertmanagerConfig/editor/index.tsx
@@ -25,7 +25,7 @@ import { useTenant, useAlertmanager } from "state/tenant/hooks";
 import { updateAlertmanager } from "state/tenant/actions";
 
 import { Tenant, Alertmanager } from "state/tenant/types";
-import { AlertmanagerUpdateResponse } from "state/graphql-api-types";
+import { StatusResponse } from "state/graphql-api-types";
 
 import { State } from "./types";
 
@@ -39,7 +39,7 @@ import { TabbedDetail } from "client/components/TabbedDetail";
 import { CondRender } from "client/utils/rendering";
 
 type FormData = {
-  remoteValidation: AlertmanagerUpdateResponse;
+  remoteValidation: StatusResponse;
 };
 
 const defaultData: FormData = {
@@ -159,7 +159,7 @@ const AlertmanagerConfigEditor = (props: AlertmanagerConfigEditorProps) => {
 };
 
 type ErrorPanelProps = {
-  response?: AlertmanagerUpdateResponse;
+  response?: StatusResponse;
 };
 
 const ErrorPanel = ({ response }: ErrorPanelProps) => {

--- a/packages/app/src/state/graphql-api-types.ts
+++ b/packages/app/src/state/graphql-api-types.ts
@@ -51,13 +51,6 @@ export type AlertmanagerInput = {
   config: Scalars["String"];
 };
 
-export type AlertmanagerUpdateResponse = {
-  error_message?: Maybe<Scalars["String"]>;
-  error_raw_response?: Maybe<Scalars["String"]>;
-  error_type?: Maybe<ErrorType>;
-  success: Scalars["Boolean"];
-};
-
 /** expression to compare columns of type Boolean. All fields are combined with logical 'AND'. */
 export type Boolean_Comparison_Exp = {
   _eq?: Maybe<Scalars["Boolean"]>;
@@ -77,6 +70,31 @@ export enum ErrorType {
   ValidationFailed = "VALIDATION_FAILED"
 }
 
+export type RuleGroup = {
+  namespace: Scalars["String"];
+  online: Scalars["Boolean"];
+  rule_group?: Maybe<Scalars["String"]>;
+  rule_group_name: Scalars["String"];
+  tenant_id: Scalars["String"];
+};
+
+export type RuleGroupInput = {
+  rule_group: Scalars["String"];
+};
+
+export type Rules = {
+  online: Scalars["Boolean"];
+  rules?: Maybe<Scalars["String"]>;
+  tenant_id: Scalars["String"];
+};
+
+export type StatusResponse = {
+  error_message?: Maybe<Scalars["String"]>;
+  error_raw_response?: Maybe<Scalars["String"]>;
+  error_type?: Maybe<ErrorType>;
+  success: Scalars["Boolean"];
+};
+
 /** expression to compare columns of type String. All fields are combined with logical 'AND'. */
 export type String_Comparison_Exp = {
   _eq?: Maybe<Scalars["String"]>;
@@ -94,13 +112,6 @@ export type String_Comparison_Exp = {
   _nlike?: Maybe<Scalars["String"]>;
   _nsimilar?: Maybe<Scalars["String"]>;
   _similar?: Maybe<Scalars["String"]>;
-};
-
-export type ValidateOutput = {
-  error_message?: Maybe<Scalars["String"]>;
-  error_raw_response?: Maybe<Scalars["String"]>;
-  error_type?: Maybe<ErrorType>;
-  success: Scalars["Boolean"];
 };
 
 /** columns and relationships of "branch" */
@@ -1587,6 +1598,8 @@ export enum Module_Version_Update_Column {
 
 /** mutation root */
 export type Mutation_Root = {
+  /** perform the action: "deleteRuleGroup" */
+  deleteRuleGroup?: Maybe<StatusResponse>;
   /** delete data from the table: "branch" */
   delete_branch?: Maybe<Branch_Mutation_Response>;
   /** delete single row from the table: "branch" */
@@ -1660,7 +1673,9 @@ export type Mutation_Root = {
   /** insert a single row into the table: "user_preference" */
   insert_user_preference_one?: Maybe<User_Preference>;
   /** perform the action: "updateAlertmanager" */
-  updateAlertmanager?: Maybe<AlertmanagerUpdateResponse>;
+  updateAlertmanager?: Maybe<StatusResponse>;
+  /** perform the action: "updateRuleGroup" */
+  updateRuleGroup?: Maybe<StatusResponse>;
   /** update data of the table: "branch" */
   update_branch?: Maybe<Branch_Mutation_Response>;
   /** update single row of the table: "branch" */
@@ -1697,6 +1712,13 @@ export type Mutation_Root = {
   update_user_preference?: Maybe<User_Preference_Mutation_Response>;
   /** update single row of the table: "user_preference" */
   update_user_preference_by_pk?: Maybe<User_Preference>;
+};
+
+/** mutation root */
+export type Mutation_RootDeleteRuleGroupArgs = {
+  namespace: Scalars["String"];
+  rule_group_name: Scalars["String"];
+  tenant_id: Scalars["String"];
 };
 
 /** mutation root */
@@ -1911,6 +1933,13 @@ export type Mutation_RootUpdateAlertmanagerArgs = {
 };
 
 /** mutation root */
+export type Mutation_RootUpdateRuleGroupArgs = {
+  namespace: Scalars["String"];
+  rule_group: RuleGroupInput;
+  tenant_id: Scalars["String"];
+};
+
+/** mutation root */
 export type Mutation_RootUpdate_BranchArgs = {
   _set?: Maybe<Branch_Set_Input>;
   where: Branch_Bool_Exp;
@@ -2072,6 +2101,10 @@ export type Query_Root = {
   file_by_pk?: Maybe<File>;
   /** perform the action: "getAlertmanager" */
   getAlertmanager?: Maybe<Alertmanager>;
+  /** perform the action: "getRuleGroup" */
+  getRuleGroup?: Maybe<RuleGroup>;
+  /** perform the action: "listRules" */
+  listRules?: Maybe<Rules>;
   /** fetch data from the table: "module" */
   module: Array<Module>;
   /** fetch aggregated fields from the table: "module" */
@@ -2103,9 +2136,9 @@ export type Query_Root = {
   /** fetch data from the table: "user_preference" using primary key columns */
   user_preference_by_pk?: Maybe<User_Preference>;
   /** perform the action: "validateCredential" */
-  validateCredential?: Maybe<ValidateOutput>;
+  validateCredential?: Maybe<StatusResponse>;
   /** perform the action: "validateExporter" */
-  validateExporter?: Maybe<ValidateOutput>;
+  validateExporter?: Maybe<StatusResponse>;
 };
 
 /** query root */
@@ -2204,6 +2237,18 @@ export type Query_RootFile_By_PkArgs = {
 
 /** query root */
 export type Query_RootGetAlertmanagerArgs = {
+  tenant_id: Scalars["String"];
+};
+
+/** query root */
+export type Query_RootGetRuleGroupArgs = {
+  namespace: Scalars["String"];
+  rule_group_name: Scalars["String"];
+  tenant_id: Scalars["String"];
+};
+
+/** query root */
+export type Query_RootListRulesArgs = {
   tenant_id: Scalars["String"];
 };
 
@@ -2338,7 +2383,7 @@ export type Query_RootValidateCredentialArgs = {
 /** query root */
 export type Query_RootValidateExporterArgs = {
   config: Scalars["json"];
-  credential: Scalars["String"];
+  credential?: Maybe<Scalars["String"]>;
   name: Scalars["String"];
   tenant_id: Scalars["String"];
   type: Scalars["String"];
@@ -2372,6 +2417,10 @@ export type Subscription_Root = {
   file_by_pk?: Maybe<File>;
   /** perform the action: "getAlertmanager" */
   getAlertmanager?: Maybe<Alertmanager>;
+  /** perform the action: "getRuleGroup" */
+  getRuleGroup?: Maybe<RuleGroup>;
+  /** perform the action: "listRules" */
+  listRules?: Maybe<Rules>;
   /** fetch data from the table: "module" */
   module: Array<Module>;
   /** fetch aggregated fields from the table: "module" */
@@ -2403,9 +2452,9 @@ export type Subscription_Root = {
   /** fetch data from the table: "user_preference" using primary key columns */
   user_preference_by_pk?: Maybe<User_Preference>;
   /** perform the action: "validateCredential" */
-  validateCredential?: Maybe<ValidateOutput>;
+  validateCredential?: Maybe<StatusResponse>;
   /** perform the action: "validateExporter" */
-  validateExporter?: Maybe<ValidateOutput>;
+  validateExporter?: Maybe<StatusResponse>;
 };
 
 /** subscription root */
@@ -2504,6 +2553,18 @@ export type Subscription_RootFile_By_PkArgs = {
 
 /** subscription root */
 export type Subscription_RootGetAlertmanagerArgs = {
+  tenant_id: Scalars["String"];
+};
+
+/** subscription root */
+export type Subscription_RootGetRuleGroupArgs = {
+  namespace: Scalars["String"];
+  rule_group_name: Scalars["String"];
+  tenant_id: Scalars["String"];
+};
+
+/** subscription root */
+export type Subscription_RootListRulesArgs = {
   tenant_id: Scalars["String"];
 };
 
@@ -2638,7 +2699,7 @@ export type Subscription_RootValidateCredentialArgs = {
 /** subscription root */
 export type Subscription_RootValidateExporterArgs = {
   config: Scalars["json"];
-  credential: Scalars["String"];
+  credential?: Maybe<Scalars["String"]>;
   name: Scalars["String"];
   tenant_id: Scalars["String"];
   type: Scalars["String"];
@@ -3665,7 +3726,7 @@ export type UpdateAlertmanagerMutationVariables = Exact<{
 export type UpdateAlertmanagerMutation = {
   updateAlertmanager?: Maybe<
     Pick<
-      AlertmanagerUpdateResponse,
+      StatusResponse,
       "success" | "error_type" | "error_message" | "error_raw_response"
     >
   >;

--- a/packages/controller/src/dbSDK.ts
+++ b/packages/controller/src/dbSDK.ts
@@ -51,13 +51,6 @@ export type AlertmanagerInput = {
   config: Scalars["String"];
 };
 
-export type AlertmanagerUpdateResponse = {
-  error_message?: Maybe<Scalars["String"]>;
-  error_raw_response?: Maybe<Scalars["String"]>;
-  error_type?: Maybe<ErrorType>;
-  success: Scalars["Boolean"];
-};
-
 /** expression to compare columns of type Boolean. All fields are combined with logical 'AND'. */
 export type Boolean_Comparison_Exp = {
   _eq?: Maybe<Scalars["Boolean"]>;
@@ -77,6 +70,31 @@ export enum ErrorType {
   ValidationFailed = "VALIDATION_FAILED"
 }
 
+export type RuleGroup = {
+  namespace: Scalars["String"];
+  online: Scalars["Boolean"];
+  rule_group?: Maybe<Scalars["String"]>;
+  rule_group_name: Scalars["String"];
+  tenant_id: Scalars["String"];
+};
+
+export type RuleGroupInput = {
+  rule_group: Scalars["String"];
+};
+
+export type Rules = {
+  online: Scalars["Boolean"];
+  rules?: Maybe<Scalars["String"]>;
+  tenant_id: Scalars["String"];
+};
+
+export type StatusResponse = {
+  error_message?: Maybe<Scalars["String"]>;
+  error_raw_response?: Maybe<Scalars["String"]>;
+  error_type?: Maybe<ErrorType>;
+  success: Scalars["Boolean"];
+};
+
 /** expression to compare columns of type String. All fields are combined with logical 'AND'. */
 export type String_Comparison_Exp = {
   _eq?: Maybe<Scalars["String"]>;
@@ -94,13 +112,6 @@ export type String_Comparison_Exp = {
   _nlike?: Maybe<Scalars["String"]>;
   _nsimilar?: Maybe<Scalars["String"]>;
   _similar?: Maybe<Scalars["String"]>;
-};
-
-export type ValidateOutput = {
-  error_message?: Maybe<Scalars["String"]>;
-  error_raw_response?: Maybe<Scalars["String"]>;
-  error_type?: Maybe<ErrorType>;
-  success: Scalars["Boolean"];
 };
 
 /** columns and relationships of "branch" */
@@ -1587,6 +1598,8 @@ export enum Module_Version_Update_Column {
 
 /** mutation root */
 export type Mutation_Root = {
+  /** perform the action: "deleteRuleGroup" */
+  deleteRuleGroup?: Maybe<StatusResponse>;
   /** delete data from the table: "branch" */
   delete_branch?: Maybe<Branch_Mutation_Response>;
   /** delete single row from the table: "branch" */
@@ -1660,7 +1673,9 @@ export type Mutation_Root = {
   /** insert a single row into the table: "user_preference" */
   insert_user_preference_one?: Maybe<User_Preference>;
   /** perform the action: "updateAlertmanager" */
-  updateAlertmanager?: Maybe<AlertmanagerUpdateResponse>;
+  updateAlertmanager?: Maybe<StatusResponse>;
+  /** perform the action: "updateRuleGroup" */
+  updateRuleGroup?: Maybe<StatusResponse>;
   /** update data of the table: "branch" */
   update_branch?: Maybe<Branch_Mutation_Response>;
   /** update single row of the table: "branch" */
@@ -1697,6 +1712,13 @@ export type Mutation_Root = {
   update_user_preference?: Maybe<User_Preference_Mutation_Response>;
   /** update single row of the table: "user_preference" */
   update_user_preference_by_pk?: Maybe<User_Preference>;
+};
+
+/** mutation root */
+export type Mutation_RootDeleteRuleGroupArgs = {
+  namespace: Scalars["String"];
+  rule_group_name: Scalars["String"];
+  tenant_id: Scalars["String"];
 };
 
 /** mutation root */
@@ -1911,6 +1933,13 @@ export type Mutation_RootUpdateAlertmanagerArgs = {
 };
 
 /** mutation root */
+export type Mutation_RootUpdateRuleGroupArgs = {
+  namespace: Scalars["String"];
+  rule_group: RuleGroupInput;
+  tenant_id: Scalars["String"];
+};
+
+/** mutation root */
 export type Mutation_RootUpdate_BranchArgs = {
   _set?: Maybe<Branch_Set_Input>;
   where: Branch_Bool_Exp;
@@ -2072,6 +2101,10 @@ export type Query_Root = {
   file_by_pk?: Maybe<File>;
   /** perform the action: "getAlertmanager" */
   getAlertmanager?: Maybe<Alertmanager>;
+  /** perform the action: "getRuleGroup" */
+  getRuleGroup?: Maybe<RuleGroup>;
+  /** perform the action: "listRules" */
+  listRules?: Maybe<Rules>;
   /** fetch data from the table: "module" */
   module: Array<Module>;
   /** fetch aggregated fields from the table: "module" */
@@ -2103,9 +2136,9 @@ export type Query_Root = {
   /** fetch data from the table: "user_preference" using primary key columns */
   user_preference_by_pk?: Maybe<User_Preference>;
   /** perform the action: "validateCredential" */
-  validateCredential?: Maybe<ValidateOutput>;
+  validateCredential?: Maybe<StatusResponse>;
   /** perform the action: "validateExporter" */
-  validateExporter?: Maybe<ValidateOutput>;
+  validateExporter?: Maybe<StatusResponse>;
 };
 
 /** query root */
@@ -2204,6 +2237,18 @@ export type Query_RootFile_By_PkArgs = {
 
 /** query root */
 export type Query_RootGetAlertmanagerArgs = {
+  tenant_id: Scalars["String"];
+};
+
+/** query root */
+export type Query_RootGetRuleGroupArgs = {
+  namespace: Scalars["String"];
+  rule_group_name: Scalars["String"];
+  tenant_id: Scalars["String"];
+};
+
+/** query root */
+export type Query_RootListRulesArgs = {
   tenant_id: Scalars["String"];
 };
 
@@ -2338,7 +2383,7 @@ export type Query_RootValidateCredentialArgs = {
 /** query root */
 export type Query_RootValidateExporterArgs = {
   config: Scalars["json"];
-  credential: Scalars["String"];
+  credential?: Maybe<Scalars["String"]>;
   name: Scalars["String"];
   tenant_id: Scalars["String"];
   type: Scalars["String"];
@@ -2372,6 +2417,10 @@ export type Subscription_Root = {
   file_by_pk?: Maybe<File>;
   /** perform the action: "getAlertmanager" */
   getAlertmanager?: Maybe<Alertmanager>;
+  /** perform the action: "getRuleGroup" */
+  getRuleGroup?: Maybe<RuleGroup>;
+  /** perform the action: "listRules" */
+  listRules?: Maybe<Rules>;
   /** fetch data from the table: "module" */
   module: Array<Module>;
   /** fetch aggregated fields from the table: "module" */
@@ -2403,9 +2452,9 @@ export type Subscription_Root = {
   /** fetch data from the table: "user_preference" using primary key columns */
   user_preference_by_pk?: Maybe<User_Preference>;
   /** perform the action: "validateCredential" */
-  validateCredential?: Maybe<ValidateOutput>;
+  validateCredential?: Maybe<StatusResponse>;
   /** perform the action: "validateExporter" */
-  validateExporter?: Maybe<ValidateOutput>;
+  validateExporter?: Maybe<StatusResponse>;
 };
 
 /** subscription root */
@@ -2504,6 +2553,18 @@ export type Subscription_RootFile_By_PkArgs = {
 
 /** subscription root */
 export type Subscription_RootGetAlertmanagerArgs = {
+  tenant_id: Scalars["String"];
+};
+
+/** subscription root */
+export type Subscription_RootGetRuleGroupArgs = {
+  namespace: Scalars["String"];
+  rule_group_name: Scalars["String"];
+  tenant_id: Scalars["String"];
+};
+
+/** subscription root */
+export type Subscription_RootListRulesArgs = {
   tenant_id: Scalars["String"];
 };
 
@@ -2638,7 +2699,7 @@ export type Subscription_RootValidateCredentialArgs = {
 /** subscription root */
 export type Subscription_RootValidateExporterArgs = {
   config: Scalars["json"];
-  credential: Scalars["String"];
+  credential?: Maybe<Scalars["String"]>;
   name: Scalars["String"];
   tenant_id: Scalars["String"];
   type: Scalars["String"];
@@ -3665,7 +3726,7 @@ export type UpdateAlertmanagerMutationVariables = Exact<{
 export type UpdateAlertmanagerMutation = {
   updateAlertmanager?: Maybe<
     Pick<
-      AlertmanagerUpdateResponse,
+      StatusResponse,
       "success" | "error_type" | "error_message" | "error_raw_response"
     >
   >;


### PR DESCRIPTION
Rules are under Rule Groups, and Rule Groups are under Namespaces. Each tenant can have one or more Namespaces.

The underlying cortex API has calls at each level, but to keep it simple for now, this just adds the following Hasura calls:
- `listRules(tenant)`: List all Rules for the tenant (across all namespaces/groups)
- `getRuleGroup(tenant, namespace, group_name)`: Get a single Rule Group
- `updateRuleGroup(tenant, namespace, group_yaml)`: Create/update a Rule Group - unlike with `updateAlertmanager` this does not support delete because the `group_yaml` payload contains the Rule Group name
- `deleteRuleGroup(tenant, namespace, group_name)`: Delete a Rule Group (Namespaces auto-delete when empty) - separate call from `update` per note above

ALSO, renames `AlertmanagerUpdateResponse` to `StatusResponse` to reflect its usage in Ruler calls as well

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
