### PR TITLE
looker: add --read-n-streams-only feature

### DIFF
--- a/test/test-remote/logstream-gen/index.ts
+++ b/test/test-remote/logstream-gen/index.ts
@@ -881,6 +881,11 @@ async function readPhase(dummystreams: Array<DummyStream | DummyTimeseries>) {
         dummystreams,
         CFG.read_n_streams_only
       );
+      // For a small selection, show the names of the streams, for debuggability
+      if (CFG.read_n_streams_only < 10) {
+        const names = streamsToValidate.map(s => s.uniqueName).join(", ");
+        log.info("selected: %s", names);
+      }
     }
 
     if (CFG.max_concurrent_reads === 0) {


### PR DESCRIPTION
Manual test, log output:
```
2021-06-09T13:31:25.259Z info: End of write phase. Log entries / metric samples sent: 5000000, Payload bytes sent: 40.00 million
2021-06-09T13:31:25.259Z info: Payload write net throughput (mean): 0.63 million bytes per second (assumes utf8 for logs and 12+8 Bytes per sample for metrics)
2021-06-09T13:31:25.261Z info: cycle 3: entering read phase
2021-06-09T13:31:25.261Z info: entering read / validation phase
2021-06-09T13:31:25.262Z info: randomly picking 2/100 streams for validation
...
    "write": {
      "nEntriesSent": 5000000,
      "nPayloadBytesSent": 40000000,
      "entriesSentPerSec": 78355.28642431553,
      "megaPayloadBytesSentPerSec": 0.6268422913945242,
      "durationSeconds": 63.811903806
    },
    "read": {
      "nEntriesRead": 100000,
      "nPayloadBytesRead": 800000,
      "entriesReadPerSec": 10521.72914401462,
      "megaPayloadBytesReadPerSec": 0.08417383315211696,
      "durationSeconds": 9.504141252
    }
  }
```
