### PR TITLE
cli: destroy: try to clarify --region force-run

### DIFF
--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -79,6 +79,8 @@ export async function upgrade(): Promise<void> {
 
   let awsRegion: string | undefined;
   if (cli.CLIARGS.cloudProvider == "aws") {
+    // TODO: The function has destroy-specific user feedback (log output);
+    // which does not read nicely when it fails in the context of `upgrade`.
     awsRegion = await util.awsGetClusterRegionWithCmdlineFallback();
   }
 


### PR DESCRIPTION
@MoSattler reported on Slack that with the wording of the error message prior to this patch it took him a minute to realize that what he wants to achieve can be done by adding `--region <region>`:

> nevermind, setting the region actually makes it work again (as the output says :face_palm:)

This patch tries to make this clearer, by explicitly mentioning the scenario of the previously only partially destroyed Opstrace instance:

> ... For cleaning up resource residuals of a previously only partially destroyed Opstrace instance, you can force-run the 'destroy' operation ...

