### PR TITLE
ci: retry teardown in AWS region if initial command failed

### DIFF
--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -125,6 +125,18 @@ teardown() {
     if [[ "${OPSTRACE_CLOUD_PROVIDER}" == "aws" ]]; then
         ./build/bin/opstrace destroy aws ${OPSTRACE_CLUSTER_NAME} --log-level=debug --yes
         EXITCODE_DESTROY=$?
+
+        # The destroy command searches for the cluster in all the available AWS
+        # regions and sometimes it can timeout and fail to cleanup resources
+        # properly.
+        if [[ "${EXITCODE_DESTROY}" -ne 0 ]]; then
+            echo "--- initial destroy failed, retrying..."
+            ./build/bin/opstrace destroy aws ${OPSTRACE_CLUSTER_NAME} \
+                --region=${AWS_CLI_REGION} \
+                --log-level=debug \
+                --yes
+        fi
+
     else
         ./build/bin/opstrace destroy gcp ${OPSTRACE_CLUSTER_NAME} --log-level=debug --yes
         EXITCODE_DESTROY=$?

--- a/ci/test-upgrade/teardown.sh
+++ b/ci/test-upgrade/teardown.sh
@@ -4,5 +4,6 @@ set -eou pipefail
 
 echo "--- tearing down cluster"
 ./to/opstrace destroy ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} \
+    --region=${AWS_CLI_REGION} \
     --log-level=debug\
     --yes

--- a/ci/test-upgrade/upgrade-cluster.sh
+++ b/ci/test-upgrade/upgrade-cluster.sh
@@ -9,7 +9,8 @@ source ci/utils.sh
 # into the cluster and wait until deployments are 'ready'.
 echo "--- upgrading cluster"
 ./to/opstrace upgrade ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} \
-    --cluster-config ci/cluster-config.yaml \
+    --region=${AWS_CLI_REGION} \
+    --cluster-config=ci/cluster-config.yaml \
     --log-level=debug \
     --yes
 


### PR DESCRIPTION
The destroy command searches for the cluster in all the available AWS regions and sometimes it can timeout and fail to cleanup resources. We don't return an error code to signal this timeout error so the workaround is to retry the teardown in the known region when the initial command fails. The CI run will fail to signal the initial teardown error to ensure we look at the failure.
 
The upgrade test and command share the same issue so I just hardcoded the region to prevent any more resource leakage. 

