### PR TITLE
docs(cli): fix missing example

### DIFF
--- a/docs/references/cli.md
+++ b/docs/references/cli.md
@@ -110,7 +110,7 @@ List existing Opstrace clusters (visible with the configured cloud credentials).
 Example:
 
 ```text
-
+./opstrace list aws
 ```
 
 Help text:


### PR DESCRIPTION
Found a text block with nothing in it...

![image](https://user-images.githubusercontent.com/19239758/117030686-bc68af00-acb4-11eb-9ee3-161c4814e82c.png)
