### PR TITLE
looker: n fragments per pushrequest dev

### DIFF
--- a/test/test-remote/logstream-gen/index.ts
+++ b/test/test-remote/logstream-gen/index.ts
@@ -257,6 +257,7 @@ function parseCmdlineArgs() {
     type: "int",
     default: 1
   });
+
   parser.add_argument("--n-chars-per-msg", {
     help: "number of characters per log message (ignored in metrics mode)",
     type: "int",
@@ -294,7 +295,9 @@ function parseCmdlineArgs() {
 
   parser.add_argument("--max-concurrent-reads", {
     help:
-      "Maximum number of GET HTTP requests to perform concurrently during the read/validation phase. Default: 0 (do as many as given by --n-concurrent-streams).",
+      "Maximum number of GET HTTP requests to perform concurrently during " +
+      "the read/validation phase. Default: 0 " +
+      "(do as many as given by --n-concurrent-streams).",
     type: "int",
     default: 0
   });
@@ -316,8 +319,8 @@ function parseCmdlineArgs() {
 
   parser.add_argument("--change-streams-every-n-cycles", {
     help:
-      "Use the same log stream for N cycles, then create a new set of " +
-      "log streams (with unique label sets)",
+      "Use the same log/metric stream for N cycles, then create a new set of " +
+      "streams (unique label sets)",
     type: "int",
     default: 1
   });
@@ -340,7 +343,7 @@ function parseCmdlineArgs() {
   stopgroup.add_argument("--stream-write-n-fragments", {
     help:
       "within a write/read cycle, stop write (and enter read phase) when " +
-      "this many fragments were written for a log stream",
+      "this many fragments were written for a log/metric stream",
     type: "int",
     default: 0
   });
@@ -363,7 +366,8 @@ function parseCmdlineArgs() {
 
   parser.add_argument("--fetch-n-entries-per-query", {
     help:
-      "Maximum number of log entries to fetch per query during read/validation phase",
+      "Maximum number of log entries to fetch per query during " +
+      "read/validation phase (honored in metric mode? TODO)",
 
     type: "int",
     default: 60000

--- a/test/test-remote/logstream-gen/index.ts
+++ b/test/test-remote/logstream-gen/index.ts
@@ -65,6 +65,7 @@ interface CfgInterface {
   n_chars_per_msg: number;
   n_entries_per_stream_fragment: number;
   n_cycles: number;
+  n_fragments_per_push_message: number;
   stream_write_n_fragments: number;
   stream_write_n_seconds: number;
   max_concurrent_writes: number;
@@ -249,6 +250,13 @@ function parseCmdlineArgs() {
     required: true
   });
 
+  parser.add_argument("--n-fragments-per-push-message", {
+    help:
+      "number of stream fragments to serialize into a single binary push message " +
+      "(HTTP POST request body), mixed from different streams. Default: 1",
+    type: "int",
+    default: 1
+  });
   parser.add_argument("--n-chars-per-msg", {
     help: "number of characters per log message (ignored in metrics mode)",
     type: "int",
@@ -866,10 +874,10 @@ export async function postFragments(
     CFG.n_concurrent_streams
   );
 
-  const N_STREAMS_PER_PUSH_REQUEST = 1;
+  //const N_STREAM_FRAGMENTS_PER_PUSH_REQUEST = 80;
   const streamChunks = chunkify<DummyStream | DummyTimeseries>(
     streams,
-    N_STREAMS_PER_PUSH_REQUEST
+    CFG.n_fragments_per_push_message
   );
 
   for (const sc of streamChunks) {

--- a/test/test-remote/loki-node-client-tools/index.ts
+++ b/test/test-remote/loki-node-client-tools/index.ts
@@ -191,6 +191,14 @@ export class LogStreamFragment {
     this.stats = stats;
   }
 
+  /**
+   * Use this to indicate that this fragment was serialized (into a binary
+   * msg) out-of-band, i..e not with the `serialize()` method.
+   */
+  public setSerialized(): void {
+    this.serialized = true;
+  }
+
   public serialize(): LogStreamFragmentPushRequest {
     this.serialized = true;
     return new LogStreamFragmentPushRequest([this]);

--- a/test/test-remote/loki-node-client-tools/index.ts
+++ b/test/test-remote/loki-node-client-tools/index.ts
@@ -393,6 +393,9 @@ export class LogStreamFragmentPushRequest {
         entries: pbentries
       });
       streamsList.push(stream);
+
+      // mark fragment as serialized, for book-keeping.
+      fragment.setSerialized();
     }
 
     const pr = pbTypePushrequest.create({ streams: streamsList });

--- a/test/test-remote/prom-node-client-tools/index.ts
+++ b/test/test-remote/prom-node-client-tools/index.ts
@@ -110,7 +110,7 @@ export class TimeseriesFragment {
       return this.stats.sampleCount * BigInt(20);
     }
 
-    log.info("NUMBER OF SAMPLES IN FRAGMENT: %s", this.samples.length);
+    //log.info("NUMBER OF SAMPLES IN FRAGMENT: %s", this.samples.length);
     return BigInt(this.samples.length) * BigInt(20);
   }
 
@@ -165,6 +165,14 @@ export class TimeseriesFragment {
     // see https://stackoverflow.com/a/1232046/145400
     this.samples.length = 0;
     this.stats = stats;
+  }
+
+  /**
+   * Use this to indicate that this fragment was serialized (into a binary
+   * msg) out-of-band, i..e not with the `serialize()` method.
+   */
+  public setSerialized(): void {
+    this.serialized = true;
   }
 
   public serialize(): TimeseriesFragmentPushMessage {
@@ -376,6 +384,9 @@ export class TimeseriesFragmentPushMessage {
       });
 
       seriesList.push(series);
+
+      // mark fragment as serialized, for book-keeping.
+      fragment.setSerialized();
     }
     const wr = pbTypeWriterequest.create({ timeseries: seriesList });
 


### PR DESCRIPTION
This further evolves the architecture towards being able to easily put N time series fragments into a single push request.
