### PR TITLE
ci(upgrades): fix invalid flag

### DIFF
--- a/ci/test-upgrade/create-cluster.sh
+++ b/ci/test-upgrade/create-cluster.sh
@@ -15,7 +15,7 @@ fi
 
 echo "--- creating cluster"
 ./from/opstrace create ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} \
-    --instance-config ci/cluster-config.yaml \
+    --cluster-config ci/cluster-config.yaml \
     --log-level=debug \
     --yes
 


### PR DESCRIPTION
The initial cluster version, 6cb91909-ci, does not recognize the `--instance-config` flag name.
