### PR TITLE
chore: fix missing return statement

### DIFF
--- a/packages/installer/src/certificates.ts
+++ b/packages/installer/src/certificates.ts
@@ -38,7 +38,7 @@ export function handleFailedCertificate(
   log.debug("checking if certificate is in failed state");
 
   const cert = certificates.find(cert => {
-    cert.spec.status?.conditions?.find(cond => {
+    return cert.spec.status?.conditions?.find(cond => {
       log.debug(`certificate condition: ${cond.message}`);
       return cond.message!.includes("Failed to wait for order resource");
     });


### PR DESCRIPTION
#557 had a bug when checking if the certificate failed or not. 

[Typescript playground](https://www.typescriptlang.org/play?#code/FAFwngDgpgBAwgewHYBMYG9g2zAtlAZwIEMBzKALhgJACcBLJUmAHxgFdUoAzRqFANzAAvsFCRYcKLRAYsOJMXxUaDJvOwBjZCnoh6yAlUSoA2gF1WHLryT8RY7UhoxN0-b03EQhY+4swALwwphoYisowAEQARlEANK46egbOVKbo+ERklDAABjGFecLmwvFh6BG5UcQJSagphumZhCTkVHkAKgAWsG4y9J7esLRQAI7shLLdxAQw3MT0ADb8MCAISbgQKz4wxKgwAO7LSzAxI1B09PxUAGKLK2jrR4uy3Ai0MB8o0jCjBAh2LQ3NFuiAQBACABafogKEAaxiADYxrgoUiACwADgAnAAGAk4gCsUTWG3O2nwfygxBQYCo31+9DmjGijAAbsQlvQUKSaMMKMVSsBzEJgDtXO4gpKBkMfAQAHS2FAAClhQQAfHIcNSQECkDKQAqnLp9IYAPxKxiqk2a7U6nCjPW0A0mhVZNpQS2MTRLdg-AgqqL3ZarZ6HV7zD5fWg-T7-QHAqBRACUQh1wjTIizwEGMDVUsCResP1s-BT9q0hgQKwVSwQpCDuhQSAA5LJDh94amRDAoEsCLBMDqnADa-XG1F3pw0Ho6rCFVUUw4gA) where I tested this change.