### PR TITLE
controller: Point alertmanager tenant ingress to cortex

### DIFF
--- a/go/cmd/config/main.go
+++ b/go/cmd/config/main.go
@@ -142,13 +142,9 @@ func buildConfigHandler(
 
 	// Cortex Alertmanager config
 	alertmanagerPathReplacement := func(requrl *url.URL) string {
-		// NOTE: We leave /api/v1/alertmanager for the Alertmanager UI as-is.
-		// By default Cortex would serve it at /alertmanager, but we configure it via 'api.alertmanager-http-prefix'.
-		// This avoids us needing to rewrite HTTP responses to fix e.g. any absolute img/href URLs.
-		// SEE ALSO: controller/src/resources/cortex/index.ts
-
 		// Route /api/v1/multitenant_alertmanager* requests to /multitenant_alertmanager* on the backend.
-		// Unlike with /alertmanager, this doesn't appear to involve a UI and just has status endpoints.
+		// Unlike with /alertmanager, this is more of an internal status page.
+		// But we could switch it to an Ingress later if we wanted.
 		if replaced := replacePathPrefix(
 			requrl,
 			"/api/v1/multitenant_alertmanager",
@@ -163,8 +159,9 @@ func buildConfigHandler(
 		alertmanagerURL,
 		disableAPIAuthentication,
 	).ReplacePaths(alertmanagerPathReplacement)
+	// We don't route /alertmanager for the Alertmanager UI since it isn't useful via curl.
+	// The Alertmanager UI can be viewed at '<tenant>.<cluster>.opstrace.io/alertmanager/'
 	router.PathPrefix("/api/v1/alerts").HandlerFunc(alertmanagerProxy.HandleWithProxy)
-	router.PathPrefix("/api/v1/alertmanager").HandlerFunc(alertmanagerProxy.HandleWithProxy)
 	router.PathPrefix("/api/v1/multitenant_alertmanager").HandlerFunc(alertmanagerProxy.HandleWithProxy)
 
 	credentialAccess := config.NewCredentialAccess(graphqlURL, graphqlSecret)

--- a/packages/controller/src/helpers.ts
+++ b/packages/controller/src/helpers.ts
@@ -83,6 +83,3 @@ export const getNodeCount = (state: State): number =>
 
 export const getPrometheusName = (tenant: Tenant): string =>
   `${tenant.name}-prometheus`;
-
-export const getAlertmanagerName = (tenant: Tenant): string =>
-  `${tenant.name}-alertmanager`;

--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -251,9 +251,10 @@ export function CortexResources(
     // at api.prometheus_http_prefix.
     http_prefix: "",
     api: {
-      // Serve Alertmanager UI at this custom location, matching the path served by the config-api pod.
-      // SEE ALSO: go/cmd/config/main.go, and alertmanager.external_url and ruler.alertmanager_url below
-      alertmanager_http_prefix: "/api/v1/alertmanager"
+      // Serve Alertmanager UI at this location, matching the path served by the tenant Ingresses.
+      // This is the default but we call it out explicitly here.
+      // SEE ALSO: resources/ingress/index.ts, and alertmanager.external_url and ruler.alertmanager_url below
+      alertmanager_http_prefix: "/alertmanager"
     },
     auth_enabled: true,
     distributor: {
@@ -438,10 +439,8 @@ export function CortexResources(
           store: "memberlist"
         }
       },
-      // Endpoint for talking to underlying per-tenant prometheus alertmanager instances.
-      // This is as opposed to the system-wide cortex APIs at the root.
-      // This is passed to prometheus and must align with api.alertmanager_http_prefix and ruler.alertmanager_url
-      external_url: "/api/v1/alertmanager"
+      // This is used by other prometheus components and must align with api.alertmanager_http_prefix and ruler.alertmanager_url
+      external_url: "/alertmanager"
     },
     // Using the new thanos-based storage for alertmanager configs
     alertmanager_storage: {
@@ -466,7 +465,7 @@ export function CortexResources(
       },
       // Must align with api.alertmanager_http_prefix and alertmanager.external_url
       // (This version needs to include the alertmanager hostname to send alerts to)
-      alertmanager_url: `http://alertmanager.${namespace}.svc.cluster.local/api/v1/alertmanager/`
+      alertmanager_url: `http://alertmanager.${namespace}.svc.cluster.local/alertmanager/`
     },
     // Using the new thanos-based storage for rule configs
     ruler_storage: {

--- a/packages/controller/src/resources/ingress/index.ts
+++ b/packages/controller/src/resources/ingress/index.ts
@@ -78,9 +78,9 @@ export function IngressResources(
                 "X-Auth-Request-User, X-Auth-Request-Email",
               // Include an X-Scope-OrgID header containing the tenant name in all requests.
               // This is (only) used by cortex-* services to identify the tenant.
-              // See https://github.com/kubernetes/ingress-nginx/blob/0dce5be/docs/examples/customization/configuration-snippets/ingress.yaml
+              // WARNING: Don't forget the trailing semicolon or else routes will silently fail.
               "nginx.ingress.kubernetes.io/configuration-snippet":
-                `more_set_headers "X-Scope-OrgID: ${tenant.name}"`
+                `more_set_input_headers "X-Scope-OrgID: ${tenant.name}";`
             }
           },
           spec: {
@@ -96,8 +96,8 @@ export function IngressResources(
                 http: {
                   paths: [
                     {
-                      path: "/prometheus/",
-                      pathType: "ImplementationSpecific",
+                      path: "/prometheus",
+                      pathType: "Prefix",
                       backend: {
                         serviceName: "prometheus",
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -107,8 +107,8 @@ export function IngressResources(
                     // An ExternalName service which points to alertmanager in the 'cortex' namespace.
                     // Our requests to this service must include the X-Scope-OrgID header for Cortex.
                     {
-                      path: "/alertmanager/",
-                      pathType: "ImplementationSpecific",
+                      path: "/alertmanager",
+                      pathType: "Prefix",
                       backend: {
                         serviceName: "cortex-alertmanager",
                         // Cortex alertmanager has ports 80 and 9094. The UI is served at port 80.
@@ -117,8 +117,8 @@ export function IngressResources(
                       }
                     },
                     {
-                      path: "/grafana/",
-                      pathType: "ImplementationSpecific",
+                      path: "/grafana",
+                      pathType: "Prefix",
                       backend: {
                         serviceName: "grafana",
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/controller/src/resources/monitoring/index.ts
+++ b/packages/controller/src/resources/monitoring/index.ts
@@ -46,8 +46,11 @@ export function MonitoringResources(
 
   // Per tenant resources
   state.tenants.list.tenants.forEach(tenant => {
-    // Each tenant gets Alertmanager, Prometheus, Grafana
+    // Cortex runs Alertmanager for all tenants
+    // Support routing per-tenant Ingress for Alertmanager UI to Cortex
     collection.add(AlertManagerResources(state, kubeConfig, tenant));
+
+    // Each tenant gets Prometheus, Grafana
     collection.add(GrafanaResources(state, kubeConfig, tenant));
     collection.add(PrometheusResources(state, kubeConfig, tenant));
 

--- a/packages/controller/src/resources/monitoring/tenants/alertmanager.ts
+++ b/packages/controller/src/resources/monitoring/tenants/alertmanager.ts
@@ -18,18 +18,11 @@ import { KubeConfig } from "@kubernetes/client-node";
 import { State } from "../../../reducer";
 import { Tenant } from "@opstrace/tenants";
 import {
-  getAlertmanagerName,
-  getDomain,
   getTenantNamespace
 } from "../../../helpers";
-import * as yaml from "js-yaml";
 import {
   ResourceCollection,
-  Secret,
   Service,
-  ServiceAccount,
-  V1AlertmanagerResource,
-  V1ServicemonitorResource
 } from "@opstrace/kubernetes";
 
 export function AlertManagerResources(
@@ -39,236 +32,23 @@ export function AlertManagerResources(
 ): ResourceCollection {
   const collection = new ResourceCollection();
 
-  const domain = getDomain(state);
-  // TODO (clambert) create a getCurrentAlertConfig helper
-  // TODO(mat): reenable
-  //const alertConfig = getCurrentStack(state).alertConfig;
-
   const namespace = getTenantNamespace(tenant);
-  const name = getAlertmanagerName(tenant);
 
-  type AlertManagerRoute = {
-    receiver: string;
-    group_by: string[];
-    repeat_interval?: string;
-    match: {
-      severity?: string;
-      alertname?: string;
-    };
-    continue: boolean;
-  };
-
-  const alertManagerRoutes: AlertManagerRoute[] = [
-    // {
-    //   receiver: "slack-notifications",
-    //   repeat_interval: "2m",
-    //   group_by: ["alertname"],
-    //   match: {},
-    //   continue: true
-    // }
-  ];
-
-  // if (alertConfig.credentials.pagerDutyKey) {
-  //   alertManagerRoutes.unshift({
-  //     receiver: "pagerduty",
-  //     group_by: ["alertname"],
-  //     match: {
-  //       severity: "critical"
-  //     },
-  //     continue: true
-  //   } as AlertManagerRoute);
-  // }
-
-  // if (alertConfig.watchdogUrl) {
-  //   alertManagerRoutes.unshift({
-  //     receiver: "pagerduty-watchdog",
-  //     repeat_interval: "5m",
-  //     match: {
-  //       alertname: "Watchdog"
-  //     },
-  //     continue: false
-  //   } as AlertManagerRoute);
-  // }
-
-  const alertManagerConfig = {
-    global: {
-      //slack_api_url: alertConfig.credentials.slackHookUrl
-    },
-    route: {
-      // This "blackhole" receiver allows us to completely ignore some alerts.  I.e., if an alert
-      // does not match any of the conditions in the routes array, it will default to the root
-      // receiver—"blackhole"—which goes nowhere.
-      receiver: "blackhole",
-      routes: alertManagerRoutes
-    },
-    receivers: [
-      {
-        name: "blackhole"
-      }
-      // {
-      //   name: "slack-notifications",
-      //   slack_configs: [
-      //     {
-      //       title: `[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} - (${
-      //         getCurrentStack(state).org
-      //       }-${getCurrentStack(state).name})\n`,
-      //       title_link: `http://system.${domain}/alertmanager/#/alerts?receiver=slack-notifications`,
-      //       channel: alertConfig.slackChannelName,
-      //       text:
-      //         "{{ with index .Alerts 0 -}}\n  :chart_with_upwards_trend: *<{{- if .Annotations.graph }}{{ .Annotations.graph }}{{else}}{{ .GeneratorURL }}#graph0{{end}}|Graph>*   {{- if .Annotations.dashboard }} :dashboard: *<{{ .Annotations.dashboard }}|Dashboard>*{{ end }}{{- if .Annotations.runbook_url }} :notebook: *<{{ .Annotations.runbook_url }}|Runbook>*{{ end }}\n{{ end }}\n*Alert details*:\n{{ range .Alerts -}}\n  *Alert:* {{ .Annotations.title }}{{ if .Labels.severity }} - `{{ .Labels.severity }}`{{ end }}\n*Description:* {{ .Annotations.description }} *Details:*\n  {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`\n  {{ end }}\n{{ end }}"
-      //     }
-      //   ]
-      // },
-      // {
-      //   name: "pagerduty-watchdog",
-      //   webhook_configs: [
-      //     {
-      //       url: `${alertConfig.watchdogUrl}?m=${getCurrentStack(state).org}-${
-      //         getCurrentStack(state).name
-      //       }`
-      //     }
-      //   ]
-      // },
-      // {
-      //   name: "pagerduty",
-      //   pagerduty_configs: [
-      //     {
-      //       description: `{{ .CommonLabels.alertname }} - ${
-      //         getCurrentStack(state).org
-      //       }-${getCurrentStack(state).name}\n`,
-      //       service_key: `${alertConfig.credentials.pagerDutyKey}`
-      //     }
-      //   ]
-      // }
-    ]
-  };
-
-  collection.add(
-    new V1ServicemonitorResource(
-      {
-        apiVersion: "monitoring.coreos.com/v1",
-        kind: "ServiceMonitor",
-        metadata: {
-          labels: {
-            "k8s-app": "alertmanager",
-            tenant: "system"
-          },
-          name: "alertmanager",
-          namespace
-        },
-        spec: {
-          endpoints: [
-            {
-              interval: "30s",
-              port: "web",
-              path: "/alertmanager/metrics"
-            }
-          ],
-          selector: {
-            matchLabels: {
-              alertmanager: name
-            }
-          }
-        }
-      },
-      kubeConfig
-    )
-  );
-
-  collection.add(
-    new Secret(
-      {
-        apiVersion: "v1",
-        data: {
-          "alertmanager.yaml": Buffer.from(
-            yaml.safeDump(alertManagerConfig)
-          ).toString("base64")
-        },
-        kind: "Secret",
-        metadata: {
-          name: `alertmanager-${name}`,
-          namespace
-        },
-        type: "Opaque"
-      },
-      kubeConfig
-    )
-  );
-
-  collection.add(
-    new V1AlertmanagerResource(
-      {
-        apiVersion: "monitoring.coreos.com/v1",
-        kind: "Alertmanager",
-        metadata: {
-          labels: {
-            alertmanager: name
-          },
-          name,
-          namespace
-        },
-        spec: {
-          baseImage: "quay.io/prometheus/alertmanager",
-          externalUrl: `https://system.${domain}/alertmanager/`,
-          routePrefix: "/alertmanager",
-          logLevel: "info",
-          nodeSelector: {
-            "kubernetes.io/os": "linux"
-          },
-          replicas: 3,
-          securityContext: {
-            fsGroup: 2000,
-            runAsNonRoot: true,
-            runAsUser: 1000
-          },
-          serviceAccountName: name,
-          version: "v0.18.0"
-        }
-      },
-      kubeConfig
-    )
-  );
-
-  collection.add(
-    new ServiceAccount(
-      {
-        apiVersion: "v1",
-        kind: "ServiceAccount",
-        metadata: {
-          name,
-          namespace
-        }
-      },
-      kubeConfig
-    )
-  );
-
+  // Points to the multitenant Cortex Alertmanager.
+  // This allows the Ingress at "<tenant>.<cluster>.opstrace.io/alertmanager" to route to Cortex.
+  // Requests must include an "X-Scope-OrgID" header to identify the tenant, this is handled at the Ingress.
   collection.add(
     new Service(
       {
         apiVersion: "v1",
         kind: "Service",
         metadata: {
-          labels: {
-            alertmanager: name
-          },
-          name: "alertmanager",
+          name: "cortex-alertmanager",
           namespace
         },
         spec: {
-          ports: [
-            {
-              name: "web",
-              port: 9093,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              targetPort: "web" as any
-            }
-          ],
-          selector: {
-            alertmanager: name,
-            app: "alertmanager"
-          },
-          sessionAffinity: "ClientIP"
+          type: "ExternalName",
+          externalName: "alertmanager.cortex.svc.cluster.local"
         }
       },
       kubeConfig


### PR DESCRIPTION
Update the Alertmanager UI endpoint at `https://<tenant>.<cluster>.opstrace.io/alertmanager` to point to Cortex

Configures the Ingress to set the X-Scope-OrgID header expected by cortex.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
