### PR TITLE
test-remote: Implement E2E tests for alerts (#442)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 **/build
 secrets
-test
 ci
 npm-debug.log
 .git

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ opstrace
 ./go.mod
 
 tsconfig.tsbuildinfo
+_tscbuild/
 
 **/secrets/**
 **/out

--- a/lib/kubernetes/package.json
+++ b/lib/kubernetes/package.json
@@ -24,6 +24,7 @@
     "glob": "^7.1.6",
     "js-yaml": "^3.13.1",
     "json-schema-to-typescript": "^8.2.0",
+    "redux-saga": "^1.1.3",
     "request": "^2.88.2"
   },
   "devDependencies": {

--- a/test/test-remote/README.md
+++ b/test/test-remote/README.md
@@ -9,7 +9,9 @@ This README is relevant for developing tests.
 Concept:
 
 * `test-remote` is the name of this test runner.
-* `test-remote` requires `kubectl` to be configured against a specific remote opstrace cluster (it uses `kubectl port-forward ...` to connect to individual [Kubernetes network services](https://kubernetes.io/docs/concepts/services-networking/service/) in the remote cluster to communicate with them).
+* `test-remote` requires `kubectl` to be configured against a specific remote opstrace cluster:
+  - it uses `kubectl port-forward ...` to connect to individual [Kubernetes network services](https://kubernetes.io/docs/concepts/services-networking/service/) in the remote cluster to communicate with them.
+  - it deploys [test harnesses](https://github.com/grafana/cortex-tools/blob/main/docs/e2ealerting.md) into the cluster to interact with cluster alerts
 * `test-remote` is executed by the NodeJS runtime and -- for separation of concerns -- is set up as an isolated NPM package; defined by the directory that this README resides in.
 
 ## Architecture overview

--- a/test/test-remote/containers/looker/Makefile
+++ b/test/test-remote/containers/looker/Makefile
@@ -3,18 +3,14 @@
 CHECKOUT_VERSION_STRING ?= $(shell git rev-parse --short HEAD)-dev
 
 LOOKER_IMAGE_NAME = opstrace/looker:$(CHECKOUT_VERSION_STRING)
-
+REPO_ROOT = ../../../..
 
 image:
-	# temporarily pull repo-global yarn lock file into test/test-remote, see
-	# comment in looker.Dockerfile
-	cp -n ../../../../yarn.lock ../../
-	docker build -f looker.Dockerfile ../.. -t $(LOOKER_IMAGE_NAME)
-	rm -f ../../yarn.lock
+	docker build -f looker.Dockerfile $(REPO_ROOT) -t $(LOOKER_IMAGE_NAME)
 
 publish:
 	docker push $(LOOKER_IMAGE_NAME)
 
 publish-as-latest:
-	docker build -f looker.Dockerfile ../.. -t opstrace/looker:latest
+	docker build -f looker.Dockerfile $(REPO_ROOT) -t opstrace/looker:latest
 	docker push opstrace/looker:latest

--- a/test/test-remote/containers/looker/looker.Dockerfile
+++ b/test/test-remote/containers/looker/looker.Dockerfile
@@ -2,36 +2,36 @@ FROM node:14-slim
 RUN mkdir /build
 
 # Build context is the `test/test-remote` directory in the repo. Pragmatically
-# copy what's required (not entire dir). `yarn.lock` is actually the
-# repo-global yarn.lock file at the root directory of the repo. Copy that to
-# `test/test-remote/yarn.lock` right before building the image (symlink does
-# not work, Docker would say `Forbidden path outside the build context:
-# yarn.lock`). `make image` does that.
-COPY tsconfig.json yarn.lock /build/
+# copy what's required (not entire dir).
+COPY package.json tsconfig.json /build/
 
-# Use a dedicated package.json for the Docker image build
-COPY containers/looker/package.json /build/
-COPY testutils /build/testutils
-COPY loki-node-client-tools /build/loki-node-client-tools
-COPY prom-node-client-tools /build/prom-node-client-tools
+# Use a dedicated package.json/tsconfig.json for the Docker image build
+# These exclude things that are not used by looker
+COPY yarn.lock test/test-remote/containers/looker/package.json test/test-remote/containers/looker/tsconfig.json /build/test/test-remote/
 
-WORKDIR /build
+COPY test/test-remote/testutils /build/test/test-remote/testutils
+COPY test/test-remote/loki-node-client-tools /build/test/test-remote/loki-node-client-tools
+COPY test/test-remote/prom-node-client-tools /build/test/test-remote/prom-node-client-tools
+
+WORKDIR /build/test/test-remote
 
 # Bake dependencies into the image, based on package.json and yarn.lock.
-RUN yarn install --frozen-lockfile
+RUN echo /build: && \
+    ls -al /build/* && \
+    yarn install --frozen-lockfile
 
-COPY logstream-gen /build/logstream-gen
+COPY test/test-remote/logstream-gen /build/test/test-remote/logstream-gen
 RUN yarn run tsc -b tsconfig.json
 
 # I tried for 45 minutes to set up a binary using the `bin` property in
 # package.json and failed miserably and a combination of `yarn install`, `yarn
 # install -force`, reading yarn docs forth and back, and blog posts. Then fell
 # back to basic unix tools to do that manually: worked within 1 minute.
-ENV PATH="/build:${PATH}"
-RUN chmod ugo+x /build/_tscbuild/logstream-gen/index.js
-RUN ln -s /build/_tscbuild/logstream-gen/index.js /build/looker
+ENV PATH="/build/test/test-remote:${PATH}"
+RUN chmod ugo+x /build/test/test-remote/_tscbuild/logstream-gen/index.js
+RUN ln -s /build/test/test-remote/_tscbuild/logstream-gen/index.js /build/test/test-remote/looker
 
-# See if that works (expect CLI invocation error)
-RUN looker || exit 0
+# See if the looker path works
+RUN looker -h
 WORKDIR /rundir
 CMD looker

--- a/test/test-remote/containers/looker/tsconfig.json
+++ b/test/test-remote/containers/looker/tsconfig.json
@@ -28,10 +28,5 @@
     "loki-node-client-tools/*.ts",
     "prom-node-client-tools/resources/*.json",
     "prom-node-client-tools/*.ts"
-  ],
-  "references": [
-    { "path": "../../lib/utils" },
-    { "path": "../../lib/kubernetes" },
-    { "path": "../../packages/buildinfo" }
   ]
 }

--- a/test/test-remote/nodejs-testrunner.Dockerfile
+++ b/test/test-remote/nodejs-testrunner.Dockerfile
@@ -56,11 +56,10 @@ ENV NO_UPDATE_NOTIFIER true
 ENV PATH=${PATH}:/build/node_modules/.bin
 
 # Sanity check that all dependencies/libraries are actually present before running tests
-# Takes a few minutes so disabled by default
-#RUN playwright -h && \
-#    cd /build/test/test-remote && \
-#    yarn tsc && \
-#    yarn clean
+# If we don't run 'yarn tsc' then we get errors about not being able to find '@opstrace/kubernetes' when running tests.
+RUN playwright -h && \
+    cd /build/test/test-remote && \
+    yarn tsc
 
 # To use this image mount a volume with tests you want to run in a directory
 # under /build, example /build/test-remote, and run `yarn run mocha` in that

--- a/test/test-remote/nodejs-testrunner.Dockerfile
+++ b/test/test-remote/nodejs-testrunner.Dockerfile
@@ -6,7 +6,7 @@ FROM node:14-buster
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
     libnss3 libcups2 libnspr4 libatk1.0-0 libatk-bridge2.0-0 \
     libdbus-c++-1-0v5 libdrm2 libxkbcommon0 libxcomposite1 \
-    libxdamage1 libxfixes3 libxrandr2 libgbm1 libgtk-3-0 libgtk-3-0 \
+    libxdamage1 libxfixes3 libxrandr2 libgbm1 libgtk-3-0 \
     libasound2 libatspi2.0-0 libxshmfence1
 
 # The test runner requires `kubectl`.
@@ -19,18 +19,21 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install && \
     rm awscliv2.zip
 
-# Make the /build directory in the container image be the NPM package dir for
-# the `test-remote` package. Bake the NPM package dependencies into the
-# container image (by running `yarn install`), based on package.json and
-# yarn lock file (the latter is expected to be copied from repo root).
-RUN mkdir /build
-COPY ./package.json /build/package.json
-COPY ./yarn.lock /build/yarn.lock
+# Make the /build/test/test-remote directory in the container image be the NPM package dir
+# for the `test-remote` package. Bake the NPM package dependencies into the container image
+# by running `yarn install`, based on package.json and yarn lock file.
+COPY package.json tsconfig.json /build/
+COPY yarn.lock test/test-remote/package.json test/test-remote/tsconfig.json /build/test/test-remote/
 
-WORKDIR /build
-RUN cat package.json
+# Copy opstrace libraries used by test-remote into the container:
+# opstrace/kubernetes: used directly by test-remote
+COPY lib/kubernetes/ /build/lib/kubernetes/
+# opstrace/utils: used by opstrace/kubernetes
+COPY lib/utils/ /build/lib/utils/
+# opstrace/buildinfo: used by opstrace/kubernetes
+COPY packages/buildinfo/ /build/packages/buildinfo/
 
-RUN yarn install --frozen-lockfile
+WORKDIR /build/test/test-remote
 
 # browserType.launch: Failed to launch chromium because executable doesn't
 # exist at
@@ -39,7 +42,11 @@ RUN yarn install --frozen-lockfile
 # playwright"
 # https://github.com/microsoft/playwright/pull/2192
 ENV PLAYWRIGHT_BROWSERS_PATH=0
-RUN yarn add playwright --frozen-lockfile
+
+RUN cat package.json tsconfig.json && \
+    echo /build: && ls -al /build/* && \
+    yarn install --frozen-lockfile && \
+    yarn add playwright --frozen-lockfile
 
 # Disable automatic NPM update check (would always show "npm update check
 # failed").
@@ -47,6 +54,13 @@ ENV NO_UPDATE_NOTIFIER true
 
 # Add the folder where dependency binaries are installed to the containers PATH.
 ENV PATH=${PATH}:/build/node_modules/.bin
+
+# Sanity check that all dependencies/libraries are actually present before running tests
+# Takes a few minutes so disabled by default
+#RUN playwright -h && \
+#    cd /build/test/test-remote && \
+#    yarn tsc && \
+#    yarn clean
 
 # To use this image mount a volume with tests you want to run in a directory
 # under /build, example /build/test-remote, and run `yarn run mocha` in that

--- a/test/test-remote/package.json
+++ b/test/test-remote/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@js-joda/core": "^3.1.0",
+    "@opstrace/kubernetes": "^0.0.0",
     "argparse": "^2.0.1",
     "await-semaphore": "^0.1.3",
     "dockerode": "^3.2.1",

--- a/test/test-remote/test_alerts.ts
+++ b/test/test-remote/test_alerts.ts
@@ -61,10 +61,11 @@ import {
   logHTTPResponse,
   mtime,
   mtimeDeadlineInSeconds,
+  queryJSONAPI,
   rndstring,
   sleep,
   waitForCortexMetricResult,
-  waitForPrometheusTarget,
+  waitForQueryResult,
   CLUSTER_BASE_URL,
   CORTEX_API_TLS_VERIFY,
   TENANT_DEFAULT_API_TOKEN_FILEPATH,
@@ -72,6 +73,8 @@ import {
   TENANT_SYSTEM_API_TOKEN_FILEPATH,
   TENANT_SYSTEM_CORTEX_API_BASE_URL,
 } from "./testutils";
+
+import { PortForward } from "./testutils/portforward";
 
 function getE2EAlertingResources(tenant: string, job: string): Array<K8sResource> {
   // The test environment should already have kubectl working, so we can use that.
@@ -315,6 +318,60 @@ async function getE2EAlertCountMetric(baseUrl: string, uniqueScrapeJobName: stri
   return value;
 }
 
+// Queries Prometheus scrape targets and waits for one or more targets with a matching job label to appear
+export async function waitForPrometheusTarget(
+  tenant: string,
+  jobLabel: string,
+  maxWaitSeconds: number,
+) {
+  const portForwardProm = new PortForward(
+    `tenant-prometheus-${tenant}`, // name (arbitrary/logging)
+    `statefulsets/prometheus-${tenant}-prometheus`, // k8sobj
+    9091, // port_local
+    9090, // port_remote
+    `${tenant}-tenant`, // namespace
+  );
+  await portForwardProm.setup();
+
+  try {
+    const url = `http://127.0.0.1:9091/prometheus/api/v1/targets`;
+    const qparms = new URLSearchParams({state: "active"});
+
+    log.info(`Querying prometheus via port-forward: ${url}`)
+    await waitForQueryResult(
+      () => queryJSONAPI(url, qparms),
+      (data) => {
+        // Example data: https://prometheus.io/docs/prometheus/latest/querying/api/#targets
+        // Search for target(s) with matching job label
+        const targets: Array<any> = data["data"]["activeTargets"];
+        const filtered = targets.filter(target => target["labels"]["job"] === jobLabel);
+        if (filtered.length == 0) {
+          log.info(
+            "No targets with job=%s, instead got: %s",
+            jobLabel,
+            targets
+              .map(t => `${t["labels"]["job"]}:${t["labels"]["namespace"]}/${t["labels"]["pod"]}`)
+              .sort()
+          );
+          return null;
+        }
+        log.info(
+          "Found tenant prometheus scrape targets for job=%s: %s",
+          jobLabel,
+          filtered
+            .map(t => `${t["labels"]["job"]}:${t["labels"]["namespace"]}/${t["labels"]["pod"]}`)
+            .sort()
+        );
+        return filtered;
+      },
+      maxWaitSeconds,
+      false, // This is VERY long for system tenant, so don't log
+    );
+  } finally {
+    await portForwardProm.terminate();
+  }
+}
+
 async function testE2EAlertsForTenant(cortexBaseUrl: string, authTokenFilepath: string | undefined, tenant: string) {
   const ruleNamespace = "testremote";
 
@@ -356,7 +413,9 @@ async function testE2EAlertsForTenant(cortexBaseUrl: string, authTokenFilepath: 
 
   // Wait for the E2E pod to appear in prometheus scrape targets
   log.info(`Waiting for E2E scrape target to appear in tenant prometheus for tenant=${tenant} job=${uniqueScrapeJobName}`);
-  await waitForPrometheusTarget(tenant, uniqueScrapeJobName);
+  // Use a long timeout when waiting for prometheus scraper to see the pod.
+  // Normally takes 5-15s, but can take longer than 30s
+  await waitForPrometheusTarget(tenant, uniqueScrapeJobName, 300);
 
   // Wait for the metric to appear in cortex with the matching random 'job' tag
   log.info(`Waiting for cortex E2E alerting metric for tenant=${tenant} job=${uniqueScrapeJobName} with zero value`);

--- a/test/test-remote/test_alerts.ts
+++ b/test/test-remote/test_alerts.ts
@@ -1,0 +1,421 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Deploys the 'e2ealerting' tool for firing alerts and checking that they are received.
+// See also: https://github.com/grafana/cortex-tools/blob/main/docs/e2ealerting.md
+//
+// The chain works like this:
+// - The test deploys an e2ealerting pod
+// - e2ealerting pod serves a metric: e2ealerting_webhook_receiver_end_to_end_duration_seconds
+// - the metric is scraped by the tenant prometheus
+// - the tenant prometheus forwards it to cortex against the tenant (X-Scope-OrgId)
+// - cortex ruler has been configured with an alert rule to always fire against the metric
+// - cortex alertmanager has been configured to report firing rules back to e2ealerting via a webhook endpoint
+// - e2ealerting receives the alert, and then increments e2ealerting_webhook_receiver_evaluations_total
+//
+// So, what we need to do is:
+// - Deploy e2ealerting and configure scraping of its metrics endpoint so that metrics get into cortex
+// - Configure cortex ruler to fire against the e2ealerting metric
+// - Configure cortex alertmanager for the tenant to send alerts back to e2ealerting
+//
+// This will validate:
+// - That scraped metrics from a tenant pod are getting into cortex automatically
+//   If this fails, then maybe the tenant prometheus isnt routing metrics into cortex?
+// - That we can configure cortex ruler/alertmanager for the tenant via Opstrace config-api endpoints
+//   If this fails, then maybe there is a regression in config-api, the cortex APIs, or the K8s ingress config?
+// - That the cortex tenant ruler/alertmanager work and send alerts as configured
+//   If this fails, then maybe there is a config issue or regression in cortex ruler/alertmanager?
+
+import { strict as assert } from "assert";
+
+import got from "got";
+
+import { KubeConfig } from "@kubernetes/client-node";
+
+import {
+  Deployment,
+  K8sResource,
+  Service,
+  V1ServicemonitorResource,
+  kubernetesError,
+} from "@opstrace/kubernetes";
+
+import {
+  enrichHeadersWithAuthTokenFile,
+  globalTestSuiteSetupOnce,
+  httpTimeoutSettings,
+  log,
+  logHTTPResponse,
+  mtime,
+  mtimeDeadlineInSeconds,
+  rndstring,
+  sleep,
+  CLUSTER_BASE_URL,
+  CORTEX_API_TLS_VERIFY,
+  TENANT_DEFAULT_API_TOKEN_FILEPATH,
+  TENANT_DEFAULT_CORTEX_API_BASE_URL,
+  TENANT_SYSTEM_API_TOKEN_FILEPATH,
+  TENANT_SYSTEM_CORTEX_API_BASE_URL
+} from "./testutils";
+
+import { waitForCortexQueryResult } from "./test_prom_remote_write";
+
+function getE2EAlertingResources(tenant: string, job: string): Array<K8sResource> {
+  // The test environment should already have kubectl working, so we can use that.
+  const kubeConfig = new KubeConfig();
+  kubeConfig.loadFromDefault();
+  // loadFromDefault will fall back to e.g. localhost if it cant find something.
+  // So let's explicitly try to communicate with the cluster.
+  const kubeContext = kubeConfig.getCurrentContext();
+  if (kubeContext === null) {
+    throw new Error('Unable to communicate with kubernetes cluster. Is kubectl set up?');
+  }
+
+  const name = "e2ealerting";
+  const namespace = `${tenant}-tenant`;
+  const matchLabels = {
+    app: name,
+    tenant
+  };
+  // With a randomized 'job' label that will appear in metrics
+  const labels = {
+    app: name,
+    tenant,
+    job
+  };
+
+  const resources: Array<K8sResource> = [];
+
+  resources.push(
+    new Deployment(
+      {
+	apiVersion: "apps/v1",
+	kind: "Deployment",
+	metadata: {
+          name,
+          namespace,
+          labels
+        },
+        spec: {
+          replicas: 1,
+          selector: {
+            matchLabels
+          },
+          template: {
+            metadata: {
+              labels
+            },
+            spec: {
+              containers: [{
+                name: "e2ealerting",
+                image: "grafana/e2ealerting:master-db38b142",
+                args: [
+                  "-server.http-listen-port=8080",
+                  "-log.level=debug"
+                ],
+                ports: [{ name: "http", containerPort: 8080 }],
+                livenessProbe: {
+                  httpGet: {
+                    path: "/metrics",
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    port: "http" as any,
+                    scheme: "HTTP"
+                  },
+                  periodSeconds: 10,
+                  successThreshold: 1,
+                  failureThreshold: 3,
+                  timeoutSeconds: 1
+                }
+              }]
+            },
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  resources.push(
+    new Service(
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name,
+          namespace,
+          labels
+        },
+        spec: {
+          ports: [
+            {
+              name: "http",
+              port: 80,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              targetPort: "http" as any
+            }
+          ],
+          selector: labels
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  resources.push(
+    new V1ServicemonitorResource(
+      {
+        apiVersion: "monitoring.coreos.com/v1",
+        kind: "ServiceMonitor",
+        metadata: {
+          name,
+          namespace,
+          labels
+        },
+        spec: {
+          jobLabel: "job", // point to 'job' label in the pod
+          endpoints: [
+            {
+              // Spam it at 5s to get faster responses in tests
+              interval: "5s",
+              port: "http",
+              path: "/metrics",
+            }
+          ],
+          selector: {
+            matchLabels
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  return resources;
+}
+
+async function storeE2EAlertsConfig(authTokenFilepath: string | undefined, tenant: string, ruleNamespace: string) {
+  // Configure tenant alertmanager to send alerts to e2ealerting service
+  // Using cortex API proxied via config-api: https://cortexmetrics.io/docs/api/#set-alertmanager-configuration
+  const alertmanagerConfigUrl = `${CLUSTER_BASE_URL}/api/v1/alerts`;
+  const alertmanagerPostResponse = await got.post(
+    alertmanagerConfigUrl,
+    {
+      body: `alertmanager_config: |
+  receivers:
+    - name: e2e-alerting
+      webhook_configs:
+        - url: http://e2ealerting.${tenant}-tenant.svc.cluster.local/api/v1/receiver
+  route:
+      group_interval: 1s
+      group_wait: 1s
+      receiver: e2e-alerting
+      repeat_interval: 1s
+`,
+      throwHttpErrors: false,
+      timeout: httpTimeoutSettings,
+      headers: enrichHeadersWithAuthTokenFile(authTokenFilepath, {}),
+      https: { rejectUnauthorized: CORTEX_API_TLS_VERIFY }
+    }
+  );
+  logHTTPResponse(alertmanagerPostResponse);
+  assert(alertmanagerPostResponse.statusCode == 201 || alertmanagerPostResponse.statusCode == 202)
+
+  // Configure tenant ruler to fire alert against metric scraped from e2ealerting pod
+  // Using cortex API proxied via config-api: https://cortexmetrics.io/docs/api/#set-rule-group
+  const ruleGroupConfigUrl = `${CLUSTER_BASE_URL}/api/v1/rules/${ruleNamespace}`;
+  const ruleGroupPostResponse = await got.post(
+    ruleGroupConfigUrl,
+    {
+      body: `name: e2ealerting
+rules:
+  - alert: E2EAlertingAlwaysFiring
+    annotations:
+        time: '{{ $value }}'
+    expr: e2ealerting_now_in_seconds > 0
+    for: 10s
+`,
+      throwHttpErrors: false,
+      timeout: httpTimeoutSettings,
+      headers: enrichHeadersWithAuthTokenFile(authTokenFilepath, {}),
+      https: { rejectUnauthorized: CORTEX_API_TLS_VERIFY }
+    }
+  );
+  logHTTPResponse(ruleGroupPostResponse);
+  assert(ruleGroupPostResponse.statusCode == 201 || ruleGroupPostResponse.statusCode == 202)
+}
+
+async function deleteE2EAlertsConfig(authTokenFilepath: string | undefined, ruleNamespace: string) {
+  // Delete alertmanager config created earlier
+  // Using cortex API proxied via config-api: https://cortexmetrics.io/docs/api/#delete-alertmanager-configuration
+  const alertmanagerConfigUrl = `${CLUSTER_BASE_URL}/api/v1/alerts`;
+  const alertmanagerDeleteResponse = await got.delete(
+    alertmanagerConfigUrl,
+    {
+      throwHttpErrors: false,
+      timeout: httpTimeoutSettings,
+      headers: enrichHeadersWithAuthTokenFile(authTokenFilepath, {}),
+      https: { rejectUnauthorized: CORTEX_API_TLS_VERIFY }
+    }
+  );
+  logHTTPResponse(alertmanagerDeleteResponse);
+  assert(alertmanagerDeleteResponse.statusCode == 202 || alertmanagerDeleteResponse.statusCode == 200)
+
+  // Delete rule namespace created earlier
+  // Using cortex API proxied via config-api: https://cortexmetrics.io/docs/api/#delete-namespace
+  const ruleGroupConfigUrl = `${CLUSTER_BASE_URL}/api/v1/rules/${ruleNamespace}`;
+  const ruleGroupDeleteResponse = await got.delete(
+    ruleGroupConfigUrl,
+    {
+      throwHttpErrors: false,
+      timeout: httpTimeoutSettings,
+      headers: enrichHeadersWithAuthTokenFile(authTokenFilepath, {}),
+      https: { rejectUnauthorized: CORTEX_API_TLS_VERIFY }
+    }
+  );
+  logHTTPResponse(ruleGroupDeleteResponse);
+  assert(ruleGroupDeleteResponse.statusCode == 202 || ruleGroupDeleteResponse.statusCode == 404)
+}
+
+async function getE2EAlertCountMetric(baseUrl: string, uniqueScrapeJobName: string): Promise<string> {
+  // Instant query - get current value
+  // https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+  const queryParams = {
+    query: `e2ealerting_webhook_receiver_evaluations_total{job="${uniqueScrapeJobName}"}`,
+  };
+  const resultArray = await waitForCortexQueryResult(
+    baseUrl,
+    queryParams,
+    "query",
+    30,
+    true // logQueryResponse
+  );
+
+  // Sanity check: label should match
+  assert.strictEqual(
+    resultArray[0]["metric"]["job"],
+    uniqueScrapeJobName,
+    "Expected to get matching job label for e2ealerting webhook metric: ${resultArray}"
+  );
+
+  const value = resultArray[0]["value"][1];
+  log.info(`Got alert count value: ${value}`, value);
+  return value;
+}
+
+async function testE2EAlertsForTenant(cortexBaseUrl: string, authTokenFilepath: string | undefined, tenant: string) {
+  const ruleNamespace = "testremote";
+
+  // Before deploying anything, delete any existing alertmanager/rulegroup configuration.
+  // This avoids an old alert config writing to the newly deployed webhook, making its hit count 1 when we expect 0
+  // This should only be a problem when running the same test repeatedly against a cluster.
+  log.info("Deleting any preexisting E2E alerts webhook");
+  await deleteE2EAlertsConfig(authTokenFilepath, ruleNamespace);
+
+  // Give a random token to include for the 'job' label in metrics.
+  // This is just in case e.g. tests are re-run against the same cluster.
+  const uniqueScrapeJobName = "testalerts-" + rndstring().slice(0, 5);
+
+  log.info(`Deploying E2E alerting resources into ${tenant}-tenant namespace`);
+  const resources = getE2EAlertingResources(tenant, uniqueScrapeJobName);
+  for (const r of resources) {
+    try {
+      log.info(`Try to create ${r.constructor.name}: ${r.namespace}/${r.name}`);
+      await r.create();
+    } catch (e) {
+      const err = kubernetesError(e);
+      if (err.statusCode === 409) {
+        // If we're re-running the test against a cluster, ensure things like job labels are updated.
+        log.info("Already exists, doing an update");
+        try {
+          await r.update();
+        } catch (e2) {
+          const err2 = kubernetesError(e2);
+          log.error(`update failed with error: ${err2.message}`);
+          throw e2;
+        }
+      } else {
+        log.error(`create failed with error: ${err.message}`);
+        throw e;
+      }
+    }
+  }
+
+  // Wait for the metric to appear in cortex with the matching random 'job' tag
+  log.info(`Waiting for cortex E2E alerting metric for tenant=${tenant} job=${uniqueScrapeJobName} with zero value`);
+  const value = await getE2EAlertCountMetric(cortexBaseUrl, uniqueScrapeJobName);
+  // Value should be zero since we haven't set up alerts
+  assert.strictEqual(
+    value,
+    "0",
+    `Expected to get zero value for e2ealerting webhook metric: ${value}`
+  );
+
+  log.info("Setting up E2E alerts webhook");
+  await storeE2EAlertsConfig(authTokenFilepath, tenant, ruleNamespace);
+
+  // Now that we've set up the alert outputs, wait for the e2ealerting webhook to be queried
+  // and the count of evaluations to be incremented at least once.
+  log.info(`Waiting for cortex E2E alerting metric for tenant=${tenant} job=${uniqueScrapeJobName} with nonzero value`);
+  const deadline = mtimeDeadlineInSeconds(300);
+  while (true) {
+    const value = await getE2EAlertCountMetric(cortexBaseUrl, uniqueScrapeJobName);
+    if (value !== "0") {
+      log.info(`Got alerts metric value: ${value}`);
+      break;
+    }
+    if (mtime() > deadline) {
+      throw new Error("Failed to get non-zero alerts metric value after 300s. Are alerts successfully reaching the e2ealerting pod?");
+    }
+    await sleep(1.0);
+  }
+
+  log.info("Deleting E2E alerts webhook");
+  await deleteE2EAlertsConfig(authTokenFilepath, ruleNamespace);
+
+  log.info(`Deleting E2E alerting resources from ${tenant}-tenant namespace`)
+  for (const r of resources) {
+    try {
+      log.info(`Try to delete ${r.constructor.name}: ${r.namespace}/${r.name}`);
+      await r.delete();
+    } catch (e) {
+      const err = kubernetesError(e);
+      if (err.statusCode === 404) {
+        log.info("already doesn't exist");
+      } else {
+        throw e;
+      }
+    }
+  }
+}
+
+suite("End-to-end alert tests", function () {
+  suiteSetup(async function () {
+    log.info("suite setup");
+    globalTestSuiteSetupOnce();
+  });
+
+  suiteTeardown(async function () {
+    log.info("suite teardown");
+  });
+
+  test("End-to-end alerts for default tenant", async function () {
+    await testE2EAlertsForTenant(TENANT_DEFAULT_CORTEX_API_BASE_URL, TENANT_DEFAULT_API_TOKEN_FILEPATH, "default");
+  });
+
+  test("End-to-end alerts for system tenant", async function () {
+    await testE2EAlertsForTenant(TENANT_SYSTEM_CORTEX_API_BASE_URL, TENANT_SYSTEM_API_TOKEN_FILEPATH, "system");
+  });
+});

--- a/test/test-remote/test_dd.ts
+++ b/test/test-remote/test_dd.ts
@@ -22,23 +22,22 @@ import { ZonedDateTime } from "@js-joda/core";
 import got from "got";
 
 import {
-  log,
-  rndstring,
-  logHTTPResponse,
-  httpTimeoutSettings,
-  TENANT_DEFAULT_DD_API_BASE_URL,
-  TENANT_DEFAULT_CORTEX_API_BASE_URL,
-  TENANT_DEFAULT_API_TOKEN_FILEPATH,
-  globalTestSuiteSetupOnce,
-  readDockerDNSSettings,
   createTempfile,
-  mtimeDeadlineInSeconds,
+  globalTestSuiteSetupOnce,
+  httpTimeoutSettings,
+  log,
+  logHTTPResponse,
   mtime,
+  mtimeDeadlineInSeconds,
+  readDockerDNSSettings,
+  readFirstNBytes,
+  rndstring,
   sleep,
-  readFirstNBytes
+  waitForCortexMetricResult,
+  TENANT_DEFAULT_API_TOKEN_FILEPATH,
+  TENANT_DEFAULT_CORTEX_API_BASE_URL,
+  TENANT_DEFAULT_DD_API_BASE_URL,
 } from "./testutils";
-
-import { waitForCortexQueryResult } from "./test_prom_remote_write";
 
 function ddApiSeriesUrl() {
   let url = `${TENANT_DEFAULT_DD_API_BASE_URL}/api/v1/series`;
@@ -294,7 +293,7 @@ suite("DD API test suite", function () {
       step: "60s"
     };
 
-    const resultArray = await waitForCortexQueryResult(
+    const resultArray = await waitForCortexMetricResult(
       TENANT_DEFAULT_CORTEX_API_BASE_URL,
       queryParams,
       "query_range"
@@ -347,7 +346,7 @@ suite("DD API test suite", function () {
       step: "60s"
     };
 
-    const resultArray = await waitForCortexQueryResult(
+    const resultArray = await waitForCortexMetricResult(
       TENANT_DEFAULT_CORTEX_API_BASE_URL,
       queryParams,
       "query_range"

--- a/test/test-remote/test_dd.ts
+++ b/test/test-remote/test_dd.ts
@@ -296,7 +296,8 @@ suite("DD API test suite", function () {
 
     const resultArray = await waitForCortexQueryResult(
       TENANT_DEFAULT_CORTEX_API_BASE_URL,
-      queryParams
+      queryParams,
+      "query_range"
     );
 
     log.info("resultArray: %s", JSON.stringify(resultArray, null, 2));
@@ -348,7 +349,8 @@ suite("DD API test suite", function () {
 
     const resultArray = await waitForCortexQueryResult(
       TENANT_DEFAULT_CORTEX_API_BASE_URL,
-      queryParams
+      queryParams,
+      "query_range"
     );
 
     log.info("resultArray: %s", JSON.stringify(resultArray, null, 2));

--- a/test/test-remote/test_prom_remote_write.ts
+++ b/test/test-remote/test_prom_remote_write.ts
@@ -16,127 +16,19 @@
 
 import { strict as assert } from "assert";
 
-import got from "got";
 import { ZonedDateTime, ZoneOffset } from "@js-joda/core";
 import {
-  log,
-  sendMetricsWithPromContainer,
-  logHTTPResponse,
-  httpTimeoutSettings,
-  rndstring,
-  mtime,
-  mtimeDeadlineInSeconds,
-  sleep,
-  globalTestSuiteSetupOnce,
   enrichHeadersWithAuthToken,
-  TENANT_DEFAULT_CORTEX_API_BASE_URL,
+  globalTestSuiteSetupOnce,
+  log,
+  rndstring,
+  sendMetricsWithPromContainer,
+  waitForCortexMetricResult,
   TENANT_DEFAULT_API_TOKEN_FILEPATH,
-  CORTEX_API_TLS_VERIFY
+  TENANT_DEFAULT_CORTEX_API_BASE_URL,
 } from "./testutils";
 
 import { DummyTimeseries } from "./prom-node-client-tools";
-
-async function queryCortex(baseUrl: string, queryUrlSuffix: string, queryParams: URLSearchParams) {
-  /* Notes, in no particular order:
-
-  - test deprecated /api/prom/query endpoint
-    https://github.com/grafana/loki/blob/master/docs/api.md#get-apipromquery
-    this resembles a query parameter set as constructed by the Grafana Explore
-    UI.
-
-  - Ideal would be: do not perform any kind of response body decoding within
-    got's HTTP client implementation, do this explicitly after retrieving the
-    response data as a byte sequence (into a Buffer), and then decode it
-    explicitly first to text using e.g. response.body.toString("utf-8") and
-    then as JSON doc. In the future use got 10 (currently 10.0.0-beta2, so a
-    little early) because of the buffer goodness:
-    https://github.com/sindresorhus/got/issues/949
-
-  - Do not magically throw an error upon receiving a non-2xx response. Leave
-    this to the test business logic.
-
-  - Note that Loki seems to set `'Content-Type': 'text/plain; charset=utf-8'`
-    even when it sends a JSON document in the response body. Submit a bug
-    report, and at some point test that this is not the case anymore here.
-  */
-  const url = `${baseUrl}/api/v1/${queryUrlSuffix}`;
-
-  // Automagically enrich with Authorization header, if applicable.
-  const headers = enrichHeadersWithAuthToken(url, {});
-
-  const options = {
-    throwHttpErrors: false,
-    searchParams: queryParams,
-    timeout: httpTimeoutSettings,
-    headers: headers,
-    https: { rejectUnauthorized: CORTEX_API_TLS_VERIFY } // disable TLS server cert verification for now
-  };
-
-  const response = await got(url, options);
-  if (response.statusCode != 200) logHTTPResponse(response);
-  // Note: for now expect `response.body` to be text.
-  return JSON.parse(response.body);
-}
-
-export interface MetricInstanaRecordLabels {
-  [key: string]: string;
-}
-
-export interface MetricInstanaRecord {
-  log: string;
-  time: string;
-  labels: MetricInstanaRecordLabels;
-}
-
-export async function waitForCortexQueryResult(
-  baseUrl: string,
-  queryParams: Record<string, string>,
-  queryUrlSuffix: string,
-  // What's our latency goal here? Upper pipeline latency limit? As of writing
-  // this code I have seen this latency to vary between about 2 seconds and 12
-  // seconds.
-  maxWaitSeconds = 30,
-  logQueryResponse = false
-) {
-  log.info(
-    "Cortex query parameter (object):\n%s",
-    JSON.stringify(queryParams, Object.keys(queryParams).sort(), 2)
-  );
-  const qparms = new URLSearchParams(queryParams);
-  log.info("Cortex query parameters (query string):\n%s", qparms);
-
-  const deadline = mtimeDeadlineInSeconds(maxWaitSeconds);
-  log.info(
-    "waiting for Cortex to return a match, deadline in %s s",
-    maxWaitSeconds
-  );
-
-  //const t0 = mtime();
-
-  while (true) {
-    // `break`ing out the loop enters the error path, returning indicates
-    // success.
-
-    if (mtime() > deadline) {
-      log.error("query deadline hit");
-      break;
-    }
-
-    log.debug("send query to Cortex");
-    const data = await queryCortex(baseUrl, queryUrlSuffix, qparms);
-    if (logQueryResponse) {
-      log.info("query response data:\n%s", JSON.stringify(data, null, 2));
-    }
-
-    const resultArray = data["data"]["result"];
-    if (resultArray.length > 0) {
-      return resultArray;
-    }
-
-    await sleep(1.0);
-  }
-  throw new Error(`Expectation not fulfilled within ${maxWaitSeconds} s`);
-}
 
 suite("Prometheus remote_write (push to opstrace cluster) tests", function () {
   suiteSetup(async function () {
@@ -168,7 +60,7 @@ suite("Prometheus remote_write (push to opstrace cluster) tests", function () {
       step: "1"
     };
 
-    const resultArray = await waitForCortexQueryResult(
+    const resultArray = await waitForCortexMetricResult(
       TENANT_DEFAULT_CORTEX_API_BASE_URL,
       queryParams,
       "query_range"
@@ -219,7 +111,7 @@ suite("Prometheus remote_write (push to opstrace cluster) tests", function () {
       step: "1"
     };
 
-    const resultArray = await waitForCortexQueryResult(
+    const resultArray = await waitForCortexMetricResult(
       TENANT_DEFAULT_CORTEX_API_BASE_URL,
       queryParams,
       "query_range"

--- a/test/test-remote/test_systemmetrics.ts
+++ b/test/test-remote/test_systemmetrics.ts
@@ -19,10 +19,9 @@ import { ZonedDateTime } from "@js-joda/core";
 import {
   log,
   globalTestSuiteSetupOnce,
-  TENANT_SYSTEM_CORTEX_API_BASE_URL
+  waitForCortexMetricResult,
+  TENANT_SYSTEM_CORTEX_API_BASE_URL,
 } from "./testutils";
-
-import { waitForCortexQueryResult } from "./test_prom_remote_write";
 
 suite("system metrics test suite", function () {
   suiteSetup(async function () {
@@ -48,7 +47,7 @@ suite("system metrics test suite", function () {
       step: "1"
     };
 
-    const resultArray = await waitForCortexQueryResult(
+    const resultArray = await waitForCortexMetricResult(
       TENANT_SYSTEM_CORTEX_API_BASE_URL,
       queryParams,
       "query_range"

--- a/test/test-remote/test_systemmetrics.ts
+++ b/test/test-remote/test_systemmetrics.ts
@@ -50,7 +50,8 @@ suite("system metrics test suite", function () {
 
     const resultArray = await waitForCortexQueryResult(
       TENANT_SYSTEM_CORTEX_API_BASE_URL,
-      queryParams
+      queryParams,
+      "query_range"
     );
 
     // pragmatic criterion for starters: expect a number of values. with

--- a/test/test-remote/testutils/index.ts
+++ b/test/test-remote/testutils/index.ts
@@ -32,8 +32,6 @@ import { ZonedDateTime, DateTimeFormatter } from "@js-joda/core";
 
 import getPort from "get-port";
 
-import { PortForward } from "./portforward";
-
 export const CORTEX_API_TLS_VERIFY = false;
 export const LOKI_API_TLS_VERIFY = false;
 
@@ -855,7 +853,7 @@ export const httpTimeoutSettings = {
   request: 60000
 };
 
-async function queryJSONAPI(url: string, queryParams: URLSearchParams) {
+export async function queryJSONAPI(url: string, queryParams: URLSearchParams) {
   /* Notes, in no particular order:
 
   - test deprecated /api/prom/query endpoint
@@ -905,7 +903,7 @@ async function queryJSONAPI(url: string, queryParams: URLSearchParams) {
 }
 
 // Generic function for polling a JSON endpoint and returning a result after it passes a check.
-async function waitForQueryResult<T>(
+export async function waitForQueryResult<T>(
   // Callback for executing the query itself
   queryFunc: { (): Promise<T> },
   // Callback for checking the result for an expected value, returning null if the query should retry
@@ -971,58 +969,4 @@ export async function waitForCortexMetricResult(
     maxWaitSeconds,
     logQueryResponse,
   );
-}
-
-// Queries Prometheus scrape targets and waits for one or more targets with a matching job label to appear
-export async function waitForPrometheusTarget(
-  tenant: string,
-  jobLabel: string,
-  maxWaitSeconds = 60,
-) {
-  const portForwardProm = new PortForward(
-    `tenant-prometheus-${tenant}`, // name (arbitrary/logging)
-    `statefulsets/prometheus-${tenant}-prometheus`, // k8sobj
-    9091, // port_local
-    9090, // port_remote
-    `${tenant}-tenant`, // namespace
-  );
-  await portForwardProm.setup();
-
-  try {
-    const url = `http://127.0.0.1:9091/prometheus/api/v1/targets`;
-    const qparms = new URLSearchParams({state: "active"});
-
-    log.info(`Querying prometheus via port-forward: ${url}`)
-    await waitForQueryResult(
-      () => queryJSONAPI(url, qparms),
-      (data) => {
-        // Example data: https://prometheus.io/docs/prometheus/latest/querying/api/#targets
-        // Search for target(s) with matching job label
-        const targets: Array<any> = data["data"]["activeTargets"];
-        const filtered = targets.filter(target => target["labels"]["job"] === jobLabel);
-        if (filtered.length == 0) {
-          log.info(
-            "No targets with job=%s, instead got: %s",
-            jobLabel,
-            targets
-              .map(t => `${t["labels"]["job"]}:${t["labels"]["namespace"]}/${t["labels"]["pod"]}`)
-              .sort()
-          );
-          return null;
-        }
-        log.info(
-          "Found tenant prometheus scrape targets for job=%s: %s",
-          jobLabel,
-          filtered
-            .map(t => `${t["labels"]["job"]}:${t["labels"]["namespace"]}/${t["labels"]["pod"]}`)
-            .sort()
-        );
-        return filtered;
-      },
-      maxWaitSeconds,
-      false, // This is VERY long for system tenant, so don't log
-    );
-  } finally {
-    await portForwardProm.terminate();
-  }
 }

--- a/test/test-remote/testutils/portforward.ts
+++ b/test/test-remote/testutils/portforward.ts
@@ -164,24 +164,20 @@ export class PortForward {
     behind (resource cleanup guarantee).
     */
 
-    log.info("%s: initialize", this);
+    log.info(`${this}: initialize`);
 
     await this.startProcess();
 
     const maxWaitSeconds = 30;
     const deadline = mtimeDeadlineInSeconds(maxWaitSeconds);
-    log.info(
-      "%s: waiting for port-forward to become ready, deadline in %s s",
-      this,
-      maxWaitSeconds
-    );
+    log.info(`${this}: waiting for port-forward to become ready, deadline in ${maxWaitSeconds}s`);
 
     while (true) {
       // `break`ing out the loop enters the error path, returning `true`
       // indicates success.
 
       if (mtime() > deadline) {
-        log.error("%s: port-forward deadline hit", this);
+        log.error(`${this}: port-forward deadline hit`);
         break;
       }
 
@@ -192,15 +188,12 @@ export class PortForward {
       // up in the next loop iteration _after_ the corresponding event handlers
       // fired.
       if (this.processStartupError) {
-        log.error("%s: kubectl process startup error, stop waiting", this);
+        log.error(`${this}: kubectl process startup error, stop waiting`);
         break;
       }
 
       if (this.processExitCode) {
-        log.error(
-          "%s: kubectl process exited unexpectedly, stop waiting",
-          this
-        );
+        log.error(`${this}: kubectl process exited unexpectedly, stop waiting`);
         break;
       }
 
@@ -211,7 +204,7 @@ export class PortForward {
         // handler with one that informs about the child having gone away
         // unexpectedly after successful port-forward establishment, should
         // then also log stdout.err as well and exit code.
-        log.info("%s: ready", this);
+        log.info(`${this}: ready\n${fileHeadBytes}`);
         return true;
       }
       await sleep(0.1);


### PR DESCRIPTION
Deploys the 'e2ealerting' tool for firing alerts and checking that they are received.
See also: https://github.com/grafana/cortex-tools/blob/main/docs/e2ealerting.md

The chain works like this:
- The test deploys an `e2ealerting` pod
- `e2ealerting` pod serves a metric: `e2ealerting_webhook_receiver_end_to_end_duration_seconds`
- the metric is scraped by the tenant prometheus
- the tenant prometheus forwards it to cortex against the tenant (`X-Scope-OrgId`)
- cortex ruler has been configured with an alert rule to always fire against the metric
- cortex alertmanager has been configured to report firing rules back to `e2ealerting` via a webhook endpoint
- `e2ealerting` receives the alert, and then increments `e2ealerting_webhook_receiver_evaluations_total`

So, what we need to do is:
- Deploy `e2ealerting` and configure scraping of its metrics endpoint so that metrics get into cortex
- Configure cortex ruler to fire against the `e2ealerting` metric
- Configure cortex alertmanager for the tenant to send alerts back to `e2ealerting`

This will validate:
- That scraped metrics from a tenant pod are getting into cortex automatically
    If this fails, then maybe the tenant prometheus isnt routing metrics into cortex?
- That we can configure cortex ruler/alertmanager for the tenant via Opstrace `config-api` endpoints
    If this fails, then maybe there is a regression in `config-api`, the cortex APIs, or the K8s ingress config?
- That the cortex tenant ruler/alertmanager work and send alerts as configured
    If this fails, then maybe there is a config issue or regression in cortex ruler/alertmanager?

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
