### PR TITLE
bump: memcached 1.6.6 -> 1.6.9

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -19,7 +19,7 @@
   "localVolumeProvisioner": "quay.io/external_storage/local-volume-provisioner:v2.2.0",
   "loki": "grafana/loki:2.2.0",
   "lokiApiProxy": "opstrace/loki-api:50089147b3fbf267a7c7d74990aa2c494c06498e",
-  "memcached": "memcached:1.6.6-alpine",
+  "memcached": "memcached:1.6.9-alpine",
   "memcachedExporter": "prom/memcached-exporter:v0.6.0",
   "nginxController": "k8s.gcr.io/ingress-nginx/controller:v0.41.2",
   "nodeExporter": "quay.io/prometheus/node-exporter:v0.18.1",

--- a/packages/controller/src/resources/memcache/index.ts
+++ b/packages/controller/src/resources/memcache/index.ts
@@ -44,12 +44,7 @@ export function MemcacheResources(
           "<=": Infinity,
           choose: min(4, roundDown(getNodeCount(state) / 3))
         }
-      ]),
-      resources: {
-        requests: {
-          memory: "3200Mi"
-        }
-      }
+      ])
     },
     memcachedIndexWrites: {
       replicas: select(getNodeCount(state), [
@@ -59,12 +54,7 @@ export function MemcacheResources(
           "<=": Infinity,
           choose: min(4, roundDown(getNodeCount(state) / 3))
         }
-      ]),
-      resources: {
-        requests: {
-          memory: "1050Mi"
-        }
-      }
+      ])
     },
     memcachedIndexQueries: {
       replicas: select(getNodeCount(state), [
@@ -74,12 +64,7 @@ export function MemcacheResources(
           "<=": Infinity,
           choose: min(4, roundDown(getNodeCount(state) / 3))
         }
-      ]),
-      resources: {
-        requests: {
-          memory: "1050Mi"
-        }
-      }
+      ])
     }
   };
 
@@ -282,7 +267,13 @@ export function MemcacheResources(
                       name: "client"
                     }
                   ],
-                  resources: config.memcachedIndexQueries.resources
+                  resources: {
+                    requests: {
+                      // Add some headroom here compared to the `-m 1024`
+                      // above, saw mem alloc failures.
+                      memory: "1400Mi"
+                    }
+                  }
                 },
                 {
                   args: [
@@ -352,7 +343,12 @@ export function MemcacheResources(
                       name: "client"
                     }
                   ],
-                  resources: config.memcachedIndexWrites.resources
+                  resources: {
+                    requests: {
+                      // Tune this to the `-m XX` above, add headroom
+                      memory: "1400Mi"
+                    }
+                  }
                 },
                 {
                   args: [
@@ -422,7 +418,12 @@ export function MemcacheResources(
                       name: "client"
                     }
                   ],
-                  resources: config.memcached.resources
+                  resources: {
+                    requests: {
+                      // Tune this to the `-m XX` above, add headroom
+                      memory: "3200Mi"
+                    }
+                  }
                 },
                 {
                   args: [


### PR DESCRIPTION
This also changes the resource requests a little bit, no magic to be expected from that change.

It's important to recognize the difference between resource requests and resource limits in k8s: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits