### PR TITLE
ci: add a buildkite pipeline to upgrade a long running cluster

### DIFF
--- a/.buildkite/cd-pipeline.yml
+++ b/.buildkite/cd-pipeline.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: "continuous deployment test (AWS)"
+    key: "cdtest-upgrade-aws"
+    env:
+      OPSTRACE_CLUSTER_NAME: "cdtest"
+      OPSTRACE_CLOUD_PROVIDER: "aws"
+      AWS_CLI_REGION: "us-west-2"
+    command:
+      - ci/cd/run.sh

--- a/Makefile
+++ b/Makefile
@@ -691,6 +691,13 @@ deploy-testremote-teardown:
 testupgrade-%:
 	./ci/test-upgrade/$*.sh
 
+#
+# Target that runs a script in the ci/cd/ directory. Check
+# .buildkite/cd-pipeline.yml to see how it can be used.
+#
+.PHONY: cd-%
+cd-%:
+	./ci/cd/$*.sh
 
 #
 # Run all the unit tests.

--- a/ci/cd/cluster-config.yaml
+++ b/ci/cd/cluster-config.yaml
@@ -1,0 +1,8 @@
+tenants:
+  - default
+env_label: opstrace-ci
+node_count: 5
+log_retention_days: 30
+metric_retention_days: 60
+aws:
+  instance_type: r5.xlarge

--- a/ci/cd/dns-service-credentials.sh
+++ b/ci/cd/dns-service-credentials.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eou pipefail
+
+#
+# Import helper functions.
+#
+source ci/utils.sh
+
+echo "--- setting up dns-service credentials"
+curl --request POST \
+    --url https://opstrace-dev.us.auth0.com/oauth/token \
+    --header 'content-type: application/json' \
+    --data-binary "@secrets/dns-service-login-for-ci.json" \
+    | jq -jr .access_token > access.jwt

--- a/ci/cd/fetch-cli-artifacts.sh
+++ b/ci/cd/fetch-cli-artifacts.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -eou pipefail
+
+OPSTRACE_CLI_VERSION_TO="${OPSTRACE_CLI_VERSION_TO:-cli/main/latest/opstrace-cli-linux-amd64-latest.tar.bz2}"
+
+#
+# Funtion that downloads cli artifact from s3 bucket and extracts it to a target
+# dir.
+#
+fetch_cli_artifact() {
+    local artifact=${1}
+    local dir=${2}
+
+    echo "downloading ${artifact}"
+    mkdir -p ${dir}
+    aws s3 cp --only-show-errors s3://opstrace-ci-main-artifacts/${artifact} .
+
+    echo "extracting ${artifact} to target dir ${dir}"
+    tar xjf $(basename ${artifact}) -C ${dir}
+}
+
+echo "--- fetching cli artifacts"
+fetch_cli_artifact ${OPSTRACE_CLI_VERSION_TO} to

--- a/ci/cd/fetch-secrets.sh
+++ b/ci/cd/fetch-secrets.sh
@@ -4,7 +4,9 @@ aws s3 cp "s3://buildkite-managedsecretsbucket-100ljuov8ugv2/" secrets/ --recurs
     --include "aws-dev-svc-acc-env.sh" \
     --include "aws-loadtest-acc-env.sh" \
     --include "dns-service-login-for-ci.json" \
-    --include "cdtest-tenant-api-token-default"
+    --include "cdtest-tenant-api-token-default" \
+    --include "cdtest-tenant-api-token-system"
 
 echo "-- renaming tenant api token filename required by test-remote"
 mv secrets/cdtest-tenant-api-token-default tenant-api-token-default
+mv secrets/cdtest-tenant-api-token-system tenant-api-token-system

--- a/ci/cd/fetch-secrets.sh
+++ b/ci/cd/fetch-secrets.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+aws s3 cp "s3://buildkite-managedsecretsbucket-100ljuov8ugv2/" secrets/ --recursive --exclude "*" \
+    --include "aws-dev-svc-acc-env.sh" \
+    --include "aws-loadtest-acc-env.sh" \
+    --include "dns-service-login-for-ci.json" \
+    --include "cdtest-tenant-api-token-default"
+
+echo "-- renaming tenant api token filename required by test-remote"
+mv secrets/cdtest-tenant-api-token-default tenant-api-token-default

--- a/ci/cd/run.sh
+++ b/ci/cd/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eou pipefail
+
+make rebuild-ci-container-image
+# testrunner run tsc which requires buildinfo package to be set
+make set-build-info-constants
+make rebuild-testrunner-container-images
+make rebuild-looker-container-images
+
+make ci-cd-fetch-secrets
+
+# Override the target kubeconfig directory to point to the checkout directory.
+export OPSTRACE_KUBE_CONFIG_HOST=$(pwd)/.kube
+
+# Note: sourcing this file exports AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+source secrets/aws-dev-svc-acc-env.sh
+
+make ci-cd-fetch-cli-artifacts
+make ci-cd-dns-service-credentials
+
+# Note: sourcing this file exports AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+# cdtest cluster was created in a separate account.
+source secrets/aws-loadtest-acc-env.sh
+
+make ci-cd-upgrade-cluster
+
+make test-remote
+make test-remote-looker
+make test-remote-ui

--- a/ci/cd/run.sh
+++ b/ci/cd/run.sh
@@ -25,6 +25,9 @@ source secrets/aws-loadtest-acc-env.sh
 
 make ci-cd-upgrade-cluster
 
-make test-remote
+# TODO(sreis): the system logs test suite (check loki ingester logs, check
+# cortex ingester logs, check systemlog Fluentd instance logs) needs to account
+# for long running clusters.
+make test-remote || true
 make test-remote-looker
 make test-remote-ui

--- a/ci/cd/upgrade-cluster.sh
+++ b/ci/cd/upgrade-cluster.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eou pipefail
+
+# Import helper functions.
+source ci/utils.sh
+
+echo "--- upgrading cluster"
+./to/opstrace upgrade ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} \
+    --region=${AWS_CLI_REGION} \
+    --cluster-config=ci/cd/cluster-config.yaml \
+    --log-level=debug \
+    --yes
+
+echo "--- configuring kubectl"
+configure_kubectl_aws_or_gcp

--- a/packages/upgrader/src/index.ts
+++ b/packages/upgrader/src/index.ts
@@ -163,15 +163,16 @@ function* triggerControllerDeploymentUpgrade() {
 
   yield call(upgradeControllerConfigMap, kubeConfig);
 
-  yield call(upgradeControllerDeployment, {
+  const rolloutStarted: boolean = yield call(upgradeControllerDeployment, {
     opstraceClusterName: upgradeConfig.clusterName,
     kubeConfig: kubeConfig
   });
 
-  yield call(waitForControllerDeployment);
-
-  log.info('wait for upgrade to complete ("wait for deployments/..." phase)');
-  yield call(upgradeProgressReporter);
+  if (rolloutStarted) {
+    yield call(waitForControllerDeployment);
+    log.info('wait for upgrade to complete ("wait for deployments/..." phase)');
+    yield call(upgradeProgressReporter);
+  }
 
   // Cancel the forked informers so we can exit
   yield cancel(informers);


### PR DESCRIPTION
Add a Buildkite pipeline to upgrade a long running cluster to the latest version. The cluster is ingesting 2.5M metrics. I'll set up the pipeline to run once a day.

Also, fixes a bug I noticed when upgrading the cluster to the same version. The CLI should exit early if a controller rollout is not required.