### PR TITLE
fix(app): error log in ring health

### DIFF
--- a/packages/app/src/client/views/ring-health/RingTable.tsx
+++ b/packages/app/src/client/views/ring-health/RingTable.tsx
@@ -162,6 +162,7 @@ const RingTable = ({ ringEndpoint, baseUrl }: Props) => {
             <TableBody>
               {shards.map(shard => (
                 <RingShard
+                  key={shard.id}
                   shard={shard}
                   onForget={forgetShard}
                   baseUrl={baseUrl}

--- a/packages/app/src/client/views/ring-health/cortex/index.tsx
+++ b/packages/app/src/client/views/ring-health/cortex/index.tsx
@@ -76,27 +76,26 @@ const RingHealth = ({ baseUrl }: Props) => {
       <Box pt={1} pb={4}>
         <Typography variant="h1">Cortex Ring Health</Typography>
       </Box>
-
-      <MuiTabs
-        value={true}
-        indicatorColor="primary"
-        variant="scrollable"
-        scrollButtons="auto"
-        classes={classes}
-      >
-        {tabs.map(tab => (
-          <Tab
-            value={location.pathname.includes(tab.absolutePath)}
-            key={tab.title}
-            label={tab.title}
-            component={Link}
-            to={tab.absolutePath}
-          />
-        ))}
-      </MuiTabs>
       <Switch>
         {tabs.map(tab => (
           <Route key={tab.absolutePath} path={tab.absolutePath}>
+            <MuiTabs
+              value={true}
+              indicatorColor="primary"
+              variant="scrollable"
+              scrollButtons="auto"
+              classes={classes}
+            >
+              {tabs.map(tab => (
+                <Tab
+                  value={location.pathname.includes(tab.absolutePath)}
+                  key={tab.title}
+                  label={tab.title}
+                  component={Link}
+                  to={tab.absolutePath}
+                />
+              ))}
+            </MuiTabs>
             <Box mt={3}>
               <RingTable
                 baseUrl={tab.absolutePath}

--- a/packages/app/src/client/views/ring-health/loki/index.tsx
+++ b/packages/app/src/client/views/ring-health/loki/index.tsx
@@ -62,27 +62,26 @@ const RingHealth = ({ baseUrl }: Props) => {
       <Box pt={1} pb={4}>
         <Typography variant="h1">Loki Ring Health</Typography>
       </Box>
-
-      <MuiTabs
-        value={true}
-        indicatorColor="primary"
-        variant="scrollable"
-        scrollButtons="auto"
-        classes={classes}
-      >
-        {tabs.map(tab => (
-          <Tab
-            value={location.pathname.includes(tab.absolutePath)}
-            key={tab.title}
-            label={tab.title}
-            component={Link}
-            to={tab.absolutePath}
-          />
-        ))}
-      </MuiTabs>
       <Switch>
         {tabs.map(tab => (
           <Route key={tab.absolutePath} path={tab.absolutePath}>
+            <MuiTabs
+              value={true}
+              indicatorColor="primary"
+              variant="scrollable"
+              scrollButtons="auto"
+              classes={classes}
+            >
+              {tabs.map(tab => (
+                <Tab
+                  value={location.pathname.includes(tab.absolutePath)}
+                  key={tab.title}
+                  label={tab.title}
+                  component={Link}
+                  to={tab.absolutePath}
+                />
+              ))}
+            </MuiTabs>
             <Box mt={3}>
               <RingTable
                 baseUrl={tab.absolutePath}


### PR DESCRIPTION
Removes this warnings:
<img width="2002" alt="Screen Shot 2021-06-02 at 3 51 14 PM" src="https://user-images.githubusercontent.com/64152453/120623133-bdc9fa80-c45f-11eb-8cd5-2d27eb7ee848.png">

The tabs were already expecting values, before the routing was done. To fix this, I moved the tabs within the routes. 

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [x] Thought about which docs need updating?
