### PR TITLE
looker: work towards N streams per push request

### DIFF
--- a/test/test-remote/loki-node-client-tools/dummystream.ts
+++ b/test/test-remote/loki-node-client-tools/dummystream.ts
@@ -270,6 +270,7 @@ export class DummyStream {
     lokiBaseUrl: string,
     additionalHeaders?: Record<string, string>
   ) {
+    // For now: one HTTP request per fragment
     for (let i = 1; i <= nFragments; i++) {
       const fragment = this.generateAndGetNextFragment();
       const t0 = mtime();
@@ -282,7 +283,8 @@ export class DummyStream {
           this.uniqueName,
           genduration.toFixed(2),
           pushrequest.dataLengthMiB.toFixed(4),
-          pushrequest.fragment.entryCount()
+          // for now: assume that there is _one_ fragment here
+          pushrequest.fragments[0].entryCount()
         );
       }
       await pushrequest.postWithRetryOrError(lokiBaseUrl, 3, additionalHeaders);

--- a/test/test-remote/prom-node-client-tools/dummyseries.ts
+++ b/test/test-remote/prom-node-client-tools/dummyseries.ts
@@ -266,7 +266,8 @@ export class DummyTimeseries {
           this.uniqueName,
           genduration.toFixed(2),
           pm.dataLengthMiB.toFixed(4),
-          pm.fragment.sampleCount()
+          // intermediate state: assume / know that there is _one_ fragment here.
+          pm.fragments[0].sampleCount()
         );
       }
       await pm.postWithRetryOrError(cortexBaseUrl, 3, additionalHeaders);


### PR DESCRIPTION
```
This is an intermediate state, introducing
the concept of serializing N series fragments
into a single push request. That will greatly
enhance the flexibility and application scenarios
for looker.

Note that this is an inner architecture change,
more thinking and work required until this is
exposed to users.
```