### PR TITLE
controller: allow cortex and loki config overrides

### DIFF
--- a/packages/controller/src/helpers.ts
+++ b/packages/controller/src/helpers.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import yaml from "js-yaml";
+
 import { State } from "./reducer";
 import { LatestControllerConfigType } from "@opstrace/controller-config";
 import { Tenant } from "@opstrace/tenants";
+import { log } from "@opstrace/utils";
 
 export { generateSecretValue } from "@opstrace/controller-config";
 
@@ -39,13 +42,47 @@ export const iAmDesiredVersion = (version: string | undefined): boolean => {
   return version === currentVersion();
 };
 
-export const getControllerConfig = (state: State): LatestControllerConfigType => {
+export const getControllerConfig = (
+  state: State
+): LatestControllerConfigType => {
   if (state.config.config === undefined) {
     throw Error("Controller configmap is not present or missing fields");
   }
   return state.config.config;
 };
 
+// getControllerConfigOverrides checks if there's a ConfigMap named
+// "opstrace-controller-config-overrides in the default namespace. If it exists
+// then parses the `key` field and returns the corresponding object. If the
+// ConfigMap does not exist it returns an empty object. If there's an error
+// parsing the config overrides it logs the error and returns an empty object.
+function getControllerConfigOverrides(state: State, key: string): any {
+  if (state.config.config === undefined) {
+    throw Error("Controller configmap is not present or missing fields");
+  }
+
+  const cm = state.kubernetes.cluster.ConfigMaps.resources.find(
+    cm =>
+      cm.namespace === "default" &&
+      cm.name === "opstrace-controller-config-overrides"
+  );
+
+  try {
+    return yaml.load(cm?.spec.data?.[key] ?? "");
+  } catch (e) {
+    log.warning(`failed to parse config overrides: ${e.message}`);
+    return {};
+  }
+}
+
+export const getControllerCortexConfigOverrides = (state: State): any => {
+  return getControllerConfigOverrides(state, "cortex");
+};
+
+// same as getControllerCortexConfigOverrides but for loki
+export const getControllerLokiConfigOverrides = (state: State): any => {
+  return getControllerConfigOverrides(state, "loki");
+};
 
 export const toTenantNamespace = (tenantName: string): string =>
   `${tenantName}-tenant`;
@@ -83,3 +120,82 @@ export const getNodeCount = (state: State): number =>
 
 export const getPrometheusName = (tenant: Tenant): string =>
   `${tenant.name}-prometheus`;
+
+//
+// Code below was extracted  from
+// https://gist.github.com/mir4ef/c172583bdb968951d9e57fb50d44c3f7 to do deep
+// object merging with typescript.
+//
+interface IIsObject {
+  (item: any): boolean;
+}
+
+interface IObject {
+  [key: string]: any;
+}
+
+interface IDeepMerge {
+  (target: IObject, ...sources: Array<IObject>): IObject;
+}
+
+/**
+ * @description Method to check if an item is an object. Date and Function are considered
+ * an object, so if you need to exclude those, please update the method accordingly.
+ * @param item - The item that needs to be checked
+ * @return {Boolean} Whether or not @item is an object
+ */
+const isObject: IIsObject = (item: any): boolean => {
+  return item === Object(item) && !Array.isArray(item);
+};
+
+/**
+ * @description Method to perform a deep merge of objects
+ * @param {Object} target - The targeted object that needs to be merged with the supplied @sources
+ * @param {Array<Object>} sources - The source(s) that will be used to update the @target object
+ * @return {Object} The final merged object
+ */
+export const deepMerge: IDeepMerge = (
+  target: IObject,
+  ...sources: Array<IObject>
+): IObject => {
+  // return the target if no sources passed
+  if (!sources.length) {
+    return target;
+  }
+
+  const result: IObject = target;
+
+  if (isObject(result)) {
+    const len: number = sources.length;
+
+    for (let i = 0; i < len; i += 1) {
+      const elm: any = sources[i];
+
+      if (isObject(elm)) {
+        for (const key in elm) {
+          // eslint-disable-next-line no-prototype-builtins
+          if (elm.hasOwnProperty(key)) {
+            if (isObject(elm[key])) {
+              if (!result[key] || !isObject(result[key])) {
+                result[key] = {};
+              }
+              deepMerge(result[key], elm[key]);
+            } else {
+              if (Array.isArray(result[key]) && Array.isArray(elm[key])) {
+                // concatenate the two arrays and remove any duplicate primitive values
+                result[key] = Array.from(new Set(result[key].concat(elm[key])));
+              } else {
+                result[key] = elm[key];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return result;
+};
+//
+// End of gist code.
+//

--- a/packages/controller/src/resources/loki/index.ts
+++ b/packages/controller/src/resources/loki/index.ts
@@ -32,8 +32,14 @@ import {
 } from "@opstrace/kubernetes";
 import { State } from "../../reducer";
 import { roundDownToOdd, select, getBucketName } from "@opstrace/utils";
-import { getControllerConfig, getNodeCount } from "../../helpers";
+import {
+  deepMerge,
+  getControllerConfig,
+  getControllerLokiConfigOverrides,
+  getNodeCount
+} from "../../helpers";
 import { DockerImages } from "@opstrace/controller-config";
+import { log } from "@opstrace/utils";
 
 export function LokiResources(
   state: State,
@@ -148,7 +154,7 @@ export function LokiResources(
     env: []
   };
 
-  const lokiConfig = {
+  const lokiDefaultConfig = {
     server: {
       http_listen_port: 1080,
       grpc_server_max_recv_msg_size: 41943040, // default (4 MB) * 10
@@ -270,6 +276,14 @@ export function LokiResources(
       }
     }
   };
+
+  const lokiConfigOverrides = getControllerLokiConfigOverrides(state);
+
+  log.debug(
+    `loki config overrides: ${JSON.stringify(lokiConfigOverrides, null, 2)}`
+  );
+
+  const lokiConfig = deepMerge(lokiDefaultConfig, lokiConfigOverrides);
 
   collection.add(
     new Namespace(


### PR DESCRIPTION
Implements Proposal 2 described in #580.

Given the following ConfigMap, deployed with `kubectl` :

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: opstrace-controller-config-overrides
  namespace: default
data:
# example Cortex config override
  cortex: |
	limits_config:
		max_label_names_per_series: 45 
# example Loki config override 
  loki: |
	limits_config:
		max_label_names_per_series: 45  

```

The controller will read the Cortex and Loki config overrides, merge them with the default configs and update all the deployments.
