### PR TITLE
test-remote(ring-health): add alertmanager to tests

### DIFF
--- a/test/test-remote/test_ui.ts
+++ b/test/test-remote/test_ui.ts
@@ -377,7 +377,13 @@ suite("test_ui_with_headless_browser", function () {
     await page.click("text=Metrics");
     assert(await page.isVisible("text=Cortex Ring Health"), "page loaded");
 
-    for (const tabName of ["Ingester", "Ruler", "Compactor", "Store-gateway"]) {
+    for (const tabName of [
+      "Ingester",
+      "Ruler",
+      "Compactor",
+      "Store-gateway",
+      "Alertmanager"
+    ]) {
       await page.click(`text=${tabName}`);
       page.waitForSelector(`css=tab >> text=${tabName} [aria-selected="true"]`);
       assert(


### PR DESCRIPTION
Since a [previous bug](https://opstrace-community.slack.com/archives/C01KZS8JRNC/p1623665131091100?thread_ts=1623664061.091000&cid=C01KZS8JRNC) was fixed [here](https://opstrace-community.slack.com/archives/C01KZS8JRNC/p1623704267093500?thread_ts=1623664061.091000&cid=C01KZS8JRNC), we can reactivate the alert manager test.

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [x] Written new tests for your changes?
* [x] Thought about which docs need updating?
