### PR TITLE
chore: handle older controller config schema

### DIFF
--- a/packages/controller-config/src/schema.ts
+++ b/packages/controller-config/src/schema.ts
@@ -18,9 +18,9 @@ import { log, keyIDfromPEM } from "@opstrace/utils";
 
 import { ControllerConfigSchemaV1, ControllerConfigTypeV1 } from "./schemav1";
 import {
-  ControllerConfigSchemaV1a,
-  ControllerConfigTypeV1a
-} from "./schemav1a";
+  ControllerConfigSchemaV1alpha,
+  ControllerConfigTypeV1alpha
+} from "./schemav1alpha";
 
 import { ControllerConfigSchemaV2, ControllerConfigTypeV2 } from "./schemav2";
 
@@ -73,7 +73,7 @@ function V1toV2(cfg: ControllerConfigTypeV1): ControllerConfigTypeV2 {
   };
 }
 
-function V1atoV2(cfg: ControllerConfigTypeV1a): ControllerConfigTypeV2 {
+function V1alphatoV2(cfg: ControllerConfigTypeV1alpha): ControllerConfigTypeV2 {
   const { logRetention, metricRetention, ...restConfig } = cfg;
 
   return {
@@ -98,9 +98,9 @@ export function upgradeControllerConfigMapToLatest(
     return V1toV2(ControllerConfigSchemaV1.validateSync(json));
   }
 
-  if (ControllerConfigSchemaV1a.isValidSync(json, { strict: true })) {
-    log.debug("got v1a controller config, upgrading...");
-    return V1atoV2(ControllerConfigSchemaV1a.validateSync(json));
+  if (ControllerConfigSchemaV1alpha.isValidSync(json, { strict: true })) {
+    log.debug("got v1alpha controller config, upgrading...");
+    return V1alphatoV2(ControllerConfigSchemaV1alpha.validateSync(json));
   }
 
   // Possible user error. Parse again and it'll throw a meaningful error

--- a/packages/controller-config/src/schemav1a.ts
+++ b/packages/controller-config/src/schemav1a.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+import { GCPConfig } from "@opstrace/gcp";
+import { AWSConfig } from "@opstrace/aws";
+
+// Between V1 and V2 there was a cluster launched that had the
+// tenant_api_authenticator_pubkey_set_json field but before logRetention and
+// metricRetention were renamed.
+export const ControllerConfigSchemaV1a = yup
+  .object({
+    name: yup.string(),
+    target: yup
+      .mixed<"gcp" | "aws">()
+      .oneOf(["gcp", "aws"])
+      .required("must specify a target (gcp | aws)"),
+    region: yup.string().required("must specify region"),
+    logRetention: yup
+      .number()
+      .required("must specify log retention in number of days"),
+    metricRetention: yup
+      .number()
+      .required("must specify metric retention in number of days"),
+    dnsName: yup.string().required(),
+    terminate: yup.bool().default(false),
+    tenant_api_authenticator_pubkey_set_json: yup
+      .string()
+      .typeError()
+      .strict(true),
+    disable_data_api_authentication: yup.bool().required(),
+    uiSourceIpFirewallRules: yup.array(yup.string()).ensure(),
+    apiSourceIpFirewallRules: yup.array(yup.string()).ensure(),
+    postgreSQLEndpoint: yup.string().notRequired(),
+    opstraceDBName: yup.string().notRequired(),
+    envLabel: yup.string(),
+    // Note: remove one of cert_issuer and `tlsCertificateIssuer`.
+    cert_issuer: yup
+      .string()
+      .oneOf(["letsencrypt-prod", "letsencrypt-staging"])
+      .required(),
+    tlsCertificateIssuer: yup
+      .mixed<"letsencrypt-staging" | "letsencrypt-prod">()
+      .oneOf(["letsencrypt-staging", "letsencrypt-prod"])
+      .required(),
+    infrastructureName: yup.string().required(),
+    aws: yup.mixed<AWSConfig | undefined>(),
+    gcp: yup.mixed<GCPConfig | undefined>(),
+    controllerTerminated: yup.bool().default(false)
+  })
+  .noUnknown()
+  .defined();
+
+export type ControllerConfigTypeV1a = yup.InferType<
+  typeof ControllerConfigSchemaV1a
+>;

--- a/packages/controller-config/src/schemav1alpha.ts
+++ b/packages/controller-config/src/schemav1alpha.ts
@@ -21,7 +21,7 @@ import { AWSConfig } from "@opstrace/aws";
 // Between V1 and V2 there was a cluster launched that had the
 // tenant_api_authenticator_pubkey_set_json field but before logRetention and
 // metricRetention were renamed.
-export const ControllerConfigSchemaV1a = yup
+export const ControllerConfigSchemaV1alpha = yup
   .object({
     name: yup.string(),
     target: yup
@@ -64,6 +64,6 @@ export const ControllerConfigSchemaV1a = yup
   .noUnknown()
   .defined();
 
-export type ControllerConfigTypeV1a = yup.InferType<
-  typeof ControllerConfigSchemaV1a
+export type ControllerConfigTypeV1alpha = yup.InferType<
+  typeof ControllerConfigSchemaV1alpha
 >;


### PR DESCRIPTION
Between the use of ControllerConfig V1 and V2 schemas there was a cluster launched that had the tenant_api_authenticator_pubkey_set_json field but before logRetention and metricRetention were renamed.