### PR TITLE
feat: re-use array equality check logic

### DIFF
--- a/lib/kubernetes/src/equality/Pod.ts
+++ b/lib/kubernetes/src/equality/Pod.ts
@@ -82,9 +82,6 @@ const isPodSpecEqual = (desired: V1PodSpec, existing: V1PodSpec): boolean => {
   ) {
     return false;
   }
-  if (desired.initContainers && existing.initContainers === undefined) {
-    return false;
-  }
 
   return true;
 };
@@ -160,9 +157,6 @@ const areContainerPortsEqual = (
         isContainerPortEqual(desiredPort, existingPort)
     )
   ) {
-    return false;
-  }
-  if (desired.ports && existing.ports === undefined) {
     return false;
   }
 
@@ -266,9 +260,6 @@ const areVolumeMountsEqual = (
   ) {
     return false;
   }
-  if (desired.volumeMounts && existing.volumeMounts === undefined) {
-    return false;
-  }
 
   return true;
 };
@@ -293,9 +284,6 @@ const areVolumesEqual = (desired: V1PodSpec, existing: V1PodSpec): boolean => {
         isVolumeEqual(desiredVolume, existingVolume)
     )
   ) {
-    return false;
-  }
-  if (desired.volumes && existing.volumes === undefined) {
     return false;
   }
 

--- a/lib/kubernetes/src/equality/PrometheusRule.ts
+++ b/lib/kubernetes/src/equality/PrometheusRule.ts
@@ -16,6 +16,7 @@
 
 import { isDeepStrictEqual } from "util";
 import { V1Prometheusrule } from "..";
+import { isResourceListEqual } from "./utils";
 
 export const isPrometheusRuleEqual = (
   desired: V1Prometheusrule,
@@ -57,14 +58,10 @@ const areGroupsEqual = (
   }
 
   if (
-    Array.isArray(desired.spec.groups) &&
-    Array.isArray(existing.spec.groups) &&
-    !(
-      desired.spec.groups.length === existing.spec.groups.length &&
-      !desired.spec.groups.find(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        (g, i) => !isGroupEqual(g, existing.spec.groups![i])
-      )
+    !isResourceListEqual(
+      desired.spec.groups,
+      existing.spec.groups,
+      (desired, existing) => isGroupEqual(desired, existing)
     )
   ) {
     return false;

--- a/lib/kubernetes/src/equality/Service.ts
+++ b/lib/kubernetes/src/equality/Service.ts
@@ -16,6 +16,7 @@
 
 import { isDeepStrictEqual } from "util";
 import { V1ServiceSpec, V1ServicePort } from "@kubernetes/client-node";
+import { isResourceListEqual } from "./utils";
 
 export const isServiceSpecEqual = (
   desired?: V1ServiceSpec,
@@ -65,11 +66,11 @@ const areServicePortsEqual = (
   }
 
   if (
-    Array.isArray(desired.ports) &&
-    !(
-      desired.ports.length === existing.ports?.length &&
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      !desired.ports.find((p, i) => !isServicePortEqual(p, existing.ports![i]))
+    !isResourceListEqual(
+      desired.ports,
+      existing.ports,
+      (desiredPort, existingPort) =>
+        isServicePortEqual(desiredPort, existingPort)
     )
   ) {
     return false;

--- a/lib/kubernetes/src/equality/ServiceMonitor.ts
+++ b/lib/kubernetes/src/equality/ServiceMonitor.ts
@@ -16,6 +16,7 @@
 
 import { isDeepStrictEqual } from "util";
 import { V1Servicemonitor } from "..";
+import { isResourceListEqual } from "./utils";
 
 export const isServiceMonitorEqual = (
   desired: V1Servicemonitor,
@@ -49,16 +50,14 @@ const areEndpointsEqual = (
   }
 
   if (
-    Array.isArray(desired.spec.endpoints) &&
-    !(
-      desired.spec.endpoints.length === existing.spec.endpoints.length &&
-      !desired.spec.endpoints.find(
-        (p, i) =>
-          !isEndpointEqual(
-            p as Endpoint,
-            existing.spec.endpoints[i] as Endpoint
-          )
-      )
+    !isResourceListEqual(
+      desired.spec.endpoints,
+      existing.spec.endpoints,
+      (desiredEndpoint, existingEndpoint) =>
+        isEndpointEqual(
+          desiredEndpoint as Endpoint,
+          existingEndpoint as Endpoint
+        )
     )
   ) {
     return false;

--- a/lib/kubernetes/src/equality/utils.ts
+++ b/lib/kubernetes/src/equality/utils.ts
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
+// empty lists can either be `undefined` or have length of 0
+const isResourceListEmpty = <Resource>(list: Array<Resource> | void) =>
+  !list || list.length === 0;
+
 export const isResourceListEqual = <Resource>(
   desiredList: Array<Resource> | void,
   existingList: Array<Resource> | void,
   isResourceEqual: (desired: Resource, existing: Resource) => boolean
 ): boolean => {
   if (!Array.isArray(desiredList) || !Array.isArray(existingList)) {
-    // TODO: why though?
-    return true;
+    return (
+      isResourceListEmpty(desiredList) && isResourceListEmpty(existingList)
+    );
   }
 
   if (desiredList.length !== existingList.length) {

--- a/lib/kubernetes/src/equality/utils.ts
+++ b/lib/kubernetes/src/equality/utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const isResourceListEqual = <Resource>(
+  desiredList: Array<Resource> | void,
+  existingList: Array<Resource> | void,
+  isResourceEqual: (desired: Resource, existing: Resource) => boolean
+): boolean => {
+  if (!Array.isArray(desiredList) || !Array.isArray(existingList)) {
+    // TODO: why though?
+    return true;
+  }
+
+  if (desiredList.length !== existingList.length) {
+    return false;
+  }
+
+  return desiredList.every((desired, i) =>
+    isResourceEqual(desired, existingList[i])
+  );
+};

--- a/lib/kubernetes/src/equality/utils.ts
+++ b/lib/kubernetes/src/equality/utils.ts
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-// empty lists can either be `undefined` or have length of 0
-const isResourceListEmpty = <Resource>(list: Array<Resource> | void) =>
-  !list || list.length === 0;
-
+/**
+ * A list of resources which is `undefined` is the equivalent of an empty list. 
+ * To keep the code simple we therefor use `[]` as default parameters.
+*/
 export const isResourceListEqual = <Resource>(
-  desiredList: Array<Resource> | void,
-  existingList: Array<Resource> | void,
+  desiredList: Array<Resource> = [],
+  existingList: Array<Resource> = [],
   isResourceEqual: (desired: Resource, existing: Resource) => boolean
 ): boolean => {
-  if (!Array.isArray(desiredList) || !Array.isArray(existingList)) {
-    return (
-      isResourceListEmpty(desiredList) && isResourceListEmpty(existingList)
-    );
-  }
-
   if (desiredList.length !== existingList.length) {
     return false;
   }


### PR DESCRIPTION
As discussed [here](https://opstrace-community.slack.com/archives/C01KZS8JRNC/p1620654448097300?thread_ts=1620653118.096800&cid=C01KZS8JRNC), this change reduces a bit of duplication be re-using the array checks in the code that detects changes in k8s resources. 

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [ ] Written new tests for your changes? 
* [x] Thought about which docs need updating?
