### PR TITLE
ci(test-upgrade): remove base cluster sanity check

### DIFF
--- a/ci/test-upgrade/run.sh
+++ b/ci/test-upgrade/run.sh
@@ -29,9 +29,8 @@ trap "teardown" EXIT
 
 make ci-testupgrade-create-cluster
 
-make test-remote
-make test-remote-looker
-make test-remote-ui
+# TODO(sreis): Add a new sanity check on the base cluster here before running
+# the upgrade. https://github.com/opstrace/opstrace/issues/591
 
 make ci-testupgrade-upgrade-cluster
 


### PR DESCRIPTION
See https://github.com/opstrace/opstrace/issues/591 for more details.


