### PR TITLE
CLI: add subcommand ta-pubkeys-list

### DIFF
--- a/ci/test-cli/cli-tests-with-cluster.sh
+++ b/ci/test-cli/cli-tests-with-cluster.sh
@@ -45,7 +45,8 @@ test_tenant_authenticator_custom_keypair_flow() {
   ./build/bin/opstrace ta-create-keypair ta-custom-keypair.pem
   ./build/bin/opstrace ta-create-token ${OPSTRACE_CLUSTER_NAME} \
     default ta-custom-keypair.pem > tenant-default-auth-token-from-custom-keypair
-  ./build/bin/opstrace ta-add-pubkey \
+  ./build/bin/opstrace ta-pubkeys-list ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME}
+  ./build/bin/opstrace ta-pubkeys-add \
     ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} ta-custom-keypair.pem
 
   # pragmatic, non-robust wait

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -266,7 +266,8 @@ export async function awsGetClusterRegionWithCmdlineFallback(): Promise<string> 
 export async function awsGetClusterRegionDynamic(
   lookForOpstraceClusterName: string
 ): Promise<list.EKSOpstraceClusterRegionRelation | undefined> {
-  log.info("starting lookup of EKS cluster accross AWS regions");
+  log.info("starting lookup of matching EKS cluster accross AWS regions");
+
   const ocnRegionMap: Record<
     string,
     list.EKSOpstraceClusterRegionRelation
@@ -336,7 +337,12 @@ function genKubConfigObjForEKScluster(
   const kstring = generateKubeconfigStringForEksCluster(awsregion, eksCluster);
   const kubeConfig = new KubeConfig();
   log.info("parse kubeconfig string for EKS cluster");
-  kubeConfig.loadFromString(kstring);
+  try {
+    kubeConfig.loadFromString(kstring);
+  } catch (err) {
+    log.error("bad kconfig string:\n%s", kstring);
+    die(`error loading kubeconfig from text: ${err.code}: ${err.message}`);
+  }
   return kubeConfig;
 }
 

--- a/packages/controller-config/src/tasks/api.ts
+++ b/packages/controller-config/src/tasks/api.ts
@@ -34,7 +34,8 @@ import { log } from "@opstrace/utils";
 export async function fetch(
   kubeConfig: KubeConfiguration
 ): Promise<LatestControllerConfigType | undefined> {
-  log.info("fetch controller config map");
+  log.info("fetch Opstrace controller config map from Kubernetes cluster");
+
   const cm = configmap(kubeConfig);
   try {
     const v1ConfigMap = await cm.read();


### PR DESCRIPTION
```
± node packages/cli/build/index.js ta-pubkeys-list --help
usage: opstrace ta-pubkeys-list [-h] [--log-level LEVEL] PROVIDER CLUSTER_NAME

Tenant authentication: list public keys for a running Opstrace cluster, i.e. the set of trust
anchors for signed authentication tokens. The configured public keys are listed via their key ID on
stdout, with one key ID per line.

positional arguments:
  PROVIDER           The cloud provider to look up the Opstrace cluster in (aws, gcp).
  CLUSTER_NAME       The name of the cluster to look up the authenticator configuration for.

optional arguments:
  -h, --help         show this help message and exit
  --log-level LEVEL  Set log level for output on stderr. One of: debug, info, warning, error.
                     Default: info
```

```
± node packages/cli/build/index.js ta-pubkeys-list --log-level=debug aws schedul-bk-2194-909-a 2> /dev/null
d0ae692d76f6409259a914763b4d5f174b571f02
```
