### PR TITLE
feat: add comparer function that disregards order

### DIFF
--- a/lib/kubernetes/src/equality/isDeepEqualInAnyOrder.test.ts
+++ b/lib/kubernetes/src/equality/isDeepEqualInAnyOrder.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import isDeepEqualInAnyOrder from "./isDeepEqualInAnyOrder";
+
+describe("isDeepEqualInAnyOrder()", () => {
+  it("identifies array containing the same items as equal", () => {
+    const object1 = {
+      A: [{ id: 1 }, { id: 2 }]
+    };
+
+    const object2 = {
+      A: [{ id: 2 }, { id: 1 }]
+    };
+
+    expect(isDeepEqualInAnyOrder(object1, object2)).toBe(true);
+  });
+
+  it("identifies arrays inside objects inside arrays containing the same items as equal", () => {
+    const object1 = {
+      A: [
+        {
+          foo: [{ id: 1 }, { id: 2 }]
+        },
+        {
+          baz: [{ id: 3 }, { id: 4 }]
+        }
+      ]
+    };
+
+    const object2 = {
+      A: [
+        {
+          baz: [{ id: 4 }, { id: 3 }]
+        },
+        {
+          foo: [{ id: 2 }, { id: 1 }]
+        }
+      ]
+    };
+
+    expect(isDeepEqualInAnyOrder(object1, object2)).toBe(true);
+  });
+
+  it("identifies array containing different items as unequal", () => {
+    const object1 = {
+      A: [{ id: 1 }, { id: 2 }]
+    };
+
+    const object2 = {
+      A: [{ id: 2 }, { id: 3 }]
+    };
+
+    expect(isDeepEqualInAnyOrder(object1, object2)).toBe(false);
+  });
+
+  it("identifies arrays inside objects inside arrays containing differen items as unequal", () => {
+    const object1 = {
+      A: [
+        {
+          foo: [{ id: 1 }, { id: 2 }]
+        },
+        {
+          baz: [{ id: 2 }, { id: 1 }]
+        }
+      ]
+    };
+
+    const object2 = {
+      A: [
+        {
+          baz: [{ id: 1 }, { id: 2 }]
+        },
+        {
+          foo: [{ id: 2 }, { id: 1 }]
+        }
+      ]
+    };
+
+    expect(isDeepEqualInAnyOrder(object1, object2)).toBe(true);
+  });
+});

--- a/lib/kubernetes/src/equality/isDeepEqualInAnyOrder.ts
+++ b/lib/kubernetes/src/equality/isDeepEqualInAnyOrder.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isEqualWith, intersectionWith } from "lodash";
+
+const doArraysContainSameItems = <T>(
+  arrOne: Array<T>,
+  arrTwo: Array<T>
+): boolean => {
+  if (arrOne.length !== arrOne.length) {
+    return false;
+  }
+
+  /* If the intersection is every element from arrOne, and every element 
+     from arrTwo, then arrOne and arrTwo are the same */
+  const intersection = intersectionWith(arrOne, arrTwo, isDeepEqualInAnyOrder);
+
+  return intersection.length === arrOne.length;
+};
+
+const isDeepEqualInAnyOrder = <T>(existing: T, desired: T): boolean => {
+  return isEqualWith(existing, desired, (a, b) => {
+    /* Is the items to compare are arrays, we compare them ourselves, if not,
+       we let lodash handle it */
+    if (Array.isArray(a) && Array.isArray(b)) {
+      return doArraysContainSameItems(a, b);
+    }
+
+    // returning `undefined` defaults to normal deep comparing of values
+    return undefined;
+  });
+};
+
+export default isDeepEqualInAnyOrder;


### PR DESCRIPTION
In order to address the problem of nested arrays when comparing Kubernetes resources (see [here](https://github.com/opstrace/opstrace/issues/588#issuecomment-833642578)), I facilitated lodash's deepEqual function, that provides an escape hatch with `deepEqualWith`. 
Whenever an array needs to be compared, the code takes over control from lodash, and compares the arrays with disregard of item order. 

* [ ] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [x] Written new tests for your changes?
* [x] Thought about which docs need updating?
