### PR TITLE
controller: Support for deploying blackbox exporter (fixes #548)

### DIFF
--- a/ci/check-deployed-docker-images.sh
+++ b/ci/check-deployed-docker-images.sh
@@ -17,9 +17,10 @@ echo
 # - postgresql-client: Only in initContainers which we aren't checking
 # - cloudwatch-exporter: Not deployed in initial cluster, only added after user adds a cloudwatch exporter
 # - stackdriver-exporter: Not deployed in initial cluster, only added after user adds a stackdriver exporter
+# - blackbox-exporter: Not deployed in initial cluster, only added after user adds a blackbox exporter
 # - local-volume-provisioner: Not deployed on AWS
 #
-UNEXPECTED_IMAGES=("tmaier/postgresql-client" "prom/cloudwatch-exporter" "prometheuscommunity/stackdriver-exporter")
+UNEXPECTED_IMAGES=("tmaier/postgresql-client" "prom/cloudwatch-exporter" "prometheuscommunity/stackdriver-exporter" "prom/blackbox-exporter")
 if [[ "${OPSTRACE_CLOUD_PROVIDER}" == "aws" ]]; then
     UNEXPECTED_IMAGES+=("quay.io/external_storage/local-volume-provisioner")
 fi

--- a/go/cmd/config/README.md
+++ b/go/cmd/config/README.md
@@ -245,22 +245,22 @@ type: gcp-service-account
 # gcp-service-account must contain valid json:
 value: |-
   {"json": "goes-here"}
-' | curl -v -H "X-Scope-OrgID: tenant-foo" -XPOST --data-binary @- http://127.0.0.1:8989/api/v1/credentials/
+' | curl -v -H "Authorization: Bearer $(cat tenant-api-token-dev)" --data-binary @- https://MYCLUSTER.opstrace.io/api/v1/credentials/
 ```
 
 Get all
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/credentials/
+curl -v -H "Authorization: Bearer $(cat tenant-api-token-dev)" https://MYCLUSTER.opstrace.io/api/v1/credentials/
 ```
 
 Get foo
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/credentials/foo
+curl -v -H "Authorization: Bearer $(cat tenant-api-token-dev)" https://MYCLUSTER.opstrace.io/api/v1/credentials/foo
 ```
 
 Delete foo
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" -XDELETE http://127.0.0.1:8989/api/v1/credentials/foo
+curl -v -H "Authorization: Bearer $(cat tenant-api-token-dev)" -XDELETE https://MYCLUSTER.opstrace.io/api/v1/credentials/foo
 ```
 
 #### Exporter HTTP examples
@@ -300,20 +300,48 @@ config:
   - proj2
   monitoring.metrics-interval: '5m' # optional
   monitoring.metrics-offset: '0s' # optional
-' | curl -v -H "X-Scope-OrgID: tenant-foo" -XPOST --data-binary @- http://127.0.0.1:8989/api/v1/exporters/
+---
+name: baz
+type: blackbox
+config:
+  probes: # required, list of probes to collect. args match HTTP params
+  - target: prometheus.io
+    module: http_2xx
+  - target: example.com
+    module: http_2xx
+  - target: 1.1.1.1
+    module: dns_opstrace_mx
+  - target: 8.8.8.8
+    module: dns_opstrace_mx
+  modules: # optional, blackbox module configuration to overwrite exporter defaults
+    http_2xx:
+      prober: http
+      timeout: 5s
+      http:
+        preferred_ip_protocol: "ip4"
+    dns_opstrace_mx:
+      prober: dns
+      timeout: 5s
+      dns:
+        preferred_ip_protocol: "ip4"
+        transport_protocol: tcp
+        dns_over_tls: true
+        query_name: opstrace.com
+        query_type: MX
+' | curl -v -H "Authorization: Bearer $(cat tenant-api-token-dev)" --data-binary @- https://MYCLUSTER.opstrace.io/api/v1/exporters/
 ```
 
 Get all
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/exporters/
+curl -v -H "Authorization: Bearer $(cat tenant-api-token-dev)" https://MYCLUSTER.opstrace.io/api/v1/exporters/
 ```
 
 Get foo
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" http://127.0.0.1:8989/api/v1/exporters/foo
+curl -v -H "Authorization: Bearer $(cat tenant-api-token-dev)" https://MYCLUSTER.opstrace.io/api/v1/exporters/foo
 ```
 
 Delete foo
 ```
-curl -v -H "X-Scope-OrgID: tenant-foo" -XDELETE http://127.0.0.1:8989/api/v1/exporters/foo
+curl -v -H "Authorization: Bearer $(cat tenant-api-token-dev)" -XDELETE https://MYCLUSTER.opstrace.io/api/v1/exporters/foo
 ```

--- a/go/cmd/config/config_types.go
+++ b/go/cmd/config/config_types.go
@@ -28,6 +28,7 @@ var (
 	}
 	// All supported exporter types, and the credential types that they may be paired with.
 	validExporterCredentials = map[string][]string{
+		"blackbox": {},
 		"cloudwatch":  {"aws-key"},
 		"stackdriver": {"gcp-service-account"},
 	}
@@ -166,7 +167,7 @@ func convertYAMLExporterConfig(exporterName string, exporterConfig interface{}) 
 
 // Validates that a GraphQL JSON exporter type and credential type are valid and compatible.
 func validateExporterTypes(exporterType string, credType *string) error {
-	// Validate exporter type is supported
+	// Validate exporter type is known/supported
 	validCredTypes, ok := validExporterCredentials[exporterType]
 	if !ok {
 		keys := make([]string, len(validExporterCredentials))
@@ -178,6 +179,7 @@ func validateExporterTypes(exporterType string, credType *string) error {
 		return fmt.Errorf("unsupported exporter type %s, expected one of: %s", exporterType, keys)
 	}
 	if credType == nil {
+		// No credential provided with exporter, skip credential lookup
 		return nil
 	}
 

--- a/go/cmd/config/config_types.go
+++ b/go/cmd/config/config_types.go
@@ -28,7 +28,7 @@ var (
 	}
 	// All supported exporter types, and the credential types that they may be paired with.
 	validExporterCredentials = map[string][]string{
-		"blackbox": {},
+		"blackbox":    {},
 		"cloudwatch":  {"aws-key"},
 		"stackdriver": {"gcp-service-account"},
 	}

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -6,6 +6,7 @@
   "cortex": "cortexproject/cortex:v1.8.0-rc.0",
   "cortexApiProxy": "opstrace/cortex-api:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
   "ddApi": "opstrace/ddapi:b3c0c6cb64ad8d38e65e2a576a4f84c3e2d8981b",
+  "exporterBlackbox": "prom/blackbox-exporter:v0.18.0",
   "exporterCloudwatch": "prom/cloudwatch-exporter:cloudwatch_exporter-0.10.0",
   "exporterStackdriver": "prometheuscommunity/stackdriver-exporter:v0.11.0",
   "externalDNS": "k8s.gcr.io/external-dns/external-dns:v0.7.4",

--- a/packages/controller/src/resources/exporters/index.ts
+++ b/packages/controller/src/resources/exporters/index.ts
@@ -48,10 +48,11 @@ type BlackboxConfig = {
   // Probes, each entry in the array is a set of key value pairs to be set as params in the HTTP url.
   // Passed to the prometheus operator as endpoints to monitor.
   // For example {target: "example.com", module: "http_2xx"} -> "/probe?target=example.com&module=http_2xx"
-  probes: object[] | undefined,
+  probes: Record<string, string>[] | undefined,
   // Modules that may be referenced by probes.
   // Passed to the blackbox exporter configuration, or the default configuration is used if this is undefined.
   // For example this may configure an "http_2xx" module to be referenced by the probes.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   modules: any | undefined
 };
 
@@ -71,7 +72,7 @@ const toKubeResources = (
 
   const resources: Array<K8sResource> = [];
   let podSpec: V1PodSpec;
-  const monitorEndpoints: Array<object> = [];
+  const monitorEndpoints: Array<Record<string, unknown>> = [];
   if (exporter.type == "cloudwatch") {
     resources.push(
       new ConfigMap(

--- a/packages/controller/src/resources/exporters/index.ts
+++ b/packages/controller/src/resources/exporters/index.ts
@@ -44,6 +44,17 @@ export function ExporterResources(
   return collection;
 }
 
+type BlackboxConfig = {
+  // Probes, each entry in the array is a set of key value pairs to be set as params in the HTTP url.
+  // Passed to the prometheus operator as endpoints to monitor.
+  // For example {target: "example.com", module: "http_2xx"} -> "/probe?target=example.com&module=http_2xx"
+  probes: object[] | undefined,
+  // Modules that may be referenced by probes.
+  // Passed to the blackbox exporter configuration, or the default configuration is used if this is undefined.
+  // For example this may configure an "http_2xx" module to be referenced by the probes.
+  modules: any | undefined
+};
+
 const toKubeResources = (
   exporter: Exporter,
   kubeConfig: KubeConfig,
@@ -60,6 +71,7 @@ const toKubeResources = (
 
   const resources: Array<K8sResource> = [];
   let podSpec: V1PodSpec;
+  const monitorEndpoints: Array<object> = [];
   if (exporter.type == "cloudwatch") {
     resources.push(
       new ConfigMap(
@@ -85,6 +97,7 @@ const toKubeResources = (
       containers: [{
         name: "exporter",
         image: DockerImages.exporterCloudwatch,
+        // Enable credential env if credential is specified
         env: (exporter.credential)
           ? [{
             name: "AWS_SECRET_ACCESS_KEY",
@@ -100,6 +113,20 @@ const toKubeResources = (
           : [],
         ports: [{ name: "metrics", containerPort: 9106 }],
         volumeMounts: [{ name: "config", mountPath: "/config" }],
+        // Use the 'healthy' endpoint
+        // See https://github.com/prometheus/cloudwatch_exporter/blob/f0e84d6/src/main/java/io/prometheus/cloudwatch/WebServer.java#L43
+        startupProbe: {
+          httpGet: {
+            path: "/-/healthy",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            port: "metrics" as any
+          },
+          failureThreshold: 3,
+          initialDelaySeconds: 10,
+          periodSeconds: 30,
+          successThreshold: 1,
+          timeoutSeconds: 5
+        }
       }],
       volumes: [{
         name: "config",
@@ -108,6 +135,12 @@ const toKubeResources = (
         }
       }]
     };
+
+    monitorEndpoints.push({
+      interval: "30s",
+      port: "metrics",
+      path: "/metrics"
+    });
   } else if (exporter.type == "stackdriver") {
     // We do not support changing the following envvars, because they are part of the integration:
     // - GOOGLE_APPLICATION_CREDENTIALS must be "/credential/secret.json"
@@ -157,8 +190,26 @@ const toKubeResources = (
         image: DockerImages.exporterStackdriver,
         env,
         ports: [{ name: "metrics", containerPort: 9255 }],
-        volumeMounts: [{ name: "credential", mountPath: "/credential" }]
+        // Enable credential mount if credential is specified
+        volumeMounts: (exporter.credential)
+          ? [{ name: "credential", mountPath: "/credential" }]
+          : [],
+        // Use the root path, which just returns a stub HTML page
+        // see https://github.com/prometheus-community/stackdriver_exporter/blob/42badeb/stackdriver_exporter.go#L178
+        startupProbe: {
+          httpGet: {
+            path: "/",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            port: "metrics" as any
+          },
+          failureThreshold: 3,
+          initialDelaySeconds: 10,
+          periodSeconds: 30,
+          successThreshold: 1,
+          timeoutSeconds: 5
+        }
       }],
+      // Enable credential volume if credential is specified
       volumes: (exporter.credential)
         ? [{
           name: "credential",
@@ -168,6 +219,97 @@ const toKubeResources = (
         }]
         : []
     };
+
+    monitorEndpoints.push({
+      interval: "30s",
+      port: "metrics",
+      path: "/metrics"
+    });
+  } else if (exporter.type == "blackbox") {
+    const exporterConfig = JSON.parse(exporter.config) as BlackboxConfig;
+
+    // modules: Override the default exporter module configuration yaml file (optional)
+    if (exporterConfig.modules) {
+      resources.push(
+        new ConfigMap(
+          {
+            apiVersion: "v1",
+            kind: "ConfigMap",
+            // Use name/labels that match the Deployment
+            metadata: {
+              name,
+              namespace,
+              labels
+            },
+            data: {
+              // Convert JSON string to YAML string.
+              // Blackbox exporter expects a root-level 'modules' section.
+              "config.yml": yaml.dump({modules: exporterConfig.modules})
+            }
+          },
+          kubeConfig
+        )
+      );
+    }
+
+    // If modules is defined, configure configmap volume.
+    // Line things up so that the config ends up at the default path of /etc/blackbox_exporter/config.yml
+    podSpec = {
+      containers: [{
+        name: "exporter",
+        image: DockerImages.exporterBlackbox,
+        ports: [{ name: "metrics", containerPort: 9115 }],
+        // Enable configmap mount if modules override is provided
+        volumeMounts: (exporterConfig.modules)
+          ? [{ name: "config", mountPath: "/etc/blackbox_exporter" }]
+          : [],
+        // Use the 'healthy' endpoint
+        // See https://github.com/prometheus/blackbox_exporter/blob/70bce1a/main.go#L312
+        startupProbe: {
+          httpGet: {
+            path: "/-/healthy",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            port: "metrics" as any
+          },
+          failureThreshold: 3,
+          initialDelaySeconds: 10,
+          periodSeconds: 30,
+          successThreshold: 1,
+          timeoutSeconds: 5
+        }
+      }],
+      // Enable configmap mount if modules override is provided
+      volumes: (exporterConfig.modules)
+        ? [{ name: "config", configMap: { name }}]
+        : [],
+    };
+
+    // probes: List of probes to run against exporter modules (required)
+    // We need to configure Prometheus to hit each of the specified probes.
+    // Add the probes to the ServiceMonitor object as HTTP /probe queries
+    if (!exporterConfig.probes) {
+      log.warning(
+        "Skipping deployment of blackbox exporter %s/%s: missing required 'probes' in config",
+        exporter.tenant,
+        exporter.name
+      );
+      return [];
+    }
+    for (const probeIdx in exporterConfig.probes) {
+      // Convert the object values to be arrays to match ServiceMonitor schema:
+      //   {module: "http_2xx", target: "example.com"} => {module: ["http_2xx"], target: ["example.com"]}
+      const params = Object.fromEntries(
+        Object.entries(exporterConfig.probes[probeIdx])
+          .map(([k,v]) => [k, [v]])
+      );
+      monitorEndpoints.push({
+        interval: "30s",
+        port: "metrics",
+        path: "/probe",
+        // HTTP GET params must be provided as separate object field, not as part of path:
+        params
+      });
+    }
   } else {
     log.warning("Exporter %s/%s has unsupported type: %s", exporter.tenant, exporter.name, exporter.type);
     return [];
@@ -244,14 +386,7 @@ const toKubeResources = (
         spec: {
           // Shows up as "job" label in metrics
           jobLabel: exporter.name,
-          endpoints: [
-            {
-              interval: "30s",
-              port: "metrics",
-              // Common default path for both the cloudwatch and stackdriver exporters
-              path: "/metrics"
-            }
-          ],
+          endpoints: monitorEndpoints,
           selector: {
             matchLabels: {
               app: name


### PR DESCRIPTION
Adds a new exporter type for the [blackbox exporter](https://github.com/prometheus/blackbox_exporter/). In practice it's used to check the uptime of things like web pages. This exporter is a little different from most because it serves multiple endpoints to prometheus, and we need to configure prometheus to query those endpoints.

- `modules` (optional): The exporter is configured with `modules` with [a default configuration](https://github.com/prometheus/blackbox_exporter/blob/master/blackbox.yml) if none is provided by the customer. Each module is one of four `prober` types (`http`, `tcp`, `dns`, `icmp`) and has various arguments for how the client should work. For example we may define a `dns_mx` module with `prober: dns` that should check for `MX` email DNS records, and then have another `dns_a` module that checks for `A` ipv4 records.
- `probes` (required): We also need to provide Prometheus with a list of `/probe` endpoints to query against the above `modules`. For example we might have a probe defined as `target: prometheus.io, module: http_2xx` that invokes the `http_2xx` module to query `prometheus.io`.

Example configuration:
```
name: baz
type: blackbox
config:
  probes: # required, list of probes to collect. args match HTTP params
  - target: prometheus.io
    module: http_2xx
  - target: example.com
    module: http_2xx
  - target: 1.1.1.1
    module: dns_opstrace_mx
  - target: 8.8.8.8
    module: dns_opstrace_mx
  modules: # optional, blackbox module configuration to overwrite exporter defaults
    http_2xx:
      prober: http
      timeout: 5s
      http:
        preferred_ip_protocol: "ip4"
    dns_opstrace_mx:
      prober: dns
      timeout: 5s
      dns:
        preferred_ip_protocol: "ip4"
        transport_protocol: tcp
        dns_over_tls: true
        query_name: opstrace.com
        query_type: MX
' | curl -v -H "X-Scope-OrgID: tenant-foo" -XPOST --data-binary @- http://127.0.0.1:8989/api/v1/exporters/
```

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
