### PR TITLE
test-remote: Add test for azure exporter (#556)

### DIFF
--- a/test/test-remote/test_alerts.ts
+++ b/test/test-remote/test_alerts.ts
@@ -63,8 +63,6 @@ import {
   mtimeDeadlineInSeconds,
   rndstring,
   sleep,
-  waitForCortexMetricResult,
-  waitForPrometheusTarget,
   CLUSTER_BASE_URL,
   CORTEX_API_TLS_VERIFY,
   TENANT_DEFAULT_API_TOKEN_FILEPATH,
@@ -72,6 +70,11 @@ import {
   TENANT_SYSTEM_API_TOKEN_FILEPATH,
   TENANT_SYSTEM_CORTEX_API_BASE_URL,
 } from "./testutils";
+
+import {
+  waitForCortexMetricResult,
+  waitForPrometheusTarget,
+} from "./testutils/metrics";
 
 function getE2EAlertingResources(tenant: string, job: string): Array<K8sResource> {
   // The test environment should already have kubectl working, so we can use that.

--- a/test/test-remote/test_dd.ts
+++ b/test/test-remote/test_dd.ts
@@ -33,11 +33,12 @@ import {
   readFirstNBytes,
   rndstring,
   sleep,
-  waitForCortexMetricResult,
   TENANT_DEFAULT_API_TOKEN_FILEPATH,
   TENANT_DEFAULT_CORTEX_API_BASE_URL,
   TENANT_DEFAULT_DD_API_BASE_URL,
 } from "./testutils";
+
+import { waitForCortexMetricResult } from "./testutils/metrics";
 
 function ddApiSeriesUrl() {
   let url = `${TENANT_DEFAULT_DD_API_BASE_URL}/api/v1/series`;

--- a/test/test-remote/test_exporters.ts
+++ b/test/test-remote/test_exporters.ts
@@ -19,6 +19,7 @@
 // where we just check that their respective 'auth failed' metric is incremented.
 
 import { strict as assert } from "assert";
+import { ZonedDateTime } from "@js-joda/core";
 
 import got from "got";
 import * as yamlParser from "js-yaml";
@@ -30,15 +31,25 @@ import {
   log,
   logHTTPResponse,
   rndstring,
-  waitForCortexMetricResult,
-  waitForPrometheusTarget,
+  timestampToNanoSinceEpoch,
   CLUSTER_BASE_URL,
   CORTEX_API_TLS_VERIFY,
   TENANT_DEFAULT_API_TOKEN_FILEPATH,
   TENANT_DEFAULT_CORTEX_API_BASE_URL,
   TENANT_SYSTEM_API_TOKEN_FILEPATH,
   TENANT_SYSTEM_CORTEX_API_BASE_URL,
+  TENANT_SYSTEM_LOKI_API_BASE_URL,
 } from "./testutils";
+
+import {
+  waitForCortexMetricResult,
+  waitForPrometheusTarget,
+} from "./testutils/metrics";
+
+import {
+  waitForLokiQueryResult,
+  LokiQueryResult,
+} from "./testutils/logs";
 
 async function listConfigNames(authTokenFilepath: string | undefined, urlSuffix: string): Promise<string[]> {
   const getResponse = await got.get(
@@ -91,11 +102,30 @@ async function deleteConfig(authTokenFilepath: string | undefined, urlSuffix: st
   assert(deleteResponse.statusCode == 200);
 }
 
-async function getExporterMetric(cortexBaseUrl: string, metricQuery: string): Promise<string> {
+async function setupExporter(
+  authTokenFilepath: string | undefined,
+  exporterConfig: string,
+  credentialContent: string | null,
+) {
+  if (credentialContent != null) {
+    await storeConfig(authTokenFilepath, "credentials", credentialContent);
+  }
+  await storeConfig(authTokenFilepath, "exporters", exporterConfig);
+}
+
+async function cleanExporter(authTokenFilepath: string | undefined) {
+  log.info("Deleting exporters/credentials");
+  await deleteAllConfigs(authTokenFilepath, "exporters");
+  await deleteAllConfigs(authTokenFilepath, "credentials");
+}
+
+async function getExporterMetric(cortexBaseUrl: string, query: string): Promise<string> {
+  log.info(`Waiting for exporter metric: ${query}`);
+
   // Instant query - get current value
   // https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
   const queryParams = {
-    query: metricQuery,
+    query,
   };
   const resultArray = await waitForCortexMetricResult(
     cortexBaseUrl,
@@ -104,10 +134,36 @@ async function getExporterMetric(cortexBaseUrl: string, metricQuery: string): Pr
     300 // normally <10s, but needs to be longer because stackdriver exporter can be slow to perform first scrape
   );
 
-  return resultArray[0]["value"][1];
+  const value = resultArray[0]["value"][1];
+  log.info(`Got exporter metric for query=${query}: ${value}`);
+  return value;
 }
 
-async function testExporter(
+async function getExporterLog(exporterNamespace: string, exporterName: string, logMessage: string): Promise<LokiQueryResult> {
+  const query = `{k8s_namespace_name="${exporterNamespace}",k8s_container_name="exporter",k8s_pod_name=~"exporter-${exporterName}-.+"} |= "${logMessage}"`;
+  log.info(`Waiting for exporter log: ${query}`);
+
+  const ts = ZonedDateTime.now();
+  const queryParams = {
+    query,
+    direction: "BACKWARD",
+    limit: "10",
+    start: timestampToNanoSinceEpoch(ts.minusHours(1)),
+    end: timestampToNanoSinceEpoch(ts.plusHours(1))
+  };
+
+  const entries = await waitForLokiQueryResult(
+    TENANT_SYSTEM_LOKI_API_BASE_URL,
+    queryParams,
+    undefined,
+    false,
+    0
+  );
+  log.info(`Got exporter log for query=${query}: ${entries}`);
+  return entries;
+}
+
+async function testExporterMetric(
   tenant: string,
   cortexBaseUrl: string,
   authTokenFilepath: string | undefined,
@@ -116,25 +172,27 @@ async function testExporter(
   credentialContent: string | null,
   expectedMetricQuery: string
 ) {
-  log.info("Deleting any preexisting exporters/credentials");
-  await deleteAllConfigs(authTokenFilepath, "exporters");
-  await deleteAllConfigs(authTokenFilepath, "credentials");
+  await setupExporter(authTokenFilepath, exporterConfig, credentialContent);
 
-  if (credentialContent != null) {
-    await storeConfig(authTokenFilepath, "credentials", credentialContent);
-  }
-  await storeConfig(authTokenFilepath, "exporters", exporterConfig);
-
-  log.info(`Waiting for exporter scrape target to appear in tenant prometheus for tenant=${tenant} job=${jobName}`);
   await waitForPrometheusTarget(tenant, jobName);
+  await getExporterMetric(cortexBaseUrl, expectedMetricQuery);
 
-  log.info(`Waiting for metric=${expectedMetricQuery}`);
-  const value = await getExporterMetric(cortexBaseUrl, expectedMetricQuery);
-  log.info(`Got value for metric=${expectedMetricQuery}: ${value}`);
+  await cleanExporter(authTokenFilepath);
+}
 
-  log.info("Deleting exporters/credentials");
-  await deleteAllConfigs(authTokenFilepath, "exporters");
-  await deleteAllConfigs(authTokenFilepath, "credentials");
+async function testExporterLog(
+  authTokenFilepath: string | undefined,
+  exporterConfig: string,
+  credentialContent: string | null,
+  exporterNamespace: string,
+  exporterName: string,
+  logMessage: string
+) {
+  await setupExporter(authTokenFilepath, exporterConfig, credentialContent);
+
+  await getExporterLog(exporterNamespace, exporterName, logMessage);
+
+  await cleanExporter(authTokenFilepath);
 }
 
 function getExporterName(type: string) {
@@ -145,6 +203,10 @@ suite("Metric exporter tests", function () {
   suiteSetup(async function () {
     log.info("suite setup");
     globalTestSuiteSetupOnce();
+
+    log.info("Deleting any preexisting exporters/credentials");
+    await cleanExporter(TENANT_DEFAULT_API_TOKEN_FILEPATH);
+    await cleanExporter(TENANT_SYSTEM_API_TOKEN_FILEPATH);
   });
 
   suiteTeardown(async function () {
@@ -186,7 +248,7 @@ value:
     const jobName = `exporter-${exporterName}`;
     const metricQuery = `cloudwatch_exporter_scrape_error{job="${jobName}"}`;
 
-    await testExporter(
+    await testExporterMetric(
       "default",
       TENANT_DEFAULT_CORTEX_API_BASE_URL,
       TENANT_DEFAULT_API_TOKEN_FILEPATH,
@@ -195,7 +257,7 @@ value:
       exporterCred,
       metricQuery
     );
-    await testExporter(
+    await testExporterMetric(
       "system",
       TENANT_SYSTEM_CORTEX_API_BASE_URL,
       TENANT_SYSTEM_API_TOKEN_FILEPATH,
@@ -239,7 +301,7 @@ value: |-
     // this metric can take >30s to appear:
     const metricQuery = `stackdriver_monitoring_scrape_errors_total{job="${jobName}"}`;
 
-    await testExporter(
+    await testExporterMetric(
       "default",
       TENANT_DEFAULT_CORTEX_API_BASE_URL,
       TENANT_DEFAULT_API_TOKEN_FILEPATH,
@@ -248,7 +310,7 @@ value: |-
       exporterCred,
       metricQuery
     );
-    await testExporter(
+    await testExporterMetric(
       "system",
       TENANT_SYSTEM_CORTEX_API_BASE_URL,
       TENANT_SYSTEM_API_TOKEN_FILEPATH,
@@ -295,7 +357,7 @@ config:
     // The probe metrics should be labeled with module and target params:
     const metricQuery = `probe_success{job="${jobName}",module="http_2xx",target="example.com"}`;
 
-    await testExporter(
+    await testExporterMetric(
       "default",
       TENANT_DEFAULT_CORTEX_API_BASE_URL,
       TENANT_DEFAULT_API_TOKEN_FILEPATH,
@@ -304,7 +366,7 @@ config:
       null,
       metricQuery
     );
-    await testExporter(
+    await testExporterMetric(
       "system",
       TENANT_SYSTEM_CORTEX_API_BASE_URL,
       TENANT_SYSTEM_API_TOKEN_FILEPATH,
@@ -312,6 +374,56 @@ config:
       exporterConfig,
       null,
       metricQuery
+    );
+  });
+
+  test("Azure exporter", async function () {
+    const exporterName = getExporterName("azure");
+    const exporterConfig = `
+name: ${exporterName}
+type: azure
+credential: ${exporterName}
+config:
+  resource_groups:
+  - resource_group: group
+    resource_types:
+    - "Microsoft.Storage/storageAccounts"
+    metrics:
+    - name: Availability
+    - name: Egress
+    - name: Ingress
+    - name: SuccessE2ELatency
+    - name: SuccessServerLatency
+    - name: Transactions
+    - name: UsedCapacity
+`;
+    // Bogus credential value. Just check for an "auth failed" log message.
+    const exporterCred = `
+name: ${exporterName}
+type: azure-service-principal
+value:
+  AZURE_SUBSCRIPTION_ID: foo
+  AZURE_TENANT_ID: testtenantshouldfail
+  AZURE_CLIENT_ID: bar
+  AZURE_CLIENT_SECRET: baz
+`;
+
+    const expectedLogMessage = "Tenant 'testtenantshouldfail' not found";
+    await testExporterLog(
+      TENANT_DEFAULT_API_TOKEN_FILEPATH,
+      exporterConfig,
+      exporterCred,
+      "default-tenant",
+      exporterName,
+      expectedLogMessage
+    );
+    await testExporterLog(
+      TENANT_SYSTEM_API_TOKEN_FILEPATH,
+      exporterConfig,
+      exporterCred,
+      "system-tenant",
+      exporterName,
+      expectedLogMessage
     );
   });
 });

--- a/test/test-remote/test_exporters.ts
+++ b/test/test-remote/test_exporters.ts
@@ -155,11 +155,15 @@ async function getExporterLog(exporterNamespace: string, exporterName: string, l
   const entries = await waitForLokiQueryResult(
     TENANT_SYSTEM_LOKI_API_BASE_URL,
     queryParams,
-    undefined,
-    false,
-    0
+    undefined, // expectedEntryCount
+    false, // logDetails
+    1, // expectedStreamCount
+    true, // buildhash
+    // Default is 30s, which is plenty for default-tenant.
+    // Meanwhile system-tenant seems to take as long as 62s for an entry to appear.
+    120 // maxWaitSeconds
   );
-  log.info(`Got exporter log for query=${query}: ${entries}`);
+  log.info(`Got exporter log for query=${query}: ${entries.entries}`);
   return entries;
 }
 
@@ -385,7 +389,7 @@ type: azure
 credential: ${exporterName}
 config:
   resource_groups:
-  - resource_group: group
+  - resource_group: mygroup
     resource_types:
     - "Microsoft.Storage/storageAccounts"
     metrics:
@@ -407,8 +411,8 @@ value:
   AZURE_CLIENT_ID: bar
   AZURE_CLIENT_SECRET: baz
 `;
-
     const expectedLogMessage = "Tenant 'testtenantshouldfail' not found";
+
     await testExporterLog(
       TENANT_DEFAULT_API_TOKEN_FILEPATH,
       exporterConfig,

--- a/test/test-remote/test_prom_remote_write.ts
+++ b/test/test-remote/test_prom_remote_write.ts
@@ -23,10 +23,11 @@ import {
   log,
   rndstring,
   sendMetricsWithPromContainer,
-  waitForCortexMetricResult,
   TENANT_DEFAULT_API_TOKEN_FILEPATH,
   TENANT_DEFAULT_CORTEX_API_BASE_URL,
 } from "./testutils";
+
+import { waitForCortexMetricResult } from "./testutils/metrics";
 
 import { DummyTimeseries } from "./prom-node-client-tools";
 

--- a/test/test-remote/test_systemmetrics.ts
+++ b/test/test-remote/test_systemmetrics.ts
@@ -19,9 +19,10 @@ import { ZonedDateTime } from "@js-joda/core";
 import {
   log,
   globalTestSuiteSetupOnce,
-  waitForCortexMetricResult,
   TENANT_SYSTEM_CORTEX_API_BASE_URL,
 } from "./testutils";
+
+import { waitForCortexMetricResult } from "./testutils/metrics";
 
 suite("system metrics test suite", function () {
   suiteSetup(async function () {

--- a/test/test-remote/testutils/logs.ts
+++ b/test/test-remote/testutils/logs.ts
@@ -96,13 +96,10 @@ export async function waitForLokiQueryResult(
   expectedEntryCount: number | undefined,
   logDetails = true,
   expectedStreamCount = 1,
-  buildhash = true
+  buildhash = true,
+  // Latency should normally vary from 2 to 12 seconds
+  maxWaitSeconds = 30
 ): Promise<LokiQueryResult> {
-  // What's our latency goal here? Upper pipeline latency limit? As of writing
-  // this code I have seen this latency to vary between about 2 seconds and 12
-  // seconds.
-  const maxWaitSeconds = 30;
-
   const deadline = mtimeDeadlineInSeconds(maxWaitSeconds);
   if (logDetails) {
     log.info(
@@ -128,9 +125,6 @@ Query parameters: ${JSON.stringify(
     }
 
     queryCount += 1;
-    if (queryCount % 15 === 0) {
-      log.info("send query %s to loki", queryCount);
-    }
     const result = await queryLoki(lokiQuerierBaseUrl, qparms);
 
     if (result.status === undefined) {
@@ -240,7 +234,6 @@ Query parameters: ${JSON.stringify(
       }
 
       const result: LokiQueryResult = {
-        //entries: data["streams"][0]["entries"],
         entries: streams[0]["values"],
         labels: labels,
         textmd5: textmd5

--- a/test/test-remote/testutils/metrics.ts
+++ b/test/test-remote/testutils/metrics.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  log,
+  queryJSONAPI,
+  waitForQueryResult
+} from "./index";
+
+import { PortForward } from "./portforward";
+
+// Queries Cortex metrics data and waits for a non-empty result.
+export async function waitForCortexMetricResult(
+  cortexBaseUrl: string,
+  queryParams: Record<string, string>,
+  // Query endpoint under /api/v1 to hit, e.g. "query" for latest value or "query_range" for time range
+  queryUrlSuffix: string,
+  // What's our latency goal here? Upper pipeline latency limit? As of writing
+  // this code I have seen this latency to vary between about 2 seconds and 12
+  // seconds.
+  maxWaitSeconds = 30,
+  logQueryResponse = false
+) {
+  const url = `${cortexBaseUrl}/api/v1/${queryUrlSuffix}`;
+
+  log.info(
+    "Cortex query parameter (object):\n%s",
+    JSON.stringify(queryParams, Object.keys(queryParams).sort(), 2)
+  );
+  const qparms = new URLSearchParams(queryParams);
+  log.info("Cortex query parameters (query string):\n%s", qparms);
+
+  return waitForQueryResult(
+    () => queryJSONAPI(url, qparms),
+    (data) => {
+      // Example data:
+      // - query: https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+      // - query_range: https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
+      // Metrics data has results nested here, wait for non-empty result:
+      const resultArray = data["data"]["result"];
+      return (resultArray.length > 0) ? resultArray : null;
+    },
+    maxWaitSeconds,
+    logQueryResponse,
+  );
+}
+
+// Queries Prometheus scrape targets and waits for one or more targets with a matching job label to appear
+export async function waitForPrometheusTarget(
+  tenant: string,
+  jobLabel: string,
+  // Use a long timeout when waiting for prometheus scraper to see the pod.
+  // Normally takes 5-15s, but can take longer than 30s
+  maxWaitSeconds = 300,
+) {
+  const portForwardProm = new PortForward(
+    `tenant-prometheus-${tenant}`, // name (arbitrary/logging)
+    `statefulsets/prometheus-${tenant}-prometheus`, // k8sobj
+    9090, // port_remote
+    `${tenant}-tenant`, // namespace
+  );
+  const localPort = await portForwardProm.setup();
+
+  try {
+    const url = `http://127.0.0.1:${localPort}/prometheus/api/v1/targets`;
+    const qparms = new URLSearchParams({state: "active"});
+
+    log.info(`Waiting for target with tenant=${tenant} job=${jobLabel} via port-forward: ${url}`)
+    await waitForQueryResult(
+      () => queryJSONAPI(url, qparms),
+      (data) => {
+        // Example data: https://prometheus.io/docs/prometheus/latest/querying/api/#targets
+        // Search for target(s) with matching job label
+        const targets: Array<any> = data["data"]["activeTargets"];
+        const filtered = targets.filter(target => target["labels"]["job"] === jobLabel);
+        if (filtered.length == 0) {
+          // Not found yet
+          return null;
+        }
+        log.info(
+          "Found tenant prometheus scrape targets for job=%s: %s",
+          jobLabel,
+          filtered
+            .map(t => `${t["labels"]["job"]}:${t["labels"]["namespace"]}/${t["labels"]["pod"]}`)
+            .sort()
+        );
+        return filtered;
+      },
+      maxWaitSeconds,
+      false, // This is VERY long for system tenant, so don't log
+    );
+  } finally {
+    await portForwardProm.terminate();
+  }
+}


### PR DESCRIPTION
The Azure exporter fails to start when provided with bogus credentials, so we just check its logs to validate that it was deployed and that it failed to query Azure as expected. In comparison, when other exporters are faced with invalid credentials, they tend to instead expose a metric with a nonzero error count.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
