### PR TITLE
docs: fix markdown lint error

### DIFF
--- a/docs/guides/administrator/gcp-setup.md
+++ b/docs/guides/administrator/gcp-setup.md
@@ -16,6 +16,7 @@ We will use it down below.
 Next up, enable billing for that new project: link a GCP billing account to it, via the [GCP UI](https://console.cloud.google.com/billing/linkedaccount). Some of the next steps will not work if you don't link a billing account.
 
 **Note:** If you are using a new GCP account, please keep in mind the [quotas](https://cloud.google.com/compute/quotas). Every new account has a limited quota for resources like vCPU per region among others. New accounts, receives a quota of 8vCPUs, less than the minimum required for this quickstart.
+
 ## Step 2: set up the  `gcloud` CLI
 
 The `gcloud` command-line tool is a part of the Google Cloud SDK.


### PR DESCRIPTION
Fix error
```
[2021-06-09T04:03:32Z] docs/guides/administrator/gcp-setup.md:19
MD022/blanks-around-headings/blanks-around-headers Headings should
be surrounded by blank lines [Expected: 1; Actual: 0; Above]
[Context: "## Step 2: set up the  `gcloud` CLI"]
```
