### PR TITLE
wip(kubernetes): replace isDeepStrictEqual with fast-deep-equal

### DIFF
--- a/lib/kubernetes/src/equality/AlertManager.spec.ts
+++ b/lib/kubernetes/src/equality/AlertManager.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1Alertmanager } from "..";
+import { isAlertManagerEqual } from "./AlertManager";
+
+// mock logger
+jest.mock("@opstrace/utils", () => ({
+  log: {
+    debug: jest.fn
+  }
+}));
+
+// return an empty certificate for testing
+function generateAlertManager(
+  template: Partial<V1Alertmanager> = {}
+): V1Alertmanager {
+  return {
+    metadata: {
+      /* start default metadata */
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring",
+      /* end default metadata */
+      annotations: {
+        some: "annotation"
+      },
+      labels: {
+        some: "label"
+      }
+    },
+    spec: {
+      baseImage: "my/image"
+    },
+    ...template
+  };
+}
+
+test("should return true when spec matches and default metatada is set", () => {
+  const desired = generateAlertManager({
+    metadata: {
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring"
+    }
+  });
+  const existing = generateAlertManager({
+    metadata: {
+      generation: 2,
+      resourceVersion: "5678",
+      selfLink: "/even/more/random/string",
+      uid: "evenmorerandomstring"
+    }
+  });
+  expect(isAlertManagerEqual(desired, existing)).toBe(true);
+});
+
+test("should return false when spec does not match", () => {
+  const desired = generateAlertManager({
+    spec: {
+      baseImage: "foo"
+    }
+  });
+  const existing = generateAlertManager({
+    spec: {
+      baseImage: "bar"
+    }
+  });
+
+  expect(isAlertManagerEqual(desired, existing)).toBe(false);
+});
+
+test("should return true when spec matches", () => {
+  const desired = generateAlertManager({
+    spec: {
+      baseImage: "foo"
+    }
+  });
+  const existing = generateAlertManager({
+    spec: {
+      baseImage: "foo"
+    }
+  });
+
+  expect(isAlertManagerEqual(desired, existing)).toBe(true);
+});

--- a/lib/kubernetes/src/equality/AlertManager.spec.ts
+++ b/lib/kubernetes/src/equality/AlertManager.spec.ts
@@ -70,6 +70,42 @@ test("should return true when spec matches and default metatada is set", () => {
   expect(isAlertManagerEqual(desired, existing)).toBe(true);
 });
 
+test("should return false when metatada.annotations changed", () => {
+  const desired = generateAlertManager({
+    metadata: {
+      annotations: {
+        my: "old-annotation"
+      }
+    }
+  });
+  const existing = generateAlertManager({
+    metadata: {
+      annotations: {
+        my: "new-annotation"
+      }
+    }
+  });
+  expect(isAlertManagerEqual(desired, existing)).toBe(false);
+});
+
+test("should return false when metatada.labels changed", () => {
+  const desired = generateAlertManager({
+    metadata: {
+      labels: {
+        my: "old-label"
+      }
+    }
+  });
+  const existing = generateAlertManager({
+    metadata: {
+      labels: {
+        my: "new-label"
+      }
+    }
+  });
+  expect(isAlertManagerEqual(desired, existing)).toBe(false);
+});
+
 test("should return false when spec does not match", () => {
   const desired = generateAlertManager({
     spec: {

--- a/lib/kubernetes/src/equality/AlertManager.ts
+++ b/lib/kubernetes/src/equality/AlertManager.ts
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
-import { isDeepStrictEqual } from "util";
+import equal from "fast-deep-equal";
 import { V1Alertmanager } from "..";
 
 export const isAlertManagerEqual = (
   desired: V1Alertmanager,
   existing: V1Alertmanager
 ): boolean => {
-  if (!isDeepStrictEqual(desired.spec, existing.spec)) {
+  if (!equal(desired.metadata?.annotations, existing.metadata?.annotations)) {
+    return false;
+  }
+  if (!equal(desired.metadata?.labels, existing.metadata?.labels)) {
+    return false;
+  }
+
+  if (!equal(desired.spec, existing.spec)) {
     return false;
   }
 

--- a/lib/kubernetes/src/equality/Certificate.spec.ts
+++ b/lib/kubernetes/src/equality/Certificate.spec.ts
@@ -25,17 +25,29 @@ jest.mock("@opstrace/utils", () => ({
 }));
 
 // return an empty certificate for testing
-function genCert(): V1Certificate {
+function genCert(template: Partial<V1Certificate> = {}): V1Certificate {
   return {
     metadata: {
-      annotations: {}
+      /* start default metadata */
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring",
+      /* end default metadata */
+      annotations: {
+        some: "annotation"
+      },
+      labels: {
+        some: "label"
+      }
     },
     spec: {
       issuerRef: {
         name: "test"
       },
       secretName: "test"
-    }
+    },
+    ...template
   };
 }
 
@@ -43,6 +55,44 @@ test("should return true when certificates are empty", () => {
   const desired = genCert();
   const existing = genCert();
 
+  expect(isCertificateEqual(desired, existing)).toBe(true);
+});
+
+test("should return true when certificates match", () => {
+  const desired = genCert();
+  const existing = genCert();
+
+  desired.metadata = {
+    annotations: {
+      foo: "foo"
+    }
+  };
+  existing.metadata = {
+    annotations: {
+      foo: "foo"
+    }
+  };
+
+  expect(isCertificateEqual(desired, existing)).toBe(true);
+});
+
+test("should return true when spec matches and default metatada is set", () => {
+  const desired = genCert({
+    metadata: {
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring"
+    }
+  });
+  const existing = genCert({
+    metadata: {
+      generation: 2,
+      resourceVersion: "5678",
+      selfLink: "/even/more/random/string",
+      uid: "evenmorerandomstring"
+    }
+  });
   expect(isCertificateEqual(desired, existing)).toBe(true);
 });
 

--- a/lib/kubernetes/src/equality/Certificate.spec.ts
+++ b/lib/kubernetes/src/equality/Certificate.spec.ts
@@ -124,6 +124,16 @@ test("should not be equal when certificate commonName does not match", () => {
   expect(isCertificateEqual(desired, existing)).toBe(false);
 });
 
+test("should return true if certificate dnsNames order changed", () => {
+  const desired = genCert();
+  const existing = genCert();
+
+  desired.spec.dnsNames = ["foo", "bar"];
+  existing.spec.dnsNames = ["bar", "foo"];
+
+  expect(isCertificateEqual(desired, existing)).toBe(true);
+});
+
 test("should not be equal when certificate dnsNames does not match", () => {
   const desired = genCert();
   const existing = genCert();

--- a/lib/kubernetes/src/equality/Certificate.ts
+++ b/lib/kubernetes/src/equality/Certificate.ts
@@ -15,8 +15,8 @@
  */
 
 import { log } from "@opstrace/utils";
-import { isDeepStrictEqual } from "util";
 import { V1Certificate } from "../custom-resources";
+import equal from "fast-deep-equal";
 
 export const isCertificateEqual = (
   desired: V1Certificate,
@@ -26,12 +26,7 @@ export const isCertificateEqual = (
     return false;
   }
 
-  if (
-    !isDeepStrictEqual(
-      desired.metadata?.annotations,
-      existing.metadata?.annotations
-    )
-  ) {
+  if (!equal(desired.metadata?.annotations, existing.metadata?.annotations)) {
     log.debug(
       `annotations mismatch: ${JSON.stringify(
         desired.metadata?.annotations
@@ -47,7 +42,7 @@ export const isCertificateEqual = (
     return false;
   }
 
-  if (!isDeepStrictEqual(desired.spec.dnsNames, existing.spec.dnsNames)) {
+  if (!equal(desired.spec.dnsNames, existing.spec.dnsNames)) {
     log.debug(
       `dnsNames mismatch:  ${desired.spec.dnsNames} vs ${existing.spec.dnsNames}`
     );
@@ -59,7 +54,7 @@ export const isCertificateEqual = (
     return false;
   }
 
-  if (!isDeepStrictEqual(desired.spec.issuerRef, existing.spec.issuerRef)) {
+  if (!equal(desired.spec.issuerRef, existing.spec.issuerRef)) {
     log.debug(
       `issuerRef mismatch:  ${desired.spec.issuerRef} vs ${existing.spec.issuerRef}`
     );

--- a/lib/kubernetes/src/equality/Pod.spec.ts
+++ b/lib/kubernetes/src/equality/Pod.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  V1PodTemplateSpec,
+  V1Container,
+  V1Probe,
+  V1Volume,
+  V1PodSpec,
+  V1KeyToPath
+} from "@kubernetes/client-node";
+import { isPodSpecTemplateEqual } from "./Pod";
+
+// mock logger
+jest.mock("@opstrace/utils", () => ({
+  log: {
+    debug: jest.fn
+  }
+}));
+
+function generateProbe(template: Partial<V1Probe> = {}): Required<V1Probe> {
+  return {
+    exec: {
+      command: ["cat", "/tmp/healthy"]
+    },
+    failureThreshold: 1,
+    initialDelaySeconds: 5,
+    periodSeconds: 5,
+    httpGet: {
+      // @ts-ignore should be number, not object as TS insists
+      port: 3000
+    },
+    successThreshold: 1,
+    timeoutSeconds: 1,
+    tcpSocket: {
+      // @ts-ignore should be number, not object as TS insists
+      port: 8080
+    },
+    ...template
+  };
+}
+
+function generateContainer(template: Partial<V1Container> = {}): V1Container {
+  return {
+    name: "busybox",
+    image: "busybox:1.25",
+    ports: [
+      {
+        name: "my-port",
+        containerPort: 8080,
+        hostPort: 3000
+      }
+    ],
+    volumeMounts: [
+      {
+        name: "my-volume",
+        mountPath: "/mountPath",
+        subPath: "/subpath"
+      }
+    ],
+    env: [
+      {
+        name: "my-env",
+        value: "my-env-value"
+      }
+    ],
+    args: ["HOSTNAME", "KUBERNETES_PORT"],
+    livenessProbe: generateProbe(),
+    readinessProbe: generateProbe(),
+    ...template
+  };
+}
+
+function generateVolumeItem(template: Partial<V1KeyToPath> = {}): V1KeyToPath {
+  return {
+    key: "SPECIAL_LEVEL",
+    mode: 511,
+    path: "keys",
+    ...template
+  };
+}
+
+function generateVolumes(template: Partial<V1Volume> = {}): V1Volume {
+  return {
+    name: "my-volume",
+    configMap: {
+      defaultMode: 511,
+      name: "special-config",
+      optional: false,
+      items: [
+        generateVolumeItem({ key: "ONE" }),
+        generateVolumeItem({ key: "TWO" }),
+        generateVolumeItem({ key: "THREE" })
+      ]
+    },
+    secret: {
+      defaultMode: 511,
+      secretName: "special-secret",
+      optional: false,
+      items: [
+        generateVolumeItem({ key: "FOUR" }),
+        generateVolumeItem({ key: "FIVE" }),
+        generateVolumeItem({ key: "SEVEN" })
+      ]
+    },
+    ...template
+  };
+}
+
+function generatePodSpec(): V1PodSpec {
+  return {
+    serviceAccountName: "my-service-account",
+    containers: [generateContainer()],
+    initContainers: [generateContainer()],
+    volumes: [generateVolumes()]
+  };
+}
+
+// return pod for testing
+function generatePodTemplateSpec(
+  template: Partial<V1PodTemplateSpec> = {}
+): Required<V1PodTemplateSpec> {
+  return {
+    metadata: {
+      /* start default metadata */
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring",
+      /* end default metadata */
+      annotations: {
+        some: "annotation"
+      },
+      labels: {
+        some: "label"
+      }
+    },
+    spec: generatePodSpec(),
+    ...template
+  };
+}
+
+test("should return true when spec matches", () => {
+  const desired = generatePodTemplateSpec();
+  const existing = generatePodTemplateSpec();
+
+  expect(isPodSpecTemplateEqual(desired, existing)).toBe(true);
+});
+
+test("should return true when spec matches and default metatada is set", () => {
+  const desired = generatePodTemplateSpec({
+    metadata: {
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring"
+    }
+  });
+  const existing = generatePodTemplateSpec({
+    metadata: {
+      generation: 2,
+      resourceVersion: "5678",
+      selfLink: "/even/more/random/string",
+      uid: "evenmorerandomstring"
+    }
+  });
+  expect(isPodSpecTemplateEqual(desired, existing)).toBe(true);
+});
+
+describe("containers", () => {
+  it("should return true when containers have not changed", () => {
+    const existing = generatePodTemplateSpec();
+    const desired = generatePodTemplateSpec();
+
+    existing.spec.containers = [generateContainer(), generateContainer()];
+    desired.spec.containers = [generateContainer(), generateContainer()];
+
+    expect(isPodSpecTemplateEqual(desired, existing)).toBe(true);
+  });
+});
+
+describe("volumes", () => {
+  it("should return true when volumes have not changed", () => {
+    const existing = generatePodTemplateSpec();
+    const desired = generatePodTemplateSpec();
+
+    existing.spec.volumes = [generateVolumes(), generateVolumes()];
+    desired.spec.volumes = [generateVolumes(), generateVolumes()];
+
+    expect(isPodSpecTemplateEqual(desired, existing)).toBe(true);
+  });
+
+  it("should return false when volume names changed", () => {
+    const existing = generatePodTemplateSpec();
+    const desired = generatePodTemplateSpec();
+
+    existing.spec.volumes = [
+      generateVolumes({ name: "old name one" }),
+      generateVolumes({ name: "new name two" })
+    ];
+    desired.spec.volumes = [
+      generateVolumes({ name: "new name one" }),
+      generateVolumes({ name: "new name two" })
+    ];
+
+    expect(isPodSpecTemplateEqual(desired, existing)).toBe(false);
+  });
+
+  describe("configMap", () => {
+    describe("items", () => {
+      it("should return false when items have changed", () => {
+        const existing = generatePodTemplateSpec();
+        const desired = generatePodTemplateSpec();
+
+        existing.spec.volumes![0].configMap!.items = [
+          generateVolumeItem({ key: "ONE OLD" }),
+          generateVolumeItem({ key: "TWO OLD" }),
+          generateVolumeItem({ key: "THREE OLD" })
+        ];
+
+        desired.spec.volumes![0].configMap!.items = [
+          generateVolumeItem({ key: "ONE NEW" }),
+          generateVolumeItem({ key: "TWO NEW" })
+        ];
+
+        expect(isPodSpecTemplateEqual(desired, existing)).toBe(false);
+      });
+    });
+  });
+
+  describe("secrets", () => {
+    describe("items", () => {
+      it("should return false when items have changed", () => {
+        const existing = generatePodTemplateSpec();
+        const desired = generatePodTemplateSpec();
+
+        existing.spec.volumes![0].secret!.items = [
+          generateVolumeItem({ key: "ONE OLD" }),
+          generateVolumeItem({ key: "TWO OLD" }),
+          generateVolumeItem({ key: "THREE OLD" })
+        ];
+
+        desired.spec.volumes![0].secret!.items = [
+          generateVolumeItem({ key: "ONE NEW" }),
+          generateVolumeItem({ key: "TWO NEW" })
+        ];
+
+        expect(isPodSpecTemplateEqual(desired, existing)).toBe(false);
+      });
+    });
+  });
+});
+
+describe("should return false when container liveness probe doesnt match", () => {
+  it("different exec", () => {
+    const existingProbe = generateProbe();
+    const desiredProbe = generateProbe({
+      exec: {
+        command: ["different", "command"]
+      }
+    });
+
+    const existing = generatePodTemplateSpec();
+    const desired = generatePodTemplateSpec();
+
+    existing.spec.containers[0].livenessProbe = existingProbe;
+    desired.spec.containers[0].livenessProbe = desiredProbe;
+
+    expect(isPodSpecTemplateEqual(desired, existing)).toBe(false);
+  });
+
+  it("different httpGet", () => {
+    const existingProbe = generateProbe();
+    const desiredProbe = generateProbe({
+      httpGet: {
+        // @ts-ignore should be number, not object as TS insists
+        port: 3001
+      }
+    });
+
+    const existing = generatePodTemplateSpec();
+    const desired = generatePodTemplateSpec();
+
+    existing.spec.containers[0].livenessProbe = existingProbe;
+    desired.spec.containers[0].livenessProbe = desiredProbe;
+
+    expect(isPodSpecTemplateEqual(desired, existing)).toBe(false);
+  });
+
+  it("different tcpSocket", () => {
+    const existingProbe = generateProbe();
+    const desiredProbe = generateProbe({
+      tcpSocket: {
+        // @ts-ignore should be number, not object as TS insists
+        port: 3001
+      }
+    });
+
+    const existing = generatePodTemplateSpec();
+    const desired = generatePodTemplateSpec();
+
+    existing.spec.containers[0].livenessProbe = existingProbe;
+    desired.spec.containers[0].livenessProbe = desiredProbe;
+
+    expect(isPodSpecTemplateEqual(desired, existing)).toBe(false);
+  });
+});

--- a/lib/kubernetes/src/equality/Pod.ts
+++ b/lib/kubernetes/src/equality/Pod.ts
@@ -26,7 +26,7 @@ import {
   V1Probe
 } from "@kubernetes/client-node";
 
-import { isDeepStrictEqual } from "util";
+import equal from "fast-deep-equal";
 
 export const ENV_HASH_NAME = "OPSTRACE_CONTROLLER_VERSION";
 
@@ -138,13 +138,13 @@ const isContainerProbeEqual = (
   existing: V1Probe | undefined
 ): boolean => {
   return (
-    isDeepStrictEqual(desired?.exec, existing?.exec) &&
+    equal(desired?.exec, existing?.exec) &&
     desired?.failureThreshold === existing?.failureThreshold &&
-    isDeepStrictEqual(desired?.httpGet, existing?.httpGet) &&
+    equal(desired?.httpGet, existing?.httpGet) &&
     desired?.initialDelaySeconds === existing?.initialDelaySeconds &&
     desired?.periodSeconds === existing?.periodSeconds &&
     desired?.successThreshold === existing?.successThreshold &&
-    isDeepStrictEqual(desired?.tcpSocket, existing?.tcpSocket) &&
+    equal(desired?.tcpSocket, existing?.tcpSocket) &&
     desired?.timeoutSeconds === existing?.timeoutSeconds
   );
 };

--- a/lib/kubernetes/src/equality/Prometheus.spec.ts
+++ b/lib/kubernetes/src/equality/Prometheus.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1Prometheus } from "..";
+import { isPrometheusEqual } from "./Prometheus";
+
+// mock logger
+jest.mock("@opstrace/utils", () => ({
+  log: {
+    debug: jest.fn
+  }
+}));
+
+// return an empty certificate for testing
+function generatePrometheus(
+  template: Partial<V1Prometheus> = {}
+): V1Prometheus {
+  return {
+    metadata: {
+      /* start default metadata */
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring",
+      /* end default metadata */
+      annotations: {
+        some: "annotation"
+      },
+      labels: {
+        some: "label"
+      }
+    },
+    spec: {
+      image: "my/image"
+    },
+    ...template
+  };
+}
+
+test("should return true when spec matches and default metatada is set", () => {
+  const desired = generatePrometheus({
+    metadata: {
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring"
+    }
+  });
+  const existing = generatePrometheus({
+    metadata: {
+      generation: 2,
+      resourceVersion: "5678",
+      selfLink: "/even/more/random/string",
+      uid: "evenmorerandomstring"
+    }
+  });
+  expect(isPrometheusEqual(desired, existing)).toBe(true);
+});
+
+test("should return false when spec does not match", () => {
+  const desired = generatePrometheus();
+  const existing = generatePrometheus();
+
+  desired.spec = {
+    baseImage: "foo"
+  };
+  existing.spec = {
+    baseImage: "bar"
+  };
+
+  expect(isPrometheusEqual(desired, existing)).toBe(false);
+});
+
+test("should return true when spec matches", () => {
+  const desired = generatePrometheus();
+  const existing = generatePrometheus();
+
+  desired.spec = {
+    baseImage: "foo"
+  };
+  existing.spec = {
+    baseImage: "foo"
+  };
+
+  expect(isPrometheusEqual(desired, existing)).toBe(true);
+});

--- a/lib/kubernetes/src/equality/Prometheus.ts
+++ b/lib/kubernetes/src/equality/Prometheus.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { isDeepStrictEqual } from "util";
+import equal from "fast-deep-equal";
 import { V1Prometheus } from "..";
 
 export const isPrometheusEqual = (
   desired: V1Prometheus,
   existing: V1Prometheus
 ): boolean => {
-  if (!isDeepStrictEqual(desired.spec, existing.spec)) {
+  if (!equal(desired.spec, existing.spec)) {
     return false;
   }
 

--- a/lib/kubernetes/src/equality/PrometheusRule.spec.ts
+++ b/lib/kubernetes/src/equality/PrometheusRule.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1Prometheusrule } from "..";
+import { isPrometheusRuleEqual } from "./PrometheusRule";
+
+// mock logger
+jest.mock("@opstrace/utils", () => ({
+  log: {
+    debug: jest.fn
+  }
+}));
+
+type Group = NonNullable<V1Prometheusrule["spec"]["groups"]>[number];
+type Rule = Group["rules"][number];
+
+function generateRule(template: Partial<Rule> = {}): Rule {
+  return {
+    alert: "my alert",
+    annotations: {
+      my: "annotation"
+    },
+    expr: "1234567",
+    for: "me",
+    labels: {
+      my: "label"
+    },
+    record: "my-record",
+    something: "else",
+    ...template
+  };
+}
+
+function generateRuleGroup(): Group {
+  return {
+    interval: "1000",
+    name: "My Group",
+    rules: [generateRule()]
+  };
+}
+
+// return an empty certificate for testing
+function generatePrometheusRule(
+  template: Partial<V1Prometheusrule> = {}
+): V1Prometheusrule {
+  return {
+    metadata: {
+      /* start default metadata */
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring",
+      /* end default metadata */
+      annotations: {
+        some: "annotation"
+      },
+      labels: {
+        some: "label"
+      }
+    },
+    spec: {
+      groups: [generateRuleGroup()]
+    },
+    ...template
+  };
+}
+
+test("should return true when spec does match", () => {
+  const desired = generatePrometheusRule();
+  const existing = generatePrometheusRule();
+
+  expect(isPrometheusRuleEqual(desired, existing)).toBe(true);
+});
+
+test("should return true when spec matches and default metatada is set", () => {
+  const desired = generatePrometheusRule({
+    metadata: {
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring"
+    }
+  });
+  const existing = generatePrometheusRule({
+    metadata: {
+      generation: 2,
+      resourceVersion: "5678",
+      selfLink: "/even/more/random/string",
+      uid: "evenmorerandomstring"
+    }
+  });
+  expect(isPrometheusRuleEqual(desired, existing)).toBe(true);
+});
+
+describe("should return false when rules in groups differ", () => {
+  it("different amount of rules", () => {
+    const existing = generatePrometheusRule();
+    const desired = generatePrometheusRule();
+
+    existing.spec.groups![0].rules = [generateRule()];
+    desired.spec.groups![0].rules = [generateRule(), generateRule()];
+
+    expect(isPrometheusRuleEqual(desired, existing)).toBe(false);
+  });
+
+  it("different labels", () => {
+    const existing = generatePrometheusRule();
+    const desired = generatePrometheusRule();
+
+    const existingRule = generateRule();
+    const desiredRule = generateRule({
+      labels: {
+        different: "labels"
+      }
+    });
+
+    existing.spec.groups![0].rules = [existingRule];
+    desired.spec.groups![0].rules = [desiredRule];
+
+    expect(isPrometheusRuleEqual(desired, existing)).toBe(false);
+  });
+
+  it("different annotations", () => {
+    const existing = generatePrometheusRule();
+    const desired = generatePrometheusRule();
+
+    const existingRule = generateRule();
+    const desiredRule = generateRule({
+      annotations: {
+        different: "labels"
+      }
+    });
+
+    existing.spec.groups![0].rules = [existingRule];
+    desired.spec.groups![0].rules = [desiredRule];
+
+    expect(isPrometheusRuleEqual(desired, existing)).toBe(false);
+  });
+});

--- a/lib/kubernetes/src/equality/PrometheusRule.ts
+++ b/lib/kubernetes/src/equality/PrometheusRule.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isDeepStrictEqual } from "util";
+import equal from "fast-deep-equal";
 import { V1Prometheusrule } from "..";
 
 export const isPrometheusRuleEqual = (
@@ -100,7 +100,7 @@ const isRuleEqual = (desired: Rule, existing: Rule): boolean => {
     desired.expr === existing.expr &&
     desired.for === existing.for &&
     desired.record === existing.record &&
-    isDeepStrictEqual(desired.labels, existing.labels) &&
-    isDeepStrictEqual(desired.annotations, existing.annotations)
+    equal(desired.labels, existing.labels) &&
+    equal(desired.annotations, existing.annotations)
   );
 };

--- a/lib/kubernetes/src/equality/Service.spec.ts
+++ b/lib/kubernetes/src/equality/Service.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1ServiceSpec } from "@kubernetes/client-node";
+import { isServiceSpecEqual } from "./Service";
+
+// mock logger
+jest.mock("@opstrace/utils", () => ({
+  log: {
+    debug: jest.fn
+  }
+}));
+
+// return an empty certificate for testing
+function generateService(template: Partial<V1ServiceSpec> = {}): V1ServiceSpec {
+  return {
+    selector: {
+      component: "redis"
+    },
+    ...template
+  };
+}
+
+test("should return true when selector does match", () => {
+  const existing = generateService();
+  const desired = generateService();
+
+  expect(isServiceSpecEqual(desired, existing)).toBe(true);
+});
+
+test("should return false when selector does not match", () => {
+  const existing = generateService();
+  const desired = generateService({
+    selector: {
+      something: "else"
+    }
+  });
+
+  expect(isServiceSpecEqual(desired, existing)).toBe(false);
+});

--- a/lib/kubernetes/src/equality/Service.ts
+++ b/lib/kubernetes/src/equality/Service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isDeepStrictEqual } from "util";
+import equal from "fast-deep-equal";
 import { V1ServiceSpec, V1ServicePort } from "@kubernetes/client-node";
 
 export const isServiceSpecEqual = (
@@ -24,7 +24,7 @@ export const isServiceSpecEqual = (
   if (!desired || !existing) {
     return !desired && !existing;
   }
-  if (!isDeepStrictEqual(desired.selector, existing.selector)) {
+  if (!equal(desired.selector, existing.selector)) {
     return false;
   }
   if (!areServicePortsEqual(desired, existing)) {

--- a/lib/kubernetes/src/equality/ServiceMonitor.spec.ts
+++ b/lib/kubernetes/src/equality/ServiceMonitor.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V1Servicemonitor } from "..";
+import { isServiceMonitorEqual } from "./ServiceMonitor";
+
+// mock logger
+jest.mock("@opstrace/utils", () => ({
+  log: {
+    debug: jest.fn
+  }
+}));
+
+type Endpoint = V1Servicemonitor["spec"]["endpoints"][number];
+function generateEndpoint(template: Partial<Endpoint> = {}): Endpoint {
+  return {
+    interval: "1",
+    port: "web",
+    path: "/test",
+    ...template
+  };
+}
+
+// return an empty certificate for testing
+function generateServiceMonitor(
+  template: Partial<V1Servicemonitor> = {}
+): V1Servicemonitor {
+  return {
+    metadata: {
+      /* start default metadata */
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring",
+      /* end default metadata */
+      annotations: {
+        some: "annotation"
+      },
+      labels: {
+        some: "label"
+      }
+    },
+    spec: {
+      jobLabel: "my-job-label",
+      selector: {
+        matchLabels: {
+          app: "prometheus"
+        },
+        component: "redis"
+      },
+      endpoints: [
+        generateEndpoint({ path: "one" }),
+        generateEndpoint({ path: "two" }),
+        generateEndpoint({ path: "three" })
+      ]
+    },
+    ...template
+  };
+}
+
+test("should return true when service monitor does match", () => {
+  const existing = generateServiceMonitor();
+  const desired = generateServiceMonitor();
+
+  expect(isServiceMonitorEqual(desired, existing)).toBe(true);
+});
+
+test("should return true when spec matches and default metatada is set", () => {
+  const desired = generateServiceMonitor({
+    metadata: {
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring"
+    }
+  });
+  const existing = generateServiceMonitor({
+    metadata: {
+      generation: 2,
+      resourceVersion: "5678",
+      selfLink: "/even/more/random/string",
+      uid: "evenmorerandomstring"
+    }
+  });
+  expect(isServiceMonitorEqual(desired, existing)).toBe(true);
+});
+
+test("should return true when only metadata changes", () => {
+  const existing = generateServiceMonitor({
+    metadata: { labels: { some: "old-label" } }
+  });
+  const desired = generateServiceMonitor({
+    metadata: { labels: { some: "new-label" } }
+  });
+
+  expect(isServiceMonitorEqual(desired, existing)).toBe(true);
+});
+
+test("should return false when selector does not match", () => {
+  const existing = generateServiceMonitor();
+  const desired = generateServiceMonitor();
+  desired.spec.selector.newStuff = "new-stuff";
+
+  expect(isServiceMonitorEqual(desired, existing)).toBe(false);
+});
+
+test("should return false when jobLabel does not match", () => {
+  const existing = generateServiceMonitor();
+  const desired = generateServiceMonitor();
+  desired.spec.jobLabel = "new-job-label";
+
+  expect(isServiceMonitorEqual(desired, existing)).toBe(false);
+});
+
+describe("should return false when endpoint does not match", () => {
+  it("changing amount of endpoints", () => {
+    const existing = generateServiceMonitor();
+    const desired = generateServiceMonitor();
+    desired.spec.endpoints = [
+      generateEndpoint({ path: "one" }),
+      generateEndpoint({ path: "two" }),
+      generateEndpoint({ path: "three" })
+    ];
+    desired.spec.endpoints = [
+      generateEndpoint({ path: "one" }),
+      generateEndpoint({ path: "four" })
+    ];
+
+    expect(isServiceMonitorEqual(desired, existing)).toBe(false);
+  });
+  it("different interval", () => {
+    const existing = generateServiceMonitor();
+    const desired = generateServiceMonitor();
+    desired.spec.endpoints = [generateEndpoint({ interval: "new" })];
+
+    expect(isServiceMonitorEqual(desired, existing)).toBe(false);
+  });
+  it("different port", () => {
+    const existing = generateServiceMonitor();
+    const desired = generateServiceMonitor();
+    desired.spec.endpoints = [generateEndpoint({ port: "new" })];
+
+    expect(isServiceMonitorEqual(desired, existing)).toBe(false);
+  });
+  it("different path", () => {
+    const existing = generateServiceMonitor();
+    const desired = generateServiceMonitor();
+    desired.spec.endpoints = [generateEndpoint({ path: "new" })];
+
+    expect(isServiceMonitorEqual(desired, existing)).toBe(false);
+  });
+});

--- a/lib/kubernetes/src/equality/ServiceMonitor.ts
+++ b/lib/kubernetes/src/equality/ServiceMonitor.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { isDeepStrictEqual } from "util";
+ import equal from "fast-deep-equal";
 import { V1Servicemonitor } from "..";
 
 export const isServiceMonitorEqual = (
   desired: V1Servicemonitor,
   existing: V1Servicemonitor
 ): boolean => {
-  if (!isDeepStrictEqual(desired.spec.selector, existing.spec.selector)) {
+  if (!equal(desired.spec.selector, existing.spec.selector)) {
     return false;
   }
   if (desired.spec.jobLabel !== existing.spec.jobLabel) {

--- a/lib/kubernetes/src/equality/index.spec.ts
+++ b/lib/kubernetes/src/equality/index.spec.ts
@@ -1,0 +1,319 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Deployment,
+  Secret,
+  ConfigMap,
+  CustomResourceDefinition,
+  ClusterRole
+} from "..";
+import {
+  hasClusterRoleChanged,
+  hasConfigMapChanged,
+  hasCustomResourceDefinitionChanged,
+  hasDeploymentChanged,
+  hasSecretChanged
+} from ".";
+import {
+  KubeConfig,
+  V1ClusterRole,
+  V1ConfigMap,
+  V1CustomResourceDefinition,
+  V1Deployment,
+  V1Secret
+} from "@kubernetes/client-node";
+
+// mock logger
+jest.mock("@opstrace/utils", () => ({
+  log: {
+    debug: jest.fn
+  }
+}));
+
+jest.mock("./general", () => ({
+  logDifference: jest.fn()
+}));
+
+jest.mock("@kubernetes/client-node");
+
+const generateDeployment = () => {
+  const resource: V1Deployment = {
+    metadata: {
+      /* start default metadata */
+      generation: 1,
+      resourceVersion: "1234",
+      selfLink: "/random/string",
+      uid: "randomstring",
+      /* end default metadata */
+      annotations: {
+        some: "annotation"
+      },
+      labels: {
+        some: "label"
+      }
+    },
+    spec: {
+      strategy: {
+        type: "RollingUpdate"
+      },
+      template: {},
+      selector: {
+        matchLabels: {
+          some: "label"
+        }
+      }
+    }
+  };
+  const kubeconfig = new KubeConfig();
+  return new Deployment(resource, kubeconfig);
+};
+
+const generateSecret = () => {
+  const resource: V1Secret = {
+    data: {
+      my: "data"
+    },
+    stringData: {
+      my: "string-data"
+    }
+  };
+  const kubeconfig = new KubeConfig();
+  return new Secret(resource, kubeconfig);
+};
+
+const generateConfigMap = () => {
+  const resource: V1ConfigMap = {
+    data: {
+      my: "data"
+    },
+    binaryData: {
+      my: "binary-data"
+    }
+  };
+  const kubeconfig = new KubeConfig();
+  return new ConfigMap(resource, kubeconfig);
+};
+
+const generateCustomResourceDefinition = () => {
+  const resource: V1CustomResourceDefinition = {
+    metadata: {
+      annotations: {
+        my: "annotation"
+      }
+    },
+    spec: {
+      names: {
+        kind: "kind",
+        plural: "plural"
+      },
+      group: "my-group",
+      scope: "my-scope",
+      versions: []
+    }
+  };
+  const kubeconfig = new KubeConfig();
+  return new CustomResourceDefinition(resource, kubeconfig);
+};
+
+const generateClusterRole = () => {
+  const resource: V1ClusterRole = {
+    kind: "my-kind",
+    rules: [
+      {
+        verbs: ["my-verb"]
+      }
+    ],
+    aggregationRule: {
+      clusterRoleSelectors: [{ matchLabels: { some: "label" } }]
+    },
+    metadata: {
+      annotations: {
+        my: "annotation"
+      },
+      labels: {
+        my: "label"
+      },
+      name: "my-name"
+    }
+  };
+  const kubeconfig = new KubeConfig();
+  return new ClusterRole(resource, kubeconfig);
+};
+
+describe("hasDeploymentChanged()", () => {
+  it("should return false when spec matches", () => {
+    const existing = generateDeployment();
+    const desired = generateDeployment();
+
+    expect(hasDeploymentChanged(desired, existing)).toBe(false);
+  });
+
+  it("should return true when strategy has changed", () => {
+    const existing = generateDeployment();
+    const desired = generateDeployment();
+
+    desired.spec.spec!.strategy!.type = "Recreate";
+
+    expect(hasDeploymentChanged(desired, existing)).toBe(true);
+  });
+
+  it("should return true when selector has changed", () => {
+    const existing = generateDeployment();
+    const desired = generateDeployment();
+
+    desired.spec.spec!.selector!.matchLabels = {};
+
+    expect(hasDeploymentChanged(desired, existing)).toBe(true);
+  });
+});
+
+describe("hasSecretChanged()", () => {
+  it("should return false when spec matches", () => {
+    const existing = generateSecret();
+    const desired = generateSecret();
+
+    expect(hasSecretChanged(desired, existing)).toBe(false);
+  });
+
+  it("should return true when data has changed", () => {
+    const existing = generateSecret();
+    const desired = generateSecret();
+
+    desired.spec!.data = { new: "data" };
+
+    expect(hasSecretChanged(desired, existing)).toBe(true);
+  });
+
+  it("should return true when stringData has changed", () => {
+    const existing = generateSecret();
+    const desired = generateSecret();
+
+    desired.spec!.stringData = { new: "string-data" };
+
+    expect(hasSecretChanged(desired, existing)).toBe(true);
+  });
+});
+
+describe("hasConfigMapChanged()", () => {
+  it("should return false when spec matches", () => {
+    const existing = generateConfigMap();
+    const desired = generateConfigMap();
+
+    expect(hasConfigMapChanged(desired, existing)).toBe(false);
+  });
+
+  it("should return true when data has changed", () => {
+    const existing = generateConfigMap();
+    const desired = generateConfigMap();
+
+    desired.spec!.data = { new: "data" };
+
+    expect(hasConfigMapChanged(desired, existing)).toBe(true);
+  });
+
+  it("should return true when binaryData has changed", () => {
+    const existing = generateConfigMap();
+    const desired = generateConfigMap();
+
+    desired.spec!.binaryData = { new: "binary-data" };
+
+    expect(hasConfigMapChanged(desired, existing)).toBe(true);
+  });
+});
+
+describe("hasCustomResourceDefinitionChanged()", () => {
+  it("should return false when spec matches", () => {
+    const existing = generateCustomResourceDefinition();
+    const desired = generateCustomResourceDefinition();
+
+    expect(hasCustomResourceDefinitionChanged(desired, existing)).toBe(false);
+  });
+
+  it("should return true when annotations have changed", () => {
+    const existing = generateCustomResourceDefinition();
+    const desired = generateCustomResourceDefinition();
+
+    desired.spec.metadata!.annotations = { new: "annotation" };
+
+    expect(hasCustomResourceDefinitionChanged(desired, existing)).toBe(true);
+  });
+});
+
+describe("hasClusterRoleChanged()", () => {
+  it("should return false when spec matches", () => {
+    const existing = generateClusterRole();
+    const desired = generateClusterRole();
+
+    expect(hasClusterRoleChanged(desired, existing)).toBe(false);
+  });
+
+  it("should return true when kind has changed", () => {
+    const existing = generateClusterRole();
+    const desired = generateClusterRole();
+
+    desired.spec.kind = "new-kind";
+
+    expect(hasClusterRoleChanged(desired, existing)).toBe(true);
+  });
+
+  it("should return true when rules have changed", () => {
+    const existing = generateClusterRole();
+    const desired = generateClusterRole();
+
+    desired.spec.rules = [{ verbs: ["new-verb"] }];
+
+    expect(hasClusterRoleChanged(desired, existing)).toBe(true);
+  });
+
+  it("should return true when aggregationRule has changed", () => {
+    const existing = generateClusterRole();
+    const desired = generateClusterRole();
+
+    desired.spec.aggregationRule = {
+      clusterRoleSelectors: []
+    };
+
+    expect(hasClusterRoleChanged(desired, existing)).toBe(true);
+  });
+
+  it("should return true when metadata.annotations has changed", () => {
+    const existing = generateClusterRole();
+    const desired = generateClusterRole();
+
+    desired.spec.metadata!.annotations = { new: "annotations" };
+
+    expect(hasClusterRoleChanged(desired, existing)).toBe(true);
+  });
+
+  it("should return true when metadata.annotations has changed", () => {
+    const existing = generateClusterRole();
+    const desired = generateClusterRole();
+
+    desired.spec.metadata!.labels = { new: "label" };
+
+    expect(hasClusterRoleChanged(desired, existing)).toBe(true);
+  });
+
+  it("should return true when metadata.name has changed", () => {
+    const existing = generateClusterRole();
+    const desired = generateClusterRole();
+
+    desired.spec.metadata!.name = "new name";
+
+    expect(hasClusterRoleChanged(desired, existing)).toBe(true);
+  });
+});

--- a/lib/kubernetes/src/equality/index.ts
+++ b/lib/kubernetes/src/equality/index.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import equal = require("fast-deep-equal");
-import { isDeepStrictEqual } from "util";
+import equal from "fast-deep-equal";
 import * as Service from "./Service";
 import * as ServiceMonitor from "./ServiceMonitor";
 import * as Pod from "./Pod";
@@ -86,10 +85,7 @@ export const hasDeploymentChanged = (
 
   if (
     desired.spec.spec?.strategy !== undefined &&
-    !isDeepStrictEqual(
-      desired.spec.spec?.strategy,
-      existing.spec.spec?.strategy
-    )
+    !equal(desired.spec.spec?.strategy, existing.spec.spec?.strategy)
   ) {
     logDifference(
       `${desired.spec.metadata?.namespace}/${desired.spec.metadata?.name}`,
@@ -101,10 +97,7 @@ export const hasDeploymentChanged = (
 
   if (
     desired.spec.spec?.selector !== undefined &&
-    !isDeepStrictEqual(
-      desired.spec.spec?.selector,
-      existing.spec.spec?.selector
-    )
+    !equal(desired.spec.spec?.selector, existing.spec.spec?.selector)
   ) {
     logDifference(
       `${desired.spec.metadata?.namespace}/${desired.spec.metadata?.name}`,
@@ -215,8 +208,8 @@ export const hasSecretChanged = (
     return false;
   }
   if (
-    !isDeepStrictEqual(desired.spec.data, existing.spec.data) ||
-    !isDeepStrictEqual(desired.spec.stringData, existing.spec.stringData)
+    !equal(desired.spec.data, existing.spec.data) ||
+    !equal(desired.spec.stringData, existing.spec.stringData)
   ) {
     logDifference(
       `${desired.spec.metadata?.namespace}/${desired.spec.metadata?.name}`,
@@ -250,8 +243,8 @@ export const hasConfigMapChanged = (
   existing: ConfigMapType
 ): boolean => {
   if (
-    !isDeepStrictEqual(desired.spec.data, existing.spec.data) ||
-    !isDeepStrictEqual(desired.spec.binaryData, existing.spec.binaryData)
+    !equal(desired.spec.data, existing.spec.data) ||
+    !equal(desired.spec.binaryData, existing.spec.binaryData)
   ) {
     logDifference(
       `${desired.spec.metadata?.namespace}/${desired.spec.metadata?.name}`,
@@ -337,25 +330,16 @@ export const hasClusterRoleChanged = (
   // Those defaults make this check fail. Check if any of the fiels we are
   // interested in have changed.
   if (
-    !isDeepStrictEqual(
-      desired.spec.aggregationRule,
-      existing.spec.aggregationRule
-    ) ||
-    !isDeepStrictEqual(desired.spec.apiVersion, existing.spec.apiVersion) ||
-    !isDeepStrictEqual(desired.spec.kind, existing.spec.kind) ||
-    !isDeepStrictEqual(desired.spec.rules, existing.spec.rules) ||
-    !isDeepStrictEqual(
+    !equal(desired.spec.aggregationRule, existing.spec.aggregationRule) ||
+    !equal(desired.spec.apiVersion, existing.spec.apiVersion) ||
+    !equal(desired.spec.kind, existing.spec.kind) ||
+    !equal(desired.spec.rules, existing.spec.rules) ||
+    !equal(
       desired.spec.metadata?.annotations,
       existing.spec.metadata?.annotations
     ) ||
-    !isDeepStrictEqual(
-      desired.spec.metadata?.labels,
-      existing.spec.metadata?.labels
-    ) ||
-    !isDeepStrictEqual(
-      desired.spec.metadata?.name,
-      existing.spec.metadata?.name
-    )
+    !equal(desired.spec.metadata?.labels, existing.spec.metadata?.labels) ||
+    !equal(desired.spec.metadata?.name, existing.spec.metadata?.name)
   ) {
     logDifference(
       `${desired.spec.metadata?.namespace}/${desired.spec.metadata?.name}`,
@@ -368,7 +352,7 @@ export const hasClusterRoleChanged = (
   return false;
 };
 
-// isDeepStrictEquals doesn't handle the CRD schema very well and always reports
+// equals doesn't handle the CRD schema very well and always reports
 // a mismatch. The workaround is to check if the annotations match. This works
 // since we add an annotation with the controller version to the CRDs.
 export const hasCustomResourceDefinitionChanged = (
@@ -376,7 +360,7 @@ export const hasCustomResourceDefinitionChanged = (
   existing: CustomResourceDefinitionType
 ): boolean => {
   if (
-    !isDeepStrictEqual(
+    !equal(
       desired.spec.metadata?.annotations,
       existing.spec.metadata?.annotations
     )


### PR DESCRIPTION
Signed-off-by: Mo Sattler <hi@mosattler.com>

Relates to #588

In this PR I merely replace the current `isDeepStrictEqual` with `fast-deep-equal`, and add some tests for it. 

TODO:
- [ ] Replace manually written array checks mentioned in #588 with `fast-deep-equal` and add some tests for those cases.
- [ ] Investigate if the comparing code which is specific to resource could be replaced by a more generic comparer function (see @sreis [comment](https://github.com/opstrace/opstrace/issues/588#issuecomment-831988684))

# Have you...

* [x] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [x] Written new tests for your changes?
* [x] Thought about which docs need updating?
