### PR TITLE
ui: bugfix for "can't save alertmanager configuration changes made in the UI"

### DIFF
--- a/packages/app/src/client/views/alerting/configuration.tsx
+++ b/packages/app/src/client/views/alerting/configuration.tsx
@@ -161,6 +161,7 @@ const AlertmanagerConfigEditor = (props: AlertmanagerConfigEditorProps) => {
       maxWait: 5000
     });
 
+    dataRef.current = newConfig;
     validationCheckOnChangeStart(filename);
     checkValidationOnChangePause(filename);
   }, []);
@@ -195,7 +196,7 @@ const AlertmanagerConfigEditor = (props: AlertmanagerConfigEditorProps) => {
         <YamlEditor
           filename={`${tenant.name}-alertmanager-config.yaml`}
           jsonSchema={jsonSchema}
-          data={dataRef.current}
+          data={alertmanager?.config || ""} // using this to initially seed the editor as don't want it to re-render each time we update dataRef based on user typing - it sends their cursor back to the start of the file
           onChange={handleChange}
         />
       </Box>


### PR DESCRIPTION
The are two independent fixes in this PR:

1. Recent changes removing alertmanager template editing also ment those templates were not being included when saving configuration changes, what was resulting in a server side validation error. This fix simply includes the default set of templates when saving which is the same as the prior behaviour if the user didn't edit the templates.

2. As the user was updating the alertmanager configuration validation checks were performed to dynamically enable/disable the "save" button but those changes were not additionally being kept for use when the "save" button was clicked. This change now keeps the user's changes in `dataRef`. FYI: the underlying issue here is that we can't directly query the monaco editor for it's current value when the user hits save so we have to constantly record it as the user types.


