### PR TITLE
ui: automatically create/destroy grafana dashboard folder for exporter integrations

### DIFF
--- a/packages/app/src/client/integrations/common/UninstallIntegrationBtn.tsx
+++ b/packages/app/src/client/integrations/common/UninstallIntegrationBtn.tsx
@@ -27,6 +27,8 @@ import { installedIntegrationsPath } from "../paths";
 import { deleteIntegration } from "state/integration/actions";
 import graphqlClient from "state/clients/graphqlClient";
 
+import { deleteFolder } from "client/utils/grafana";
+
 import { Button } from "client/components/Button";
 
 export const UninstallBtn = ({
@@ -53,6 +55,10 @@ export const UninstallBtn = ({
           id: integration.id
         })
         .then(() => {
+          deleteFolder({ integration, tenant }).catch(err => {
+            // Dashboard folder might not exist
+            console.log(err);
+          });
           dispatch(
             deleteIntegration({ tenantId: tenant.id, id: integration.id })
           );

--- a/packages/app/src/client/integrations/exporterAzure/Form.tsx
+++ b/packages/app/src/client/integrations/exporterAzure/Form.tsx
@@ -73,18 +73,21 @@ export const ExporterAzureForm = ({ handleCreate }: Props) => {
   });
 
   const onSubmit = (data: Values) => {
-    handleCreate({
-      name: data.name,
-      data: {
-        credentials: {
-          AZURE_SUBSCRIPTION_ID: data.subscriptionId,
-          AZURE_TENANT_ID: data.azureTenantId,
-          AZURE_CLIENT_ID: data.clientId,
-          AZURE_CLIENT_SECRET: data.clientSecret
-        },
-        config: data.config
-      }
-    });
+    handleCreate(
+      {
+        name: data.name,
+        data: {
+          credentials: {
+            AZURE_SUBSCRIPTION_ID: data.subscriptionId,
+            AZURE_TENANT_ID: data.azureTenantId,
+            AZURE_CLIENT_ID: data.clientId,
+            AZURE_CLIENT_SECRET: data.clientSecret
+          },
+          config: data.config
+        }
+      },
+      { createGrafanaFolder: true }
+    );
   };
 
   return (

--- a/packages/app/src/client/integrations/exporterCloudMonitoring/Form.tsx
+++ b/packages/app/src/client/integrations/exporterCloudMonitoring/Form.tsx
@@ -76,22 +76,25 @@ export const ExporterCloudMonitoringForm = ({ handleCreate }: Props) => {
   });
 
   const onSubmit = (data: Values) => {
-    handleCreate({
-      name: data.name,
-      data: {
-        credentials: data.credentials,
-        config: {
-          "google.project-id": data.googleProjectId
-            .split(",")
-            .map(id => id.trim()),
-          "monitoring.metrics-type-prefixes": data.monitoringMetricsTypePrefixes
-            .split(",")
-            .map(prefix => prefix.trim()),
-          "monitoring.metrics-interval": data.monitoringMetricsInterval,
-          "monitoring.metrics-offset": data.monitoringMetricsOffset
+    handleCreate(
+      {
+        name: data.name,
+        data: {
+          credentials: data.credentials,
+          config: {
+            "google.project-id": data.googleProjectId
+              .split(",")
+              .map(id => id.trim()),
+            "monitoring.metrics-type-prefixes": data.monitoringMetricsTypePrefixes
+              .split(",")
+              .map(prefix => prefix.trim()),
+            "monitoring.metrics-interval": data.monitoringMetricsInterval,
+            "monitoring.metrics-offset": data.monitoringMetricsOffset
+          }
         }
-      }
-    });
+      },
+      { createGrafanaFolder: true }
+    );
   };
 
   return (

--- a/packages/app/src/client/integrations/exporterCloudMonitoring/Show/index.tsx
+++ b/packages/app/src/client/integrations/exporterCloudMonitoring/Show/index.tsx
@@ -14,31 +14,42 @@
  * limitations under the License.
  */
 
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect } from "react";
+import { useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import { format, parseISO } from "date-fns";
 
 import { installedIntegrationsPath } from "client/integrations/paths";
+import { grafanaUrl } from "client/utils/grafana";
 
 import Status from "client/integrations/exporterCloudMonitoring/Status";
 import { Details } from "./Details";
 import { Actions } from "./Actions";
 
-import { Box } from "client/components/Box";
-import Attribute from "client/components/Attribute";
-import { Card, CardContent, CardHeader } from "client/components/Card";
-import { Button } from "client/components/Button";
+import { CondRender } from "client/utils/rendering";
 
 import { ExternalLink } from "client/components/Link";
 import { ArrowLeft } from "react-feather";
 import { useSelectedTenantWithFallback } from "state/tenant/hooks/useTenant";
 import { useSelectedIntegration } from "state/integration/hooks";
 import { integrationDefRecords } from "client/integrations";
+import { loadGrafanaStateForIntegration } from "state/integration/actions";
+
+import { Box } from "client/components/Box";
+import Attribute from "client/components/Attribute";
+import { Card, CardContent, CardHeader } from "client/components/Card";
+import { Button } from "client/components/Button";
 
 export const ExporterCloudMonitoringShow = () => {
+  const dispatch = useDispatch();
   const history = useHistory();
   const tenant = useSelectedTenantWithFallback();
   const integration = useSelectedIntegration();
+
+  useEffect(() => {
+    if (integration?.id)
+      dispatch(loadGrafanaStateForIntegration({ id: integration.id }));
+  }, [dispatch, integration?.id]);
 
   // NOTE: the timeranges for these urls is not the same as that used by the status component
   // const errorLogsUrl = useMemo(() => {
@@ -99,13 +110,29 @@ export const ExporterCloudMonitoringShow = () => {
                   {format(parseISO(integration.created_at), "Pppp")}
                 </Attribute.Value>
               </Box>
-              <Attribute.Key>
-                <ExternalLink target="_blank" href={logsUrl}>
-                  <Button state="primary" variant="outlined" size="medium">
-                    View Integration Logs
-                  </Button>
-                </ExternalLink>
-              </Attribute.Key>
+              <Box display="flex" flexDirection="column">
+                <CondRender when={!!integration?.grafana?.folder?.id}>
+                  <Attribute.Key>
+                    <ExternalLink
+                      target="_blank"
+                      href={`${grafanaUrl({ tenant })}${
+                        integration.grafana?.folder?.path
+                      }`}
+                    >
+                      <Button state="primary" variant="outlined" size="medium">
+                        Grafana Dashboard Folder
+                      </Button>
+                    </ExternalLink>
+                  </Attribute.Key>
+                </CondRender>
+                <Attribute.Key>
+                  <ExternalLink target="_blank" href={logsUrl}>
+                    <Button state="primary" variant="outlined" size="medium">
+                      View Integration Logs
+                    </Button>
+                  </ExternalLink>
+                </Attribute.Key>
+              </Box>
             </Box>
           </CardContent>
         </Card>

--- a/packages/app/src/client/integrations/exporterCloudWatch/Form.tsx
+++ b/packages/app/src/client/integrations/exporterCloudWatch/Form.tsx
@@ -68,16 +68,19 @@ export const ExporterCloudWatchForm = ({ handleCreate }: Props) => {
   });
 
   const onSubmit = (data: Values) => {
-    handleCreate({
-      name: data.name,
-      data: {
-        credentials: {
-          AWS_ACCESS_KEY_ID: data.accessKeyId,
-          AWS_SECRET_ACCESS_KEY: data.secretAccessKey
-        },
-        config: data.config
-      }
-    });
+    handleCreate(
+      {
+        name: data.name,
+        data: {
+          credentials: {
+            AWS_ACCESS_KEY_ID: data.accessKeyId,
+            AWS_SECRET_ACCESS_KEY: data.secretAccessKey
+          },
+          config: data.config
+        }
+      },
+      { createGrafanaFolder: true }
+    );
   };
 
   return (

--- a/packages/app/src/client/integrations/exporterCloudWatch/Show/index.tsx
+++ b/packages/app/src/client/integrations/exporterCloudWatch/Show/index.tsx
@@ -14,30 +14,41 @@
  * limitations under the License.
  */
 
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect } from "react";
+import { useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import { format, parseISO } from "date-fns";
 
 import { installedIntegrationsPath } from "client/integrations/paths";
+import { grafanaUrl } from "client/utils/grafana";
 
 import Status from "client/integrations/exporterCloudWatch/Status";
 import { Actions } from "./Actions";
 
-import { Box } from "client/components/Box";
-import Attribute from "client/components/Attribute";
-import { Card, CardContent, CardHeader } from "client/components/Card";
-import { Button } from "client/components/Button";
+import { CondRender } from "client/utils/rendering";
 
 import { ExternalLink } from "client/components/Link";
 import { ArrowLeft } from "react-feather";
 import { useSelectedTenantWithFallback } from "state/tenant/hooks/useTenant";
 import { useSelectedIntegration } from "state/integration/hooks";
 import { integrationDefRecords } from "client/integrations";
+import { loadGrafanaStateForIntegration } from "state/integration/actions";
+
+import { Box } from "client/components/Box";
+import Attribute from "client/components/Attribute";
+import { Card, CardContent, CardHeader } from "client/components/Card";
+import { Button } from "client/components/Button";
 
 export const ExporterCloudWatchShow = () => {
+  const dispatch = useDispatch();
   const history = useHistory();
   const tenant = useSelectedTenantWithFallback();
   const integration = useSelectedIntegration();
+
+  useEffect(() => {
+    if (integration?.id)
+      dispatch(loadGrafanaStateForIntegration({ id: integration.id }));
+  }, [dispatch, integration?.id]);
 
   // NOTE: the timeranges for these urls is not the same as that used by the status component
   // const errorLogsUrl = useMemo(() => {
@@ -98,13 +109,29 @@ export const ExporterCloudWatchShow = () => {
                   {format(parseISO(integration.created_at), "Pppp")}
                 </Attribute.Value>
               </Box>
-              <Attribute.Key>
-                <ExternalLink target="_blank" href={logsUrl}>
-                  <Button state="primary" variant="outlined" size="medium">
-                    View Integration Logs
-                  </Button>
-                </ExternalLink>
-              </Attribute.Key>
+              <Box display="flex" flexDirection="column">
+                <CondRender when={!!integration?.grafana?.folder?.id}>
+                  <Attribute.Key>
+                    <ExternalLink
+                      target="_blank"
+                      href={`${grafanaUrl({ tenant })}${
+                        integration.grafana?.folder?.path
+                      }`}
+                    >
+                      <Button state="primary" variant="outlined" size="medium">
+                        Grafana Dashboard Folder
+                      </Button>
+                    </ExternalLink>
+                  </Attribute.Key>
+                </CondRender>
+                <Attribute.Key>
+                  <ExternalLink target="_blank" href={logsUrl}>
+                    <Button state="primary" variant="outlined" size="medium">
+                      View Integration Logs
+                    </Button>
+                  </ExternalLink>
+                </Attribute.Key>
+              </Box>
             </Box>
           </CardContent>
         </Card>


### PR DESCRIPTION
Also providing a direct link to it on the detail page for the integration. Makes a default folder for users to create dashboards in.