### PR TITLE
chore: allow for more ingesters when there are more nodes

### DIFF
--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -195,7 +195,13 @@ export function CortexResources(
           choose: 9
         },
         {
+          "<=": 20,
+          // TODO does rounding down to odd matter?
+          choose: roundDownToOdd(getNodeCount(state))
+        },
+        {
           "<=": Infinity,
+          // TODO reconsider whether dividing by 2 is the right thing
           choose: roundDownToOdd(getNodeCount(state) / 2)
         }
       ])


### PR DESCRIPTION
When scale testing, we explicitly want more ingesters when we add more nodes.  This is a bit of a specific fix for that use case, rather than a well-thought-out strategic change.