### PR TITLE
ui: removing accidentially commited migrations that were breaking upgrading a cluster with defined integrations

### DIFF
--- a/packages/app/migrations/1621731892198_alter_table_public_integration_add_column_tenant_name/down.sql
+++ b/packages/app/migrations/1621731892198_alter_table_public_integration_add_column_tenant_name/down.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "public"."integration" DROP COLUMN "tenant_name";

--- a/packages/app/migrations/1621731892198_alter_table_public_integration_add_column_tenant_name/up.sql
+++ b/packages/app/migrations/1621731892198_alter_table_public_integration_add_column_tenant_name/up.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "public"."integration" ADD COLUMN "tenant_name" text NOT NULL;

--- a/packages/app/migrations/1621731969932_alter_table_public_integration_drop_column_tenant_name/down.sql
+++ b/packages/app/migrations/1621731969932_alter_table_public_integration_drop_column_tenant_name/down.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "public"."integration" ADD COLUMN "tenant_name" text;
-ALTER TABLE "public"."integration" ALTER COLUMN "tenant_name" DROP NOT NULL;

--- a/packages/app/migrations/1621731969932_alter_table_public_integration_drop_column_tenant_name/up.sql
+++ b/packages/app/migrations/1621731969932_alter_table_public_integration_drop_column_tenant_name/up.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "public"."integration" DROP COLUMN "tenant_name" CASCADE;


### PR DESCRIPTION
Recently migrations that added then removed the `tenant_name` field on the `integrations` table were accidently commited. These have caused a problem as the migration adding the `tenant_name` field has it set as `NOT NULL` but doesn't do anything towards migrating existing records in the `integrations` table meaning the migration fails when run against a populated table.

This leaves the `graphql` pod in a crash loop, the following error is logged:

```
time="2021-05-25T04:44:53Z" level=fatal msg="apply failed: [postgres-error] query execution failed ($.args[12].args)\r\nFile: '1621731892198_alter_table_public_integration_add_column_tenant_name/up.sql'\r\n{\n    \"check_metadata_consistency\": false,\n    \"sql\": \"ALTER TABLE \\\"public\\\".\\\"integration\\\" ADD COLUMN \\\"tenant_name\\\" text NOT NULL;\\n\"\n}\r\n[23502] FatalError: column \"tenant_name\" contains null values"
```

This PR simply deletes those migration as they are not needed.