### PR TITLE
ui(test-remote): add test case for ring health

### DIFF
--- a/test/test-remote/test_ui.ts
+++ b/test/test-remote/test_ui.ts
@@ -363,4 +363,27 @@ suite("test_ui_with_headless_browser", function () {
       await sleep(10);
     }
   });
+
+  test("view_ring_health", async function () {
+    // Same consideration as above: this test is here in this module for now
+    // just because it's easy to use the authentication state after actual
+    // UI-based login.
+    assert(COOKIES_AFTER_LOGIN, "Auth cookies are present");
+    const page = await BROWSER.contexts()[0].newPage();
+    await page.goto(CLUSTER_BASE_URL);
+    await page.waitForNavigation();
+
+    await page.click("text=Health");
+    await page.click("text=Metrics");
+    assert(await page.isVisible("text=Cortex Ring Health"), "page loaded");
+
+    for (const tabName of ["Ingester", "Ruler", "Compactor", "Store-gateway"]) {
+      await page.click(`text=${tabName}`);
+      page.waitForSelector(`css=tab >> text=${tabName} [aria-selected="true"]`);
+      assert(
+        await page.waitForSelector("text=less than a minute ago"),
+        `Loading ${tabName} table`
+      );
+    }
+  });
 });


### PR DESCRIPTION
Adding E2E tests for ring health. 

- Navigates to the health metrics, opens each tab (`Ingester`, `Ruler`, etc), and checks if the table loads.
- It assumes that when at least one row with valid content for the "Last heartbeat" cell is rendered, that the table loaded correctly, and the test passes.
- Excluding Alert Manager for the moment, as there is a problem that prevents it from working right now, see [here](https://opstrace-community.slack.com/archives/C01KZS8JRNC/p1623664061091000).

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [x] Written new tests for your changes?
* [x] Thought about which docs need updating?
