### PR TITLE
chore: update additional user-facing text removing "cluster"

### DIFF
--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -200,9 +200,7 @@ export function timestampForFilenames(ts: ZonedDateTime): string {
  * - use what was provided via --region on cmdline
  * - error out if --region was not provided
  */
-export async function awsGetClusterRegionWithCmdlineFallback(): Promise<
-  string
-> {
+export async function awsGetClusterRegionWithCmdlineFallback(): Promise<string> {
   if (cli.CLIARGS.region !== "") {
     log.debug("region to destroy in from cli args: %s", cli.CLIARGS.region);
 
@@ -256,8 +254,8 @@ export async function awsGetClusterRegionWithCmdlineFallback(): Promise<
   //    `... destroy foo --region=eu-central-1` -> remainders are
   //    discovered and cleaned up after.
   die(
-    `No EKS cluster found for Opstrace cluster name '${cli.CLIARGS.instanceName}. ` +
-      "Assume that the Opstrace cluster does not exist (anymore). " +
+    `No EKS cluster found for Opstrace instance name '${cli.CLIARGS.instanceName}. ` +
+      "Assume that the Opstrace instance does not exist (anymore). " +
       "You can force running the requested operation in a specific AWS region " +
       "by setting the --region <region> command line parameter."
   );

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -288,7 +288,7 @@ function* createClusterCore() {
 
   if (clusterCreateConfig.holdController) {
     log.info(
-      `Not deploying controller. Raw cluster creation finished: ${ccfg.cluster_name} (${ccfg.cloud_provider})`
+      `Not deploying controller. Raw instance creation finished: ${ccfg.cluster_name} (${ccfg.cloud_provider})`
     );
     return;
   }
@@ -332,7 +332,7 @@ function* createClusterCore() {
   yield call(waitUntilUIIsReachable, ccfg.cluster_name, ccfg.tenants);
 
   log.info(
-    `cluster creation finished: ${ccfg.cluster_name} (${ccfg.cloud_provider})`
+    `create operation finished: ${ccfg.cluster_name} (${ccfg.cloud_provider})`
   );
   log.info(`Log in here: https://${ccfg.cluster_name}.opstrace.io`);
 }

--- a/packages/upgrader/src/index.ts
+++ b/packages/upgrader/src/index.ts
@@ -246,10 +246,11 @@ function* rootTaskUpgrade() {
   yield call(upgradeControllerDeploymentWithTimeout);
 
   log.info(
-    "Opstrace cluster upgrade done for %s (%s)",
+    "upgrade operation finished for %s (%s)",
     upgradeConfig.clusterName,
     upgradeConfig.cloudProvider
   );
+  log.info(`Log in here: https://${upgradeConfig.clusterName}.opstrace.io`);
 }
 
 /**


### PR DESCRIPTION
@jgehrcke already updated much of the user-facing CLI output in #829.  While I understand and agree that the log message output is not written for humans, I would like to update the very last lines that come out of the CLI to make them compliant with our new guidelines.  

UPDATE:  aside from making these consistent for our users, it's important to make these consistent for screenshots, gifs, etc.