### PR TITLE
ui: specify correct "kind" value for K8sMetrics I9n definition

### DIFF
--- a/packages/app/src/client/viewsBasic/integrationDefs/k8sMetrics/index.tsx
+++ b/packages/app/src/client/viewsBasic/integrationDefs/k8sMetrics/index.tsx
@@ -23,7 +23,7 @@ import K8sMetricsLogo from "./Logo.png";
 import { IntegrationDef } from "client/viewsBasic/integrationDefs/types";
 
 export const k8sMetricsIntegration: IntegrationDef = {
-  kind: "k8s-logs",
+  kind: "k8s-metrics",
   category: "infrastructure",
   label: "Kubernetes Metrics",
   desc:

--- a/packages/app/src/client/viewsBasic/tenantIntegrations/Add.tsx
+++ b/packages/app/src/client/viewsBasic/tenantIntegrations/Add.tsx
@@ -47,7 +47,7 @@ export const AddIntegration = withTenantFromParams(
       graphqlClient
         .InsertIntegration({
           name: data.name,
-          kind: "k8s-metrics",
+          kind: kind,
           status: "active",
           data: data.data || {},
           tenant_id: tenant.id


### PR DESCRIPTION
And stop harding coding to it when creating an I9n

This fixes a 404 being seen when looking at "show" page for k8s-metrics integrations