### PR TITLE
Sync Opstrace user's preferences (darkmode) to all Grafana instances across user's tenants

### DIFF
--- a/packages/app/src/client/components/Grafana/Iframe.tsx
+++ b/packages/app/src/client/components/Grafana/Iframe.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useEffect, useRef } from "react";
+import { entries } from "lodash";
+import { useTheme } from "@material-ui/core/styles";
+
+import { Box } from "client/components/Box";
+
+export type GrafanaIframeProps = {
+  // e.g. /d/3e97d1d02672cdd0861f4c97c64f89b2/use-method-cluster
+  path: string;
+  initialHeight: number;
+  params?: { [key: string]: string | number };
+  tenant?: string;
+  title?: string;
+};
+
+const GrafanaIframe = (props: GrafanaIframeProps) => {
+  const theme = useTheme();
+  const [height] = useState(props.initialHeight);
+  const frame = useRef<HTMLIFrameElement | null>(null);
+  const [reloadTrigger, setReloadTrigger] = useState(1);
+
+  useEffect(() => {
+    if (theme.palette.type && frame.current) {
+      setReloadTrigger(reloadTrigger + 1);
+    }
+  }, [theme.palette.type]);
+
+  let queryParams = {
+    orgId: 1,
+    refresh: "10s"
+  };
+  if (props.params) {
+    // delete key if it exists so we can control how its added
+    if (props.params.kiosk) {
+      delete props.params.kiosk;
+    }
+    queryParams = { ...queryParams, ...props.params };
+  }
+
+  const queryString = entries(queryParams).reduce((query, [key, val]) => {
+    return `${query}&${key}=${val}`;
+  }, "kiosk");
+
+  return (
+    <Box
+      border={`1px solid ${theme.palette.divider}`}
+      borderRadius={theme.shape.borderRadius}
+      overflow="hidden"
+      width="100%"
+    >
+      <iframe
+        key={`${reloadTrigger}`}
+        ref={frame}
+        width="100%"
+        height={height}
+        style={{ border: "none" }}
+        title={props.title || "Opstrace"}
+        src={`${window.location.protocol}//${props.tenant || "system"}.${
+          window.location.host
+        }/grafana${props.path}?${queryString}`}
+      />
+    </Box>
+  );
+};
+
+export default GrafanaIframe;

--- a/packages/app/src/client/themes/Provider.tsx
+++ b/packages/app/src/client/themes/Provider.tsx
@@ -33,7 +33,7 @@ import lightTheme from "./light";
 import { ITheme } from "./types";
 import { useCommandService } from "../services/Command";
 import { useDispatch } from "state/provider";
-import { setDarkMode } from "state/user/actions";
+import { requestSetDarkMode } from "state/user/actions";
 import useCurrentUser from "state/user/hooks/useCurrentUser";
 
 interface Props {
@@ -100,7 +100,7 @@ export function ThemeCommands({ children }: { children: React.ReactNode }) {
 
   const setDarkModePreference = useCallback(
     (darkMode: boolean) => {
-      dispatch(setDarkMode(darkMode));
+      dispatch(requestSetDarkMode(darkMode));
     },
     [dispatch]
   );

--- a/packages/app/src/client/views/cluster-overview/index.tsx
+++ b/packages/app/src/client/views/cluster-overview/index.tsx
@@ -19,11 +19,9 @@ import Grid from "@material-ui/core/Grid";
 
 import { Box } from "client/components/Box";
 import Typography from "client/components/Typography/Typography";
-import { useTheme } from "@material-ui/core/styles";
+import GrafanaIframe from "client/components/Grafana/Iframe";
 
 const ClusterOverview = () => {
-  const theme = useTheme();
-
   return (
     <>
       <Box pt={1} pb={4}>
@@ -32,19 +30,12 @@ const ClusterOverview = () => {
 
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Box
-            border={`1px solid ${theme.palette.divider}`}
-            borderRadius={theme.shape.borderRadius}
-            overflow="hidden"
-          >
-            <iframe
-              width="100%"
-              height={1550}
-              style={{ border: "none" }}
-              title="Cluster Health"
-              src={`${window.location.protocol}//system.${window.location.host}/grafana/d/3e97d1d02672cdd0861f4c97c64f89b2/use-method-cluster?orgId=1&refresh=10s&kiosk`}
-            />
-          </Box>
+          <GrafanaIframe
+            initialHeight={1550}
+            tenant="system"
+            title="Cluster Health"
+            path="/d/3e97d1d02672cdd0861f4c97c64f89b2/use-method-cluster"
+          />
         </Grid>
       </Grid>
     </>

--- a/packages/app/src/client/views/overview/index.tsx
+++ b/packages/app/src/client/views/overview/index.tsx
@@ -22,11 +22,10 @@ import { Card, CardContent, CardHeader } from "client/components/Card";
 import Typography from "client/components/Typography/Typography";
 import { useSelectedTenant } from "state/tenant/hooks/useTenant";
 import { ExternalLink } from "client/components/Link";
-import { useTheme } from "@material-ui/core/styles";
+import GrafanaIframe from "client/components/Grafana/Iframe";
 
 const TenantOverview = () => {
   const tenant = useSelectedTenant();
-  const theme = useTheme();
 
   if (!tenant) {
     return null;
@@ -67,19 +66,15 @@ const TenantOverview = () => {
           </Card>
         </Grid>
         <Grid item xs={12}>
-          <Box
-            border={`1px solid ${theme.palette.divider}`}
-            borderRadius={theme.shape.borderRadius}
-            overflow="hidden"
-          >
-            <iframe
-              width="100%"
-              height={1000}
-              style={{ border: "none" }}
-              title="Tenant Overview"
-              src={`${window.location.protocol}//system.${window.location.host}/grafana/d/GqFJrOxGk/opstrace-overview-dashboard?orgId=1&refresh=30s&kiosk`}
-            />
-          </Box>
+          <GrafanaIframe
+            initialHeight={1550}
+            tenant="system"
+            title="Tenant Overview"
+            path="/d/c72shqQZz/cortex-overview"
+            params={{
+              "var-tenant": tenant.name
+            }}
+          />
         </Grid>
       </Grid>
     </>

--- a/packages/app/src/state/tenant/hooks/useTenantList.ts
+++ b/packages/app/src/state/tenant/hooks/useTenantList.ts
@@ -24,7 +24,7 @@ import {
 } from "state/tenant/actions";
 import getSubscriptionID from "state/utils/getSubscriptionID";
 
-const selectTenantList = createSelector(
+export const selectTenantList = createSelector(
   (state: State) => state.tenants.loading,
   (state: State) => state.tenants.tenants,
   (loading, tenants) => (loading ? [] : values(tenants))

--- a/packages/app/src/state/user/actions.ts
+++ b/packages/app/src/state/user/actions.ts
@@ -17,15 +17,19 @@ import { createAction } from "typesafe-actions";
 import { SubscriptionID, Users } from "./types";
 
 export const setCurrentUser = createAction("SET_CURRENT_USER")<string>();
+
+export const requestSetDarkMode = createAction(
+  "REQUEST_SET_DARK_MODE"
+)<boolean>();
 export const setDarkMode = createAction("SET_DARK_MODE")<boolean>();
 
-export const subscribeToUserList = createAction("SUBSCRIBE_USER_LIST")<
-  SubscriptionID
->();
+export const subscribeToUserList = createAction(
+  "SUBSCRIBE_USER_LIST"
+)<SubscriptionID>();
 
-export const unsubscribeFromUserList = createAction("UNSUBSCRIBE_USER_LIST")<
-  SubscriptionID
->();
+export const unsubscribeFromUserList = createAction(
+  "UNSUBSCRIBE_USER_LIST"
+)<SubscriptionID>();
 export const setUserList = createAction("SET_USER_LIST")<Users>();
 export const deleteUser = createAction("DELETE_USER")<string>();
 export const addUser = createAction("ADD_USER")<string>();

--- a/packages/controller/src/resources/ingress/index.ts
+++ b/packages/controller/src/resources/ingress/index.ts
@@ -81,7 +81,8 @@ export function IngressResources(
               // WARNING: Don't forget the trailing semicolon or else routes will silently fail.
               "nginx.ingress.kubernetes.io/configuration-snippet": ` more_set_input_headers "X-Scope-OrgID: ${tenant.name}";`,
               "nginx.ingress.kubernetes.io/cors-allow-credentials": "true",
-              "nginx.ingress.kubernetes.io/cors-allow-methods": "GET, OPTIONS",
+              "nginx.ingress.kubernetes.io/cors-allow-methods":
+                "GET, OPTIONS, PUT, POST, DELETE",
               "nginx.ingress.kubernetes.io/cors-allow-origin": `https://${domain}`,
               "nginx.ingress.kubernetes.io/enable-cors": "true"
             }


### PR DESCRIPTION
Setting darkmode is now applied cluster-wide for a user, meaning it's applied to the Opstrace UI and all Grafana instances the user has access to.

https://www.loom.com/share/cf8de1e6c6064cdea8e8143d0aed6302
