### PR TITLE
config: Validate credential/exporter names (#475)

### DIFF
--- a/go/cmd/config/credential_api.go
+++ b/go/cmd/config/credential_api.go
@@ -250,9 +250,13 @@ func (c *credentialAPI) listCredentialTypes(tenant string) (map[string]string, e
 // Accepts the tenant name, the name->type mapping of any existin credentials, and the new credential payload.
 // Returns whether the credential already exists, and any validation error.
 func (c *credentialAPI) validateCredential(existingTypes map[string]string, credential Credential) (bool, error) {
+	// Check that the credential name is suitable for use in K8s object names
+	if err := config.ValidateName(credential.Name); err != nil {
+		return false, err
+	}
+
 	// Check that the credential value is valid JSON
-	err := validateCredentialValue(credential.Name, credential.Type, credential.ValueJSON)
-	if err != nil {
+	if err := validateCredentialValue(credential.Name, credential.Type, credential.ValueJSON); err != nil {
 		return false, err
 	}
 

--- a/go/cmd/config/exporter_api.go
+++ b/go/cmd/config/exporter_api.go
@@ -284,6 +284,11 @@ func (e *exporterAPI) validateExporter(
 	existingTypes map[string]string,
 	exporter Exporter,
 ) (bool, error) {
+	// Check that the exporter name is suitable for use in K8s object names
+	if err := config.ValidateName(exporter.Name); err != nil {
+		return false, err
+	}
+
 	if exporter.Credential == "" {
 		if err := validateExporterTypes(exporter.Type, nil); err != nil {
 			msg := fmt.Sprintf("Invalid exporter input %s: %s", exporter.Name, err)

--- a/go/pkg/config/common.go
+++ b/go/pkg/config/common.go
@@ -1,0 +1,44 @@
+// Copyright 2021 Opstrace, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Maximum length is 63 characters, leave some room in the name for 'credential-' (11 chars) or 'exporter-' (8 chars).
+const maxNameLength = (63 - 11)
+
+// Validate that the name is a valid DNS RFC1123 label, as required by K8s for object names.
+// See also: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+var namePattern = regexp.MustCompile("^[a-z0-9]+(-[a-z0-9]+)*$")
+
+// Check that the provided Credential or Exporter name is safe for the K8s objects that will contain the name.
+func ValidateName(name string) error {
+	if len(name) > maxNameLength {
+		return fmt.Errorf(
+			"name '%s' is %d characters, must be at most %d characters", name, len(name), maxNameLength,
+		)
+	}
+	if !namePattern.Match([]byte(name)) {
+		return fmt.Errorf(
+			"name '%s' is invalid: must contain only lowercase letters, numbers, and '-' (regex: %s)",
+			name,
+			namePattern.String(),
+		)
+	}
+	return nil
+}

--- a/go/pkg/config/common_test.go
+++ b/go/pkg/config/common_test.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Opstrace, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateName_TooLong(t *testing.T) {
+	assert.Error(t, ValidateName("thisisaverylongstring-thisisaverylongstring-thisisave"))
+}
+
+func TestValidateName_StartsWithDash(t *testing.T) {
+	assert.Error(t, ValidateName("-testname123"))
+}
+
+func TestValidateName_EndsWithDash(t *testing.T) {
+	assert.Error(t, ValidateName("testname123-"))
+}
+
+func TestValidateName_Uppercase(t *testing.T) {
+	assert.Error(t, ValidateName("testName123"))
+}
+
+func TestValidateName_Underscore(t *testing.T) {
+	assert.Error(t, ValidateName("test_name123"))
+}
+
+func TestValidateName_Period(t *testing.T) {
+	assert.Error(t, ValidateName("test.name123"))
+}
+
+func TestValidateName_ExclamationMark(t *testing.T) {
+	assert.Error(t, ValidateName("test!name123"))
+}
+
+func TestValidateName_Valid(t *testing.T) {
+	assert.Nil(t, ValidateName("testname"))
+	assert.Nil(t, ValidateName("123test-name123"))
+	assert.Nil(t, ValidateName("test-name123"))
+	assert.Nil(t, ValidateName("testname"))
+	assert.Nil(t, ValidateName("thisisaverylongstring-thisisaverylongstring-thisisav"))
+}


### PR DESCRIPTION
Ensure that they are safe to use in the names of K8s Secrets/Deployments/etc

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
