### PR TITLE
chore: update links to point to latest released CLI binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD041 -->
 <!-- markdownlint-disable MD033 -->
 
-[![Build status](https://badge.buildkite.com/df9e995b3a5e4b0bebce8b432b0bf48b092fd261b7017b65c1.svg)](https://buildkite.com/opstrace/scheduled-main-builds)
+![Build status](https://badge.buildkite.com/df9e995b3a5e4b0bebce8b432b0bf48b092fd261b7017b65c1.svg)
 [![License](https://img.shields.io/github/license/opstrace/opstrace)](https://github.com/opstrace/opstrace/blob/main/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
@@ -113,7 +113,7 @@ You can find out more on [our community page](https://opstrace.com/community), i
 
 ## Documentation
 
-You can find the Opstrace documentation in [/docs](/docs).
+You can find the Opstrace documentation in [/docs](./docs).
 We invite you to improve these docs together with us, and have a [corresponding guide](./docs/guides/contributor/writing-docs.md) for that.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ info: Log in here: https://tracy.opstrace.io
 
 # a week later...
 
-$ curl -L https://go.opstrace.com/cli-latest-macos | tar xjf -
+$ curl -L https://go.opstrace.com/cli-latest-release-macos | tar xjf -
 $ ./opstrace upgrade aws tracy -c config.yaml
 ...
 info: Opstrace cluster upgrade done for tracy (aws)

--- a/docs/guides/administrator/upgrading.md
+++ b/docs/guides/administrator/upgrading.md
@@ -41,13 +41,13 @@ Download the latest Opstrace CLI binary from S3, which you will use to upgrade O
 ### MacOS
 
 ```bash
-curl -L https://go.opstrace.com/cli-latest-macos | tar xjf -
+curl -L https://go.opstrace.com/cli-latest-release-macos | tar xjf -
 ```
 
 ### Linux
 
 ```bash
-curl -L https://go.opstrace.com/cli-latest-linux | tar xjf -
+curl -L https://go.opstrace.com/cli-latest-release-linux | tar xjf -
 ```
 
 <!-- /tabs -->

--- a/docs/guides/contributor/workflows.md
+++ b/docs/guides/contributor/workflows.md
@@ -12,13 +12,13 @@ First, download and extract the CLI:
 ### MacOS
 
 ```bash
-curl -L https://go.opstrace.com/cli-latest-macos | tar xjf -
+curl -L https://go.opstrace.com/cli-latest-release-macos | tar xjf -
 ```
 
 ### Linux
 
 ```bash
-curl -L https://go.opstrace.com/cli-latest-linux | tar xjf -
+curl -L https://go.opstrace.com/cli-latest-release-linux | tar xjf -
 ```
 
 <!-- /tabs -->

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,7 +48,7 @@ Download the latest Opstrace CLI binary from S3, which you will use to install O
 
 ```bash
 # Download the CLI from S3 and extract it
-curl -L https://go.opstrace.com/cli-latest-macos | tar xjf -
+curl -L https://go.opstrace.com/cli-latest-release-macos | tar xjf -
 
 # Test the extracted binary
 ./opstrace --help
@@ -58,7 +58,7 @@ curl -L https://go.opstrace.com/cli-latest-macos | tar xjf -
 
 ```bash
 # Download the CLI from S3 and extract it
-curl -L https://go.opstrace.com/cli-latest-linux | tar xjf -
+curl -L https://go.opstrace.com/cli-latest-release-linux | tar xjf -
 
 # Test the extracted binary
 ./opstrace --help


### PR DESCRIPTION
Now that we have proper releases — 🎉 — we should point our documentation to those binaries (instead of the latest from CI).