### PR TITLE
bump: golangci-lint to v1.40.1 and increase timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ lint-codebase.js:
 
 lint-codebase.go:
 	# Also see https://github.com/opstrace/opstrace/issues/166
-	(cd go/ && golangci-lint run --allow-parallel-runners)
+	(cd go/ && golangci-lint run --timeout 3m --allow-parallel-runners)
 
 .PHONY: cli-tsc
 cli-tsc: set-build-info-constants

--- a/containers/ci/opstrace-ci.Dockerfile
+++ b/containers/ci/opstrace-ci.Dockerfile
@@ -89,7 +89,7 @@ ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
 
 # Set up golanglint-ci in the container image.
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-    sh -s -- -b /usr/local/bin v1.38.0
+    sh -s -- -b /usr/local/bin v1.40.1
 
 # Set up markdownlint in the container image so that we can lint right away! :)
 RUN npm install -g markdownlint-cli@0.26.0


### PR DESCRIPTION
Increase timeout to handle failures when the build agent is busy.

Close #709 
Close #166