### PR TITLE
ui: global redux actions for tenant change

### DIFF
--- a/packages/app/src/client/services/Picker/types.ts
+++ b/packages/app/src/client/services/Picker/types.ts
@@ -18,6 +18,7 @@ import { ReactNode } from "react";
 export type PickerOption = {
   id: string;
   text: string;
+  data?: any;
 };
 
 export type PickerListProps = {

--- a/packages/app/src/client/views/tenants/TenantPicker.tsx
+++ b/packages/app/src/client/views/tenants/TenantPicker.tsx
@@ -23,14 +23,17 @@ import useTenantList from "state/tenant/hooks/useTenantList";
 
 import { Tenant } from "state/tenant/types";
 
-import { clearIntegrations } from "state/integration/actions";
+import { selectedTenantChanged } from "state/global/actions";
 
 import { PickerOption, usePickerService } from "client/services/Picker";
 
-function tenantToPickerOption(tenant: Tenant): PickerOption {
+type TenantPickerOption = Pick<PickerOption, "id" | "text"> & { data: Tenant };
+
+function tenantToPickerOption(tenant: Tenant): TenantPickerOption {
   return {
     text: tenant.name,
-    id: tenant.name
+    id: tenant.name,
+    data: tenant
   };
 }
 
@@ -46,7 +49,7 @@ const TenantPicker = () => {
       activationPrefix: "tenant:",
       options: tenants ? tenants.map(tenantToPickerOption) : [],
       onSelected: option => {
-        dispatch(clearIntegrations()); // note: ideally we would dispatch a "global" action here that each reducer could respond to if required
+        dispatch(selectedTenantChanged({ tenant: option.data }));
         history.push(`/tenant/${option.id}`); // todo: would be nice to keep the current path and simply change the tenant rather than send user back to the home for the tenant
       }
     },

--- a/packages/app/src/state/global/actions.ts
+++ b/packages/app/src/state/global/actions.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createAction } from "typesafe-actions";
+
+import { Tenant } from "state/tenant/types";
+
+export const selectedTenantChanged = createAction(
+  "global/SELECTED_TENANT_CHANGED"
+)<{ tenant: Tenant }>();

--- a/packages/app/src/state/integration/reducer.ts
+++ b/packages/app/src/state/integration/reducer.ts
@@ -20,8 +20,11 @@ import { createReducer, ActionType } from "typesafe-actions";
 
 import { IntegrationRecords } from "./types";
 import * as actions from "./actions";
+import * as globalActions from "state/global/actions";
 
-type IntegrationActions = ActionType<typeof actions>;
+const allActions = mergeDeepRight(globalActions, actions);
+
+type IntegrationActions = ActionType<typeof allActions>;
 
 type IntegrationState = {
   loading: boolean;
@@ -85,7 +88,7 @@ export const reducer = createReducer<IntegrationState, IntegrationActions>(
     }
   )
   .handleAction(
-    actions.clearIntegrations,
+    globalActions.selectedTenantChanged,
     (state, action): IntegrationState => {
       return IntegrationInitialState;
     }

--- a/packages/app/src/state/integration/sagas/integrationListSubscription.ts
+++ b/packages/app/src/state/integration/sagas/integrationListSubscription.ts
@@ -102,8 +102,6 @@ export default function* integrationListSubscriptionManager() {
       // Cancel active subscription if there are no subscribers
       if (activeSubscription && subscribers.size === 0) {
         yield cancel(activeSubscription);
-        // Reset list
-        yield put(actions.updateIntegrations([]));
         activeSubscription = undefined;
       }
     }


### PR DESCRIPTION
This creates a global action which gets dispatched when the currently selected Tenant is changed by the user - any reducer can respond to it, in this case the Integration reducer resets it's state so as to not containt Integrations for the wrong Tenant