### PR TITLE
Fix bug that prevents the dashboards from showing on the Tenant Overview and Cluster Health pages

### DIFF
--- a/packages/app/src/client/components/Grafana/Iframe.tsx
+++ b/packages/app/src/client/components/Grafana/Iframe.tsx
@@ -39,7 +39,8 @@ const GrafanaIframe = (props: GrafanaIframeProps) => {
     if (theme.palette.type && frame.current) {
       setReloadTrigger(reloadTrigger + 1);
     }
-  }, [theme.palette.type, reloadTrigger]);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [theme.palette.type]); // do not add reloadTrigger as a dependency (will cause infinite loop if it is)
 
   let queryParams = {
     orgId: 1,


### PR DESCRIPTION
Fixes a bug that recently found its way into main, that prevents the dashboards from showing on the Tenant Overview and Cluster Health pages.

Integration test coming in a follow up PR.
