### PR TITLE
test-remote: Implement exporter tests for each exporter type.

### DIFF
--- a/go/cmd/config/credential_api.go
+++ b/go/cmd/config/credential_api.go
@@ -71,15 +71,20 @@ func (c *credentialAPI) listCredentials(tenant string, w http.ResponseWriter, r 
 
 	log.Debugf("Listing %d credentials", len(resp.Credential))
 
-	encoder := yaml.NewEncoder(w)
-	for _, credential := range resp.Credential {
-		encoder.Encode(CredentialInfo{
+	// Create list payload to respond with.
+	// Avoid passing entries individually to encoder since that won't consistently produce a list.
+	entries := make([]CredentialInfo, len(resp.Credential))
+	for i, credential := range resp.Credential {
+		entries[i] = CredentialInfo{
 			Name:      credential.Name,
 			Type:      credential.Type,
 			CreatedAt: credential.CreatedAt,
 			UpdatedAt: credential.UpdatedAt,
-		})
+		}
 	}
+
+	encoder := yaml.NewEncoder(w)
+	encoder.Encode(entries)
 }
 
 func (c *credentialAPI) writeCredentials(tenant string, w http.ResponseWriter, r *http.Request) {

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -2,7 +2,7 @@
   "addonResizer": "k8s.gcr.io/addon-resizer:1.8.4",
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.2.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
-  "configApi": "opstrace/config-api:50089147b3fbf267a7c7d74990aa2c494c06498e",
+  "configApi": "opstrace/config-api:8ddb7fb6bf5395c184862356e225a0db803af7f3",
   "cortex": "cortexproject/cortex:master-d302dc4",
   "cortexApiProxy": "opstrace/cortex-api:50089147b3fbf267a7c7d74990aa2c494c06498e",
   "ddApi": "opstrace/ddapi:50089147b3fbf267a7c7d74990aa2c494c06498e",

--- a/packages/controller/src/resources/exporters/index.ts
+++ b/packages/controller/src/resources/exporters/index.ts
@@ -303,12 +303,22 @@ const toKubeResources = (
         Object.entries(exporterConfig.probes[probeIdx])
           .map(([k,v]) => [k, [v]])
       );
+      // Ensure that the per-probe metrics are each labeled with the probe info: module and target normally
+      const relabelings = Object.entries(exporterConfig.probes[probeIdx])
+        .map(([k, v]) => ({
+          // Prometheus label hack: Pick an arbitrary label that should exist in the metric.
+          // This value is ignored and results in inserting a new label.
+          sourceLabels: ["job"],
+          targetLabel: k,
+          replacement: v,
+        }));
       monitorEndpoints.push({
         interval: "30s",
         port: "metrics",
         path: "/probe",
         // HTTP GET params must be provided as separate object field, not as part of path:
-        params
+        params,
+        relabelings,
       });
     }
   } else {

--- a/test/test-remote/test_alerts.ts
+++ b/test/test-remote/test_alerts.ts
@@ -299,8 +299,7 @@ async function getE2EAlertCountMetric(cortexBaseUrl: string, uniqueScrapeJobName
     cortexBaseUrl,
     queryParams,
     "query",
-    30, // timeout
-    true // logQueryResponse
+    30 // timeout
   );
 
   // Sanity check: label should match

--- a/test/test-remote/test_alerts.ts
+++ b/test/test-remote/test_alerts.ts
@@ -61,11 +61,10 @@ import {
   logHTTPResponse,
   mtime,
   mtimeDeadlineInSeconds,
-  queryJSONAPI,
   rndstring,
   sleep,
   waitForCortexMetricResult,
-  waitForQueryResult,
+  waitForPrometheusTarget,
   CLUSTER_BASE_URL,
   CORTEX_API_TLS_VERIFY,
   TENANT_DEFAULT_API_TOKEN_FILEPATH,
@@ -73,8 +72,6 @@ import {
   TENANT_SYSTEM_API_TOKEN_FILEPATH,
   TENANT_SYSTEM_CORTEX_API_BASE_URL,
 } from "./testutils";
-
-import { PortForward } from "./testutils/portforward";
 
 function getE2EAlertingResources(tenant: string, job: string): Array<K8sResource> {
   // The test environment should already have kubectl working, so we can use that.
@@ -292,14 +289,14 @@ async function deleteE2EAlertsConfig(authTokenFilepath: string | undefined, rule
   assert(ruleGroupDeleteResponse.statusCode == 202 || ruleGroupDeleteResponse.statusCode == 404)
 }
 
-async function getE2EAlertCountMetric(baseUrl: string, uniqueScrapeJobName: string): Promise<string> {
+async function getE2EAlertCountMetric(cortexBaseUrl: string, uniqueScrapeJobName: string): Promise<string> {
   // Instant query - get current value
   // https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
   const queryParams = {
     query: `e2ealerting_webhook_receiver_evaluations_total{job="${uniqueScrapeJobName}"}`,
   };
   const resultArray = await waitForCortexMetricResult(
-    baseUrl,
+    cortexBaseUrl,
     queryParams,
     "query",
     30, // timeout
@@ -316,60 +313,6 @@ async function getE2EAlertCountMetric(baseUrl: string, uniqueScrapeJobName: stri
   const value = resultArray[0]["value"][1];
   log.info(`Got alert count value: ${value}`, value);
   return value;
-}
-
-// Queries Prometheus scrape targets and waits for one or more targets with a matching job label to appear
-export async function waitForPrometheusTarget(
-  tenant: string,
-  jobLabel: string,
-  maxWaitSeconds: number,
-) {
-  const portForwardProm = new PortForward(
-    `tenant-prometheus-${tenant}`, // name (arbitrary/logging)
-    `statefulsets/prometheus-${tenant}-prometheus`, // k8sobj
-    9091, // port_local
-    9090, // port_remote
-    `${tenant}-tenant`, // namespace
-  );
-  await portForwardProm.setup();
-
-  try {
-    const url = `http://127.0.0.1:9091/prometheus/api/v1/targets`;
-    const qparms = new URLSearchParams({state: "active"});
-
-    log.info(`Querying prometheus via port-forward: ${url}`)
-    await waitForQueryResult(
-      () => queryJSONAPI(url, qparms),
-      (data) => {
-        // Example data: https://prometheus.io/docs/prometheus/latest/querying/api/#targets
-        // Search for target(s) with matching job label
-        const targets: Array<any> = data["data"]["activeTargets"];
-        const filtered = targets.filter(target => target["labels"]["job"] === jobLabel);
-        if (filtered.length == 0) {
-          log.info(
-            "No targets with job=%s, instead got: %s",
-            jobLabel,
-            targets
-              .map(t => `${t["labels"]["job"]}:${t["labels"]["namespace"]}/${t["labels"]["pod"]}`)
-              .sort()
-          );
-          return null;
-        }
-        log.info(
-          "Found tenant prometheus scrape targets for job=%s: %s",
-          jobLabel,
-          filtered
-            .map(t => `${t["labels"]["job"]}:${t["labels"]["namespace"]}/${t["labels"]["pod"]}`)
-            .sort()
-        );
-        return filtered;
-      },
-      maxWaitSeconds,
-      false, // This is VERY long for system tenant, so don't log
-    );
-  } finally {
-    await portForwardProm.terminate();
-  }
 }
 
 async function testE2EAlertsForTenant(cortexBaseUrl: string, authTokenFilepath: string | undefined, tenant: string) {
@@ -413,9 +356,7 @@ async function testE2EAlertsForTenant(cortexBaseUrl: string, authTokenFilepath: 
 
   // Wait for the E2E pod to appear in prometheus scrape targets
   log.info(`Waiting for E2E scrape target to appear in tenant prometheus for tenant=${tenant} job=${uniqueScrapeJobName}`);
-  // Use a long timeout when waiting for prometheus scraper to see the pod.
-  // Normally takes 5-15s, but can take longer than 30s
-  await waitForPrometheusTarget(tenant, uniqueScrapeJobName, 300);
+  await waitForPrometheusTarget(tenant, uniqueScrapeJobName);
 
   // Wait for the metric to appear in cortex with the matching random 'job' tag
   log.info(`Waiting for cortex E2E alerting metric for tenant=${tenant} job=${uniqueScrapeJobName} with zero value`);

--- a/test/test-remote/test_exporters.ts
+++ b/test/test-remote/test_exporters.ts
@@ -101,7 +101,7 @@ async function getExporterMetric(cortexBaseUrl: string, metricQuery: string): Pr
     cortexBaseUrl,
     queryParams,
     "query",
-    30, // timeout
+    300, // timeout, use longer since stackdriver can take a while to try its first scrape
     true // logQueryResponse
   );
 
@@ -238,6 +238,7 @@ value: |-
 `;
 
     const jobName = `exporter-${exporterName}`;
+    // this metric can take >30s to appear:
     const metricQuery = `stackdriver_monitoring_scrape_errors_total{job="${jobName}"}`;
 
     await testExporter(

--- a/test/test-remote/test_exporters.ts
+++ b/test/test-remote/test_exporters.ts
@@ -101,8 +101,7 @@ async function getExporterMetric(cortexBaseUrl: string, metricQuery: string): Pr
     cortexBaseUrl,
     queryParams,
     "query",
-    300, // timeout, use longer since stackdriver can take a while to try its first scrape
-    true // logQueryResponse
+    300 // normally <10s, but needs to be longer because stackdriver exporter can be slow to perform first scrape
   );
 
   return resultArray[0]["value"][1];
@@ -219,8 +218,7 @@ config:
   - compute.googleapis.com/instance/cpu
   - compute.googleapis.com/instance/disk
   google.project-id:
-  - vast-pad-240918
-  - proj2
+  - phony-project-12345
   monitoring.metrics-interval: '5m'
   monitoring.metrics-offset: '0s'
 `;

--- a/test/test-remote/test_exporters.ts
+++ b/test/test-remote/test_exporters.ts
@@ -1,0 +1,318 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Deploys exporter instances and checks that their metrics appear in Cortex.
+// Cloud exporters are currently just configured with bogus credentials,
+// where we just check that their respective 'auth failed' metric is incremented.
+
+import { strict as assert } from "assert";
+
+import got from "got";
+import * as yamlParser from "js-yaml";
+
+import {
+  enrichHeadersWithAuthTokenFile,
+  globalTestSuiteSetupOnce,
+  httpTimeoutSettings,
+  log,
+  logHTTPResponse,
+  rndstring,
+  waitForCortexMetricResult,
+  waitForPrometheusTarget,
+  CLUSTER_BASE_URL,
+  CORTEX_API_TLS_VERIFY,
+  TENANT_DEFAULT_API_TOKEN_FILEPATH,
+  TENANT_DEFAULT_CORTEX_API_BASE_URL,
+  TENANT_SYSTEM_API_TOKEN_FILEPATH,
+  TENANT_SYSTEM_CORTEX_API_BASE_URL,
+} from "./testutils";
+
+async function listConfigNames(authTokenFilepath: string | undefined, urlSuffix: string): Promise<string[]> {
+  const getResponse = await got.get(
+    `${CLUSTER_BASE_URL}/api/v1/${urlSuffix}`,
+    {
+      throwHttpErrors: false,
+      timeout: httpTimeoutSettings,
+      headers: enrichHeadersWithAuthTokenFile(authTokenFilepath, {}),
+      https: { rejectUnauthorized: CORTEX_API_TLS_VERIFY }
+    }
+  );
+  logHTTPResponse(getResponse);
+  assert(getResponse.statusCode == 200);
+  const body: Record<string, string>[] = yamlParser.load(getResponse.body);
+  return body.map(entry => entry["name"]);
+}
+
+async function storeConfig(authTokenFilepath: string | undefined, urlSuffix: string, config: string) {
+  const postResponse = await got.post(
+    `${CLUSTER_BASE_URL}/api/v1/${urlSuffix}`,
+    {
+      body: config,
+      throwHttpErrors: false,
+      timeout: httpTimeoutSettings,
+      headers: enrichHeadersWithAuthTokenFile(authTokenFilepath, {}),
+      https: { rejectUnauthorized: CORTEX_API_TLS_VERIFY }
+    }
+  );
+  logHTTPResponse(postResponse);
+  assert(postResponse.statusCode == 200);
+}
+
+async function deleteAllConfigs(authTokenFilepath: string | undefined, urlSuffix: string) {
+  for (const name of await listConfigNames(authTokenFilepath, urlSuffix)) {
+    await deleteConfig(authTokenFilepath, urlSuffix, name);
+  }
+}
+
+async function deleteConfig(authTokenFilepath: string | undefined, urlSuffix: string, name: string) {
+  const deleteResponse = await got.delete(
+    `${CLUSTER_BASE_URL}/api/v1/${urlSuffix}/${name}`,
+    {
+      throwHttpErrors: false,
+      timeout: httpTimeoutSettings,
+      headers: enrichHeadersWithAuthTokenFile(authTokenFilepath, {}),
+      https: { rejectUnauthorized: CORTEX_API_TLS_VERIFY }
+    }
+  );
+  logHTTPResponse(deleteResponse);
+  assert(deleteResponse.statusCode == 200);
+}
+
+async function getExporterMetric(cortexBaseUrl: string, metricQuery: string): Promise<string> {
+  // Instant query - get current value
+  // https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+  const queryParams = {
+    query: metricQuery,
+  };
+  const resultArray = await waitForCortexMetricResult(
+    cortexBaseUrl,
+    queryParams,
+    "query",
+    30, // timeout
+    true // logQueryResponse
+  );
+
+  return resultArray[0]["value"][1];
+}
+
+async function testExporter(
+  tenant: string,
+  cortexBaseUrl: string,
+  authTokenFilepath: string | undefined,
+  jobName: string,
+  exporterConfig: string,
+  credentialContent: string | null,
+  expectedMetricQuery: string
+) {
+  log.info("Deleting any preexisting exporters/credentials");
+  await deleteAllConfigs(authTokenFilepath, "exporters");
+  await deleteAllConfigs(authTokenFilepath, "credentials");
+
+  if (credentialContent != null) {
+    await storeConfig(authTokenFilepath, "credentials", credentialContent);
+  }
+  await storeConfig(authTokenFilepath, "exporters", exporterConfig);
+
+  log.info(`Waiting for exporter scrape target to appear in tenant prometheus for tenant=${tenant} job=${jobName}`);
+  await waitForPrometheusTarget(tenant, jobName);
+
+  log.info(`Waiting for metric=${expectedMetricQuery}`);
+  const value = await getExporterMetric(cortexBaseUrl, expectedMetricQuery);
+  log.info(`Got value for metric=${expectedMetricQuery}: ${value}`);
+
+  log.info("Deleting exporters/credentials");
+  await deleteAllConfigs(authTokenFilepath, "exporters");
+  await deleteAllConfigs(authTokenFilepath, "credentials");
+}
+
+function getExporterName(type: string) {
+  return `testexporters-${rndstring().slice(0, 5).toLowerCase().replace('_', '0')}-${type}`;
+}
+
+suite("Metric exporter tests", function () {
+  suiteSetup(async function () {
+    log.info("suite setup");
+    globalTestSuiteSetupOnce();
+  });
+
+  suiteTeardown(async function () {
+    log.info("suite teardown");
+  });
+
+  test("Cloudwatch exporter", async function () {
+    const exporterName = getExporterName("cloudwatch");
+    const exporterConfig = `
+name: ${exporterName}
+type: cloudwatch
+credential: ${exporterName}
+# nested yaml payload defined by cloudwatch exporter:
+config:
+  region: us-west-2
+  metrics:
+  - aws_namespace: Buildkite
+    aws_metric_name: ScheduledJobsCount
+    aws_dimensions: [Org, Queue]
+    aws_statistics: [Sum]
+  - aws_namespace: Buildkite
+    aws_metric_name: RunningJobsCount
+    aws_dimensions: [Org, Queue]
+    aws_statistics: [Sum]
+  - aws_namespace: Buildkite
+    aws_metric_name: WaitingJobsCount
+    aws_dimensions: [Org, Queue]
+    aws_statistics: [Sum]
+`;
+    // Bogus credential value. Just check for an "auth failed" metric.
+    const exporterCred = `
+name: ${exporterName}
+type: aws-key
+value:
+  AWS_ACCESS_KEY_ID: foo
+  AWS_SECRET_ACCESS_KEY: bar
+`;
+
+    const jobName = `exporter-${exporterName}`;
+    const metricQuery = `cloudwatch_exporter_scrape_error{job="${jobName}"}`;
+
+    await testExporter(
+      "default",
+      TENANT_DEFAULT_CORTEX_API_BASE_URL,
+      TENANT_DEFAULT_API_TOKEN_FILEPATH,
+      jobName,
+      exporterConfig,
+      exporterCred,
+      metricQuery
+    );
+    await testExporter(
+      "system",
+      TENANT_SYSTEM_CORTEX_API_BASE_URL,
+      TENANT_SYSTEM_API_TOKEN_FILEPATH,
+      jobName,
+      exporterConfig,
+      exporterCred,
+      metricQuery
+    );
+  });
+
+
+  test("Stackdriver exporter", async function () {
+    const exporterName = getExporterName("stackdriver");
+    const exporterConfig = `
+name: ${exporterName}
+type: stackdriver
+credential: ${exporterName}
+config:
+  monitoring.metrics-type-prefixes:
+  - compute.googleapis.com/instance/cpu
+  - compute.googleapis.com/instance/disk
+  google.project-id:
+  - vast-pad-240918
+  - proj2
+  monitoring.metrics-interval: '5m'
+  monitoring.metrics-offset: '0s'
+`;
+    // Bogus credential value. Just check for an "auth failed" metric.
+    const exporterCred = `
+name: ${exporterName}
+type: gcp-service-account
+value: |-
+  {
+    "type": "service_account",
+    "project_id": "phony-project-12345",
+    "private_key_id": "phony_id",
+    "private_key": "phony_key"
+  }
+`;
+
+    const jobName = `exporter-${exporterName}`;
+    const metricQuery = `stackdriver_monitoring_scrape_errors_total{job="${jobName}"}`;
+
+    await testExporter(
+      "default",
+      TENANT_DEFAULT_CORTEX_API_BASE_URL,
+      TENANT_DEFAULT_API_TOKEN_FILEPATH,
+      jobName,
+      exporterConfig,
+      exporterCred,
+      metricQuery
+    );
+    await testExporter(
+      "system",
+      TENANT_SYSTEM_CORTEX_API_BASE_URL,
+      TENANT_SYSTEM_API_TOKEN_FILEPATH,
+      jobName,
+      exporterConfig,
+      exporterCred,
+      metricQuery
+    );
+  });
+
+
+  test("Blackbox exporter", async function () {
+    const exporterName = getExporterName("blackbox");
+    const exporterConfig = `
+name: ${exporterName}
+type: blackbox
+config:
+  probes:
+  - target: prometheus.io
+    module: http_2xx
+  - target: example.com
+    module: http_2xx
+  - target: 1.1.1.1
+    module: dns_opstrace_mx
+  - target: 8.8.8.8
+    module: dns_opstrace_mx
+  modules:
+    http_2xx:
+      prober: http
+      timeout: 5s
+      http:
+        preferred_ip_protocol: "ip4"
+    dns_opstrace_mx:
+      prober: dns
+      timeout: 5s
+      dns:
+        preferred_ip_protocol: "ip4"
+        transport_protocol: tcp
+        dns_over_tls: true
+        query_name: opstrace.com
+        query_type: MX
+`;
+    const jobName = `exporter-${exporterName}`;
+    // The probe metrics should be labeled with module and target params:
+    const metricQuery = `probe_success{job="${jobName}",module="http_2xx",target="example.com"}`;
+
+    await testExporter(
+      "default",
+      TENANT_DEFAULT_CORTEX_API_BASE_URL,
+      TENANT_DEFAULT_API_TOKEN_FILEPATH,
+      jobName,
+      exporterConfig,
+      null,
+      metricQuery
+    );
+    await testExporter(
+      "system",
+      TENANT_SYSTEM_CORTEX_API_BASE_URL,
+      TENANT_SYSTEM_API_TOKEN_FILEPATH,
+      jobName,
+      exporterConfig,
+      null,
+      metricQuery
+    );
+  });
+});

--- a/test/test-remote/testutils/index.ts
+++ b/test/test-remote/testutils/index.ts
@@ -983,14 +983,13 @@ export async function waitForPrometheusTarget(
   const portForwardProm = new PortForward(
     `tenant-prometheus-${tenant}`, // name (arbitrary/logging)
     `statefulsets/prometheus-${tenant}-prometheus`, // k8sobj
-    9091, // port_local
     9090, // port_remote
     `${tenant}-tenant`, // namespace
   );
-  await portForwardProm.setup();
+  const localPort = await portForwardProm.setup();
 
   try {
-    const url = `http://127.0.0.1:9091/prometheus/api/v1/targets`;
+    const url = `http://127.0.0.1:${localPort}/prometheus/api/v1/targets`;
     const qparms = new URLSearchParams({state: "active"});
 
     log.info(`Querying prometheus via port-forward: ${url}`)

--- a/test/test-remote/testutils/index.ts
+++ b/test/test-remote/testutils/index.ts
@@ -992,7 +992,7 @@ export async function waitForPrometheusTarget(
     const url = `http://127.0.0.1:${localPort}/prometheus/api/v1/targets`;
     const qparms = new URLSearchParams({state: "active"});
 
-    log.info(`Querying prometheus via port-forward: ${url}`)
+    log.info(`Waiting for target with tenant=${tenant} job=${jobLabel} via port-forward: ${url}`)
     await waitForQueryResult(
       () => queryJSONAPI(url, qparms),
       (data) => {
@@ -1001,13 +1001,7 @@ export async function waitForPrometheusTarget(
         const targets: Array<any> = data["data"]["activeTargets"];
         const filtered = targets.filter(target => target["labels"]["job"] === jobLabel);
         if (filtered.length == 0) {
-          log.info(
-            "No targets with job=%s, instead got: %s",
-            jobLabel,
-            targets
-              .map(t => `${t["labels"]["job"]}:${t["labels"]["namespace"]}/${t["labels"]["pod"]}`)
-              .sort()
-          );
+          // Not found yet
           return null;
         }
         log.info(

--- a/test/test-remote/testutils/portforward.ts
+++ b/test/test-remote/testutils/portforward.ts
@@ -27,6 +27,8 @@ import {
   readFirstNBytes
 } from "./index";
 
+const PORT_FORWARD_LISTEN_PATTERN = /^Forwarding from 127\.0\.0\.1:(\d+) -> \d+/g;
+
 export class PortForward {
   /*
   Represents a local port-forward to a service running a in K8S cluster,
@@ -54,24 +56,17 @@ export class PortForward {
   private processStartupError: Error | null;
   // To be populated by the "exit" event emitter of the child process.
   private processExitCode: number | null;
-  public port_local: number;
 
   constructor(
     name: string,
     k8sobj: string,
-    port_local: number,
     port_remote: number,
     namespace: string
   ) {
     /*
     name: arbitrary name for this port-foward, used in log and output filename.
-
     k8sobj: the TYPE/NAME in the cmdline signature for kubectl
-
-    port_local: local port
-
     port_remote: remote port
-
     namespace: passed as --namespace <namespace> to kubectl
     */
 
@@ -82,14 +77,16 @@ export class PortForward {
       "--namespace",
       namespace,
       k8sobj,
-      port_local + ":" + port_remote
+      // local port 0: Select a random ephemeral port on each invocation.
+      // This avoids collisions with other parallel test runs or other services on the same machine.
+      // kubectl will print the local ephemeral port that it has selected and we will return it to the caller.
+      `0:${port_remote}`
     ];
 
     this.outfilePath = createTempfile("kubectl-port-forward-", ".outerr");
 
     this.kubectlCmd = "kubectl " + this.kubectlArgs.join(" ");
 
-    this.port_local = port_local;
     this.processStartupError = null;
     this.processExitCode = null;
     this.process = null;
@@ -143,11 +140,9 @@ export class PortForward {
     this.process = process;
   }
 
-  public baseUrl() {
-    return `http://127.0.0.1:${this.port_local}`;
-  }
-
-  public async setup() {
+  // Starts the port forward and returns the local port number to connect to.
+  // If the port forward fails, an error is thrown.
+  public async setup(): Promise<number> {
     /*
     Wait for the port-forward setup to become ready.
 
@@ -197,15 +192,12 @@ export class PortForward {
         break;
       }
 
-      // Success criterion: stdout haystack contains needle.
-      const fileHeadBytes = await readFirstNBytes(this.outfilePath, 100);
-      if (fileHeadBytes.includes(Buffer.from("Forwarding from", "utf-8"))) {
-        // here we might want to replace the current process "exit" event
-        // handler with one that informs about the child having gone away
-        // unexpectedly after successful port-forward establishment, should
-        // then also log stdout.err as well and exit code.
-        log.info(`${this}: ready\n${fileHeadBytes}`);
-        return true;
+      // Wait for kubectl to print the ephemeral ipv4 port
+      const kubectlOut = new TextDecoder("utf-8").decode(await readFirstNBytes(this.outfilePath, 100));
+      const regexResult = PORT_FORWARD_LISTEN_PATTERN.exec(kubectlOut)
+      if (regexResult != null && regexResult.length > 1) {
+        log.info(`${this}: port-forward listening on port ${regexResult[1]}`);
+        return parseInt(regexResult[1], 10);
       }
       await sleep(0.1);
     }
@@ -238,8 +230,9 @@ export class PortForward {
       await this.terminate();
     }
 
-    if (this.processExitCode)
+    if (this.processExitCode) {
       log.info("%s: child process exit code: %s", this, this.processExitCode);
+    }
 
     // Not documented, but this performs a surrogate escape if necessary, see
     // https://github.com/nodejs/node/pull/30706


### PR DESCRIPTION
Across default+system tenants x cloudwatch+stackdriver+blackbox types: Configures the exporter using the `/api/` endpoint, then waits for the exporter to appear as a scrape target in tenant prometheus, then waits for a sample metric to appear in Cortex.

Cloud exporters are run with invalid/stub credentials, where we just check that debug metrics are getting through.

Also fixes:
- Update credential/exporter API list responses to consistently return list format when there are zero or one entries. (`GET /api/v1/credentials` and `GET /api/v1/exporters`)
- Insert per-probe module/target labels into blackbox exporter metrics, so that probes can be distinguished from one another.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
