### PR TITLE
controller: Configure ingesters to not block on readiness (of other ingesters)

### DIFF
--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -1221,7 +1221,9 @@ export function CortexResources(
         spec: {
           serviceName: "ingester",
           replicas: config.ingester.replicas,
-          podManagementPolicy: "OrderedReady",
+          // Avoid circular dependency between ingester-X failing readiness checks due to ingester-Y being down.
+          // In this situation, the StatefulSet will not deploy ingester-Y if the podManagementPolicy is OrderedReady.
+          podManagementPolicy: "Parallel",
           selector: {
             matchLabels: {
               name: "ingester"


### PR DESCRIPTION
The ingester readiness check is based on the ring status of all ingesters.
As a result you can end up with e.g. ingester-1 refusing to deploy because ingester-5 is unhappy.
The StatefulSet will then refuse to deploy ingester-5 because it wants ingester-1 to be ready first.

This breaks the dependency cycle by allowing ingesters to deploy (and/or scale out) in parallel. Note that it does not affect the rollout of config changes, which will remain sequential.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
