### PR TITLE
[WIP] ui: manually installing playwright browser binaries with node as yarn is flakey

### DIFF
--- a/test/test-remote/nodejs-testrunner.Dockerfile
+++ b/test/test-remote/nodejs-testrunner.Dockerfile
@@ -48,6 +48,16 @@ RUN cat package.json tsconfig.json && \
     yarn install --frozen-lockfile && \
     yarn add playwright --frozen-lockfile
 
+# note: there is a known and unresolved issue where yarn can fail to download playwright browser
+# binaries, npm doesn't have this issue. https://github.com/yarnpkg/yarn/issues/7887
+# The suggested workaround is to manually install the binaries:
+# https://github.com/microsoft/playwright/issues/581#issuecomment-585506945
+# https://github.com/microsoft/playwright/issues/598#issuecomment-590151978
+WORKDIR /build
+run node node_modules/playwright/install.js
+
+WORKDIR /build/test/test-remote
+
 # Disable automatic NPM update check (would always show "npm update check
 # failed").
 ENV NO_UPDATE_NOTIFIER true

--- a/test/test-remote/package.json
+++ b/test/test-remote/package.json
@@ -49,6 +49,6 @@
     "winston": "^3.3.3"
   },
   "optionalDependencies": {
-    "playwright": "1.10.0"
+    "playwright": "1.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16387,10 +16387,10 @@ pkg@^4.4.9:
     resolve "^1.15.1"
     stream-meter "^1.0.4"
 
-playwright@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.10.0.tgz#a14d295f1ad886caf4cc5e674afe03ac832066bc"
-  integrity sha512-b7SGBcCPq4W3pb4ImEDmNXtO0ZkJbZMuWiShsaNJd+rGfY/6fqwgllsAojmxGSgFmijYw7WxCoPiAIEDIH16Kw==
+playwright@1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.11.1.tgz#c5f2946db5195bd099a57ce4e188c01057876cff"
+  integrity sha512-UuMrYuvzttbJXUD7sTVcQBsGRojelGepvuQPD+QtVm/n5zyKvkiUErU/DGRXfX8VDZRdQ5D6qVqZndrydC2b4w==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"
@@ -16405,6 +16405,7 @@ playwright@1.10.0:
     rimraf "^3.0.2"
     stack-utils "^2.0.3"
     ws "^7.3.1"
+    yazl "^2.5.1"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -22486,6 +22487,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yazl@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
also updated to latest version of playwright.

Turns out there is a known and unresolved issue where yarn can fail to download playwright browser binaries, npm doesn't have this issue. https://github.com/yarnpkg/yarn/issues/7887. I've been encountering this on my local development environment so ended up looking into it a bit.

The suggested workaround is to manually install the binaries so giving that a try
https://github.com/microsoft/playwright/issues/581#issuecomment-585506945
https://github.com/microsoft/playwright/issues/598#issuecomment-590151978
