### PR TITLE
ui: fix - integration.key should be unique per tenant, not per cluster

### DIFF
--- a/go/pkg/graphql/client_generated.go
+++ b/go/pkg/graphql/client_generated.go
@@ -1644,7 +1644,7 @@ const (
 type IntegrationConstraint string
 
 const (
-	IntegrationConstraintIntegrationKeyKey           IntegrationConstraint = "integration_key_key"
+	IntegrationConstraintIntegrationKeyTenantIdKey   IntegrationConstraint = "integration_key_tenant_id_key"
 	IntegrationConstraintIntegrationsNameTenantIdKey IntegrationConstraint = "integrations_name_tenant_id_key"
 	IntegrationConstraintIntegrationsPkey            IntegrationConstraint = "integrations_pkey"
 )

--- a/packages/app/migrations/1622501245248_alter_table_public_integration_add_unique_key_tenant_id/down.sql
+++ b/packages/app/migrations/1622501245248_alter_table_public_integration_add_unique_key_tenant_id/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."integration" drop constraint "integration_key_tenant_id_key";
+alter table "public"."integration" add constraint "integration_key_key" unique ("key");

--- a/packages/app/migrations/1622501245248_alter_table_public_integration_add_unique_key_tenant_id/up.sql
+++ b/packages/app/migrations/1622501245248_alter_table_public_integration_add_unique_key_tenant_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."integration" drop constraint "integration_key_key";
+alter table "public"."integration" add constraint "integration_key_tenant_id_key" unique ("key", "tenant_id");

--- a/packages/app/src/state/graphql-api-types.ts
+++ b/packages/app/src/state/graphql-api-types.ts
@@ -197,7 +197,7 @@ export type Integration_Bool_Exp = {
 /** unique or primary key constraints on table "integration" */
 export enum Integration_Constraint {
   /** unique or primary key constraint */
-  IntegrationKeyKey = "integration_key_key",
+  IntegrationKeyTenantIdKey = "integration_key_tenant_id_key",
   /** unique or primary key constraint */
   IntegrationsNameTenantIdKey = "integrations_name_tenant_id_key",
   /** unique or primary key constraint */

--- a/packages/controller/src/dbSDK.ts
+++ b/packages/controller/src/dbSDK.ts
@@ -197,7 +197,7 @@ export type Integration_Bool_Exp = {
 /** unique or primary key constraints on table "integration" */
 export enum Integration_Constraint {
   /** unique or primary key constraint */
-  IntegrationKeyKey = "integration_key_key",
+  IntegrationKeyTenantIdKey = "integration_key_tenant_id_key",
   /** unique or primary key constraint */
   IntegrationsNameTenantIdKey = "integrations_name_tenant_id_key",
   /** unique or primary key constraint */


### PR DESCRIPTION
updated unique constraint on the integration table to be `key+tenant_id`
