### PR TITLE
fix: handle auto scaling group upgrade without recent activity

### DIFF
--- a/lib/aws/src/autoScalingGroup.ts
+++ b/lib/aws/src/autoScalingGroup.ts
@@ -124,6 +124,12 @@ class ASGRes extends AWSResource<
     );
 
     const scalingacts: AutoScaling.Activities = await this.getScalingActivities();
+
+    if ((scalingacts.length === 0) && (instanceCount === this.expectedInstanceCount)) {
+      log.info("%s setup: nothing to do, no scaling activities seen recently and already at desired capacity", this.rname);
+      return asg;
+    }
+
     if (scalingacts.length === 0) {
       log.info("%s setup: no scaling activities seen yet", this.rname);
       return false;


### PR DESCRIPTION
Close #564 

I checked [Terraform code](https://github.com/hashicorp/terraform-provider-aws/blob/068ebd8bb5a703e92342ba69406746c993444033/aws/resource_aws_autoscaling_group_waiting.go#L22) to see how they handle this scenario. They [compare state](https://github.com/hashicorp/terraform-provider-aws/blob/068ebd8bb5a703e92342ba69406746c993444033/aws/resource_aws_autoscaling_group.go#L1057-L1060) using their internal data structures instead of relying on cloud provider state. This way they only trigger an AutoScaling group update if there are any desired changes.

I ended up settling on exit if the AutoScaling group activities are empty but the instance count is at the desired capacity. 