### PR TITLE
ci(upgrades): fetch artifacts from full s3 resource uri

### DIFF
--- a/ci/test-upgrade/fetch-cli-artifacts.sh
+++ b/ci/test-upgrade/fetch-cli-artifacts.sh
@@ -15,16 +15,6 @@ then
 fi
 
 #
-# Initial cluster install version.
-#
-FROM=cli/main/${OPSTRACE_CLI_VERSION_FROM}/opstrace-cli-linux-amd64-${OPSTRACE_CLI_VERSION_FROM}.tar.bz2
-
-#
-# Upgrade the cluster to this version.
-#
-TO=cli/main/${OPSTRACE_CLI_VERSION_TO}/opstrace-cli-linux-amd64-${OPSTRACE_CLI_VERSION_TO}.tar.bz2
-
-#
 # Funtion that downloads cli artifact from s3 bucket and extracts it to a target
 # dir.
 #
@@ -41,5 +31,5 @@ fetch_cli_artifact() {
 }
 
 echo "--- fetching cli artifacts"
-fetch_cli_artifact ${FROM} from
-fetch_cli_artifact ${TO} to
+fetch_cli_artifact ${OPSTRACE_CLI_VERSION_FROM} from
+fetch_cli_artifact ${OPSTRACE_CLI_VERSION_TO} to


### PR DESCRIPTION
Makes it easier to test upgrades for CLIs built from PRs.

You can create a Buildkite build with the following env vars to choose which artifacts will be used in the test.
```
# Initial cluster install version
OPSTRACE_CLI_VERSION_FROM=cli/main/6cb91909-ci/opstrace-cli-linux-amd64-6cb91909-ci.tar.bz2
# Upgrade the cluster to this version.
OPSTRACE_CLI_VERSION_TO=cli/main/latest/opstrace-cli-linux-amd64-latest.tar.bz2
```

Close #738