### PR TITLE
Show tenant overview page and cluster health

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out
 .cache
 .build
 .log
+telepresence.log
 yarn-error.log
 id.jwt
 access.jwt

--- a/packages/app/src/client/app.tsx
+++ b/packages/app/src/client/app.tsx
@@ -19,7 +19,15 @@ import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Switch, Route, Redirect, useRouteMatch } from "react-router";
 
-import { Zap, Grid, BarChart2, Bell, Users, Layers } from "react-feather";
+import {
+  Zap,
+  Grid,
+  BarChart2,
+  Bell,
+  Users,
+  Layers,
+  Activity
+} from "react-feather";
 
 import WithAuthentication from "client/components/withAuthentication";
 import ErrorBoundary from "client/components/Error/Boundary";
@@ -42,6 +50,7 @@ import TenantAlerting from "client/views/alerting";
 import LoginView from "client/views/login";
 import HelpDialog from "client/views/help";
 import NotFound from "client/views/404/404";
+import ClusterOverview from "./views/cluster-overview";
 import UsersTable from "client/views/users/list";
 import TenantsTable from "client/views/tenants/list";
 
@@ -130,6 +139,11 @@ const AuthProtectedApplication = () => {
         ]}
         clusterNavItems={[
           {
+            title: "Health",
+            icon: <Activity />,
+            path: `/cluster/health`
+          },
+          {
             title: "Users",
             icon: <Users />,
             path: `/cluster/users`
@@ -204,6 +218,12 @@ const AuthProtectedApplication = () => {
               key="tenant-cloud-metrics"
               path="/tenant/:tenantId/cloud-metrics"
               component={CloudMetrics}
+            />
+            <Route
+              exact
+              key="cluster-health"
+              path="/cluster/health"
+              component={ClusterOverview}
             />
             <Route
               exact

--- a/packages/app/src/client/views/cluster-overview/index.tsx
+++ b/packages/app/src/client/views/cluster-overview/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import Grid from "@material-ui/core/Grid";
+
+import { Box } from "client/components/Box";
+import Typography from "client/components/Typography/Typography";
+import { useTheme } from "@material-ui/core/styles";
+
+const ClusterOverview = () => {
+  const theme = useTheme();
+
+  return (
+    <>
+      <Box pt={1} pb={4}>
+        <Typography variant="h1">Cluster Health</Typography>
+      </Box>
+
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <Box
+            border={`1px solid ${theme.palette.divider}`}
+            borderRadius={theme.shape.borderRadius}
+            overflow="hidden"
+          >
+            <iframe
+              width="100%"
+              height={1550}
+              style={{ border: "none" }}
+              title="Cluster Health"
+              src={`${window.location.protocol}//system.${window.location.host}/grafana/d/3e97d1d02672cdd0861f4c97c64f89b2/use-method-cluster?orgId=1&refresh=10s&kiosk`}
+            />
+          </Box>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export default ClusterOverview;

--- a/packages/app/src/client/views/overview/index.tsx
+++ b/packages/app/src/client/views/overview/index.tsx
@@ -76,8 +76,8 @@ const TenantOverview = () => {
               width="100%"
               height={1000}
               style={{ border: "none" }}
-              title="Opstrace Module Sandbox"
-              src={`${window.location.protocol}//${tenant.name}.${window.location.host}/grafana/d/GqFJrOxGk/opstrace-overview-dashboard?orgId=1&refresh=30s&kiosk`}
+              title="Tenant Overview"
+              src={`${window.location.protocol}//system.${window.location.host}/grafana/d/GqFJrOxGk/opstrace-overview-dashboard?orgId=1&refresh=30s&kiosk`}
             />
           </Box>
         </Grid>

--- a/packages/app/src/client/views/overview/index.tsx
+++ b/packages/app/src/client/views/overview/index.tsx
@@ -22,9 +22,11 @@ import { Card, CardContent, CardHeader } from "client/components/Card";
 import Typography from "client/components/Typography/Typography";
 import { useSelectedTenant } from "state/tenant/hooks/useTenant";
 import { ExternalLink } from "client/components/Link";
+import { useTheme } from "@material-ui/core/styles";
 
 const TenantOverview = () => {
   const tenant = useSelectedTenant();
+  const theme = useTheme();
 
   if (!tenant) {
     return null;
@@ -35,6 +37,7 @@ const TenantOverview = () => {
       <Box pt={1} pb={4}>
         <Typography variant="h1">Overview</Typography>
       </Box>
+
       <Grid container spacing={3}>
         <Grid item xs={12}>
           <Card>
@@ -62,6 +65,21 @@ const TenantOverview = () => {
               </Grid>
             </CardContent>
           </Card>
+        </Grid>
+        <Grid item xs={12}>
+          <Box
+            border={`1px solid ${theme.palette.divider}`}
+            borderRadius={theme.shape.borderRadius}
+            overflow="hidden"
+          >
+            <iframe
+              width="100%"
+              height={1000}
+              style={{ border: "none" }}
+              title="Opstrace Module Sandbox"
+              src={`${window.location.protocol}//${tenant.name}.${window.location.host}/grafana/d/GqFJrOxGk/opstrace-overview-dashboard?orgId=1&refresh=30s&kiosk`}
+            />
+          </Box>
         </Grid>
       </Grid>
     </>

--- a/packages/controller/src/resources/monitoring/tenants/grafana.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafana.ts
@@ -231,6 +231,14 @@ export function GrafanaResources(
                   resources: {},
                   env: [
                     {
+                      name: "GF_USERS_DEFAULT_THEME",
+                      value: "light"
+                    },
+                    {
+                      name: "GF_SECURITY_ALLOW_EMBEDDING",
+                      value: "true"
+                    },
+                    {
                       name: "GF_LOG_LEVEL",
                       value: "debug"
                     },


### PR DESCRIPTION
**Cluster health:**
<img width="1502" alt="Screen Shot 2021-05-11 at 7 15 16 PM" src="https://user-images.githubusercontent.com/465022/117908904-245b5e80-b28e-11eb-8a38-1fb391aebe31.png">

The "opstrace overview" dashboard is temporarily used for the following tenant overview. Dedicated tenant overview dashboard coming soon.

**Tenant overview:**
<img width="1500" alt="Screen Shot 2021-05-11 at 6 23 11 PM" src="https://user-images.githubusercontent.com/465022/117905305-d6435c80-b287-11eb-985c-f2cb44a81072.png">




