### PR TITLE
test-remote: Replace ALL underscores with non-underscores, not just the first

### DIFF
--- a/test/test-remote/test_exporters.ts
+++ b/test/test-remote/test_exporters.ts
@@ -138,7 +138,11 @@ async function testExporter(
 }
 
 function getExporterName(type: string) {
-  return `testexporters-${rndstring().slice(0, 5).toLowerCase().replace('_', '0')}-${type}`;
+  // The exporter name is used in the K8s deployment name.
+  // As such, the exporter name can only contain letters, numbers, and '-'.
+  // rndstring() can return '_', so replace all '_'s with '0' just so that they fit.
+  // (use regex with /g to ensure ALL instances are replaced)
+  return `testexporters-${rndstring().slice(0, 5).toLowerCase().replace(/_/g, '0')}-${type}`;
 }
 
 suite("Metric exporter tests", function () {


### PR DESCRIPTION
If we're very lucky, we get back more than one `_`. This was seen in a scheduled build, where the token ended up being `0lpb_`, which I think maps to originally being `_lpb_` where only the first `_` was replaced.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
