### PR TITLE
ui(ring-health): improve tests

### DIFF
--- a/packages/app/src/client/views/ring-health/RingHealth.test.tsx
+++ b/packages/app/src/client/views/ring-health/RingHealth.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import RingHealth from "./RingHealth";
+import Services from "client/services";
+import light from "client/themes/light";
+import ThemeProvider from "client/themes/Provider";
+import { StoreProvider } from "state/provider";
+import nock from "nock";
+import { MemoryRouter } from "react-router";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { render } from "@testing-library/react";
+
+jest.useFakeTimers();
+
+beforeEach(() => {
+  // @ts-ignore
+  nock.cleanAll();
+});
+
+const createMockShards = () => {
+  function getRandomInt() {
+    return Math.floor(Math.random() * 1000);
+  }
+  return new Array(5).fill(true).map(() => {
+    const id = getRandomInt();
+    return {
+      id: `shard-id-${id}`,
+      state: `shard-state-${id}`,
+      timestamp: "2021-05-31T13:02:47+00:00",
+      zone: `shard-zone-${id}`,
+      address: `shard-address-${id}`,
+      tokens: [
+        `shard-token-${id}-a`,
+        `shard-token-${id}-b`,
+        `shard-token-${id}-c`
+      ],
+      registered_timestamp: `shard-registered_timestamp-${id}`
+    };
+  });
+};
+
+describe("CortexRingHealth", () => {
+  test("renders title correctly", async () => {
+    const title = "my title";
+    const container = renderComponent(
+      <RingHealth
+        title={title}
+        tabs={[
+          {
+            title: "Something",
+            path: `/something`,
+            endpoint: "/something-endpoint"
+          }
+        ]}
+      />
+    );
+
+    const ingesterTab = container.getByRole("heading");
+    expect(ingesterTab).toHaveTextContent(title);
+  });
+
+  test("has selectable tabs", async () => {
+    const firstTabName = "First Tab";
+    const secondTabName = "Second Tab";
+    const tabs = [
+      {
+        title: firstTabName,
+        path: `/first`,
+        endpoint: "/first-endpoint"
+      },
+      {
+        title: secondTabName,
+        path: `/second`,
+        endpoint: "/second-endpoint"
+      }
+    ];
+    const container = renderComponent(
+      <RingHealth title="some title" tabs={tabs} />
+    );
+
+    const firstTab = container.getByRole("tab", { name: firstTabName });
+    const secondTab = container.getByRole("tab", { name: secondTabName });
+
+    expect(firstTab).toHaveAttribute("aria-selected", "true");
+    expect(secondTab).toHaveAttribute("aria-selected", "false");
+
+    userEvent.click(secondTab);
+    const firstTabAfterClick = container.getByRole("tab", {
+      name: firstTabName
+    });
+    const secondTabAfterClick = container.getByRole("tab", {
+      name: secondTabName
+    });
+    expect(firstTabAfterClick).toHaveAttribute("aria-selected", "false");
+    expect(secondTabAfterClick).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("loads table", async () => {
+    const tab = {
+      title: "Tab",
+      path: `/tab`,
+      endpoint: "/tab-endpoint"
+    };
+    const mockShards = createMockShards();
+    nock("http://localhost").get(tab.endpoint).reply(200, {
+      shards: mockShards,
+      now: Date.now()
+    });
+
+    const container = renderComponent(
+      <RingHealth title="some title" tabs={[tab]} />
+    );
+
+    // wait for polling
+    jest.runOnlyPendingTimers();
+
+    // assert table is rendered properly
+    expect(
+      await container.findByRole("cell", { name: mockShards[0].id })
+    ).toBeInTheDocument();
+    expect(
+      await container.findByRole("cell", { name: mockShards[0].state })
+    ).toBeInTheDocument();
+    expect(
+      await container.findByRole("cell", { name: mockShards[0].zone })
+    ).toBeInTheDocument();
+    expect(
+      await container.findByRole("cell", { name: mockShards[0].address })
+    ).toBeInTheDocument();
+
+    // assert token dialog
+    const tokenDialogButton = container.getAllByRole("button", {
+      name: "show token dialog"
+    })[0];
+    userEvent.click(tokenDialogButton);
+    expect(
+      await container.findByText(mockShards[0].tokens[0])
+    ).toBeInTheDocument();
+    expect(
+      await container.findByText(mockShards[0].tokens[1])
+    ).toBeInTheDocument();
+    expect(
+      await container.findByText(mockShards[0].tokens[2])
+    ).toBeInTheDocument();
+  });
+
+  
+
+  test("fetches new results every 2s", async () => {
+    const tab = {
+      title: "Tab",
+      path: `/tab`,
+      endpoint: "/tab-endpoint"
+    };
+    const firstBatch = createMockShards();
+    nock("http://localhost").get(tab.endpoint).reply(200, {
+      shards: firstBatch,
+      now: Date.now()
+    });
+
+    const container = renderComponent(
+      <RingHealth title="some title" tabs={[tab]} />
+    );
+
+    // wait for polling
+    jest.runOnlyPendingTimers();
+
+    // assert table is rendered properly
+    expect(
+      await container.findByRole("cell", { name: firstBatch[0].id })
+    ).toBeInTheDocument();
+
+
+    const secondBatch = createMockShards();
+    nock("http://localhost").get(tab.endpoint).reply(200, {
+      shards: secondBatch,
+      now: Date.now()
+    });
+    
+    // wait for polling
+    jest.advanceTimersByTime(2000);
+    expect(
+      await container.findByRole("cell", { name: secondBatch[0].id})
+    ).toBeInTheDocument();
+  });
+});
+
+test("handles request errors", async () => {
+  const tab = {
+    title: "Tab",
+    path: `/tab`,
+    endpoint: "/tab-endpoint"
+  };
+  
+  nock("http://localhost").get(tab.endpoint).reply(500);
+
+  const container = renderComponent(
+    <RingHealth title="some title" tabs={[tab]} />
+  );
+
+  jest.runOnlyPendingTimers();
+
+  expect(await container.findByText("Could not load table")).toBeInTheDocument()
+  expect(await container.findByText("Request failed with status code 500")).toBeInTheDocument()
+});
+
+const renderComponent = (children: React.ReactNode) => {
+  return render(
+    <StoreProvider>
+      <ThemeProvider theme={light}>
+        <Services>
+          <MemoryRouter>{children}</MemoryRouter>
+        </Services>
+      </ThemeProvider>
+    </StoreProvider>
+  );
+};

--- a/packages/app/src/client/views/ring-health/RingHealth.test.tsx
+++ b/packages/app/src/client/views/ring-health/RingHealth.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Opstrace, Inc.
+ * Copyright 2021 Opstrace, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/app/src/client/views/ring-health/RingTable.tsx
+++ b/packages/app/src/client/views/ring-health/RingTable.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-type Shard = {
+export type Shard = {
   id: string;
   state: string;
   timestamp: string;

--- a/packages/app/src/client/views/ring-health/cortex/CortexRingHealth.test.tsx
+++ b/packages/app/src/client/views/ring-health/cortex/CortexRingHealth.test.tsx
@@ -26,6 +26,7 @@ import { createMemoryHistory } from "history";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import { render } from "@testing-library/react";
+import { createMockShard } from "../testUtils";
 
 jest.useFakeTimers();
 
@@ -38,24 +39,6 @@ beforeEach(() => {
     now: Date.now()
   });
 });
-
-const createMockShards = () => {
-  function getRandomInt() {
-    return Math.floor(Math.random() * 1000);
-  }
-  return new Array(5).fill(true).map(() => {
-    const id = getRandomInt();
-    return {
-      id: `shard-id-${id}`,
-      state: `shard-state-${id}`,
-      timestamp: "2021-05-31T13:02:47+00:00",
-      zone: `shard-zone-${id}`,
-      address: `shard-address-${id}`,
-      tokens: [],
-      registered_timestamp: `shard-registered_timestamp-${id}`
-    };
-  });
-};
 
 describe("CortexRingHealth", () => {
   test("renders title correctly", async () => {
@@ -93,11 +76,13 @@ describe("CortexRingHealth", () => {
     test.each(tabTestCases)(
       "%s tab",
       async (tabLabel, tabRoute, tabEndpoint) => {
-        const mockShards = createMockShards();
-        nock("http://localhost").get(tabEndpoint).reply(200, {
-          shards: mockShards,
-          now: Date.now()
-        });
+        const mockShard = createMockShard("first-shard");
+        nock("http://localhost")
+          .get(tabEndpoint)
+          .reply(200, {
+            shards: [mockShard],
+            now: Date.now()
+          });
 
         const baseUrl = "/route/to/ring-health";
         const history = createMemoryHistory({ initialEntries: [baseUrl] });
@@ -123,7 +108,7 @@ describe("CortexRingHealth", () => {
 
         // assert table is rendered properly
         expect(
-          await container.findByRole("cell", { name: mockShards[0].id })
+          await container.findByRole("cell", { name: mockShard.id })
         ).toBeInTheDocument();
       }
     );

--- a/packages/app/src/client/views/ring-health/cortex/CortexRingHealth.test.tsx
+++ b/packages/app/src/client/views/ring-health/cortex/CortexRingHealth.test.tsx
@@ -51,11 +51,7 @@ const createMockShards = () => {
       timestamp: "2021-05-31T13:02:47+00:00",
       zone: `shard-zone-${id}`,
       address: `shard-address-${id}`,
-      tokens: [
-        `shard-token-${id}-a`,
-        `shard-token-${id}-b`,
-        `shard-token-${id}-c`
-      ],
+      tokens: [],
       registered_timestamp: `shard-registered_timestamp-${id}`
     };
   });
@@ -74,7 +70,7 @@ describe("CortexRingHealth", () => {
     const ingesterTab = container.getByRole("heading");
     expect(ingesterTab).toHaveTextContent("Cortex Ring Health");
   });
-  test("selects first tab by default", async () => {
+  test("selects ingester tab by default", async () => {
     const baseUrl = "/route/to/ring-health";
     const history = createMemoryHistory({ initialEntries: [baseUrl] });
     const container = renderComponent(
@@ -93,63 +89,44 @@ describe("CortexRingHealth", () => {
     path,
     endpoint
   ]);
-  test.each(tabTestCases)("%s tab", async (tabLabel, tabRoute, tabEndpoint) => {
-    const mockShards = createMockShards();
-    nock("http://localhost").get(tabEndpoint).reply(200, {
-      shards: mockShards,
-      now: Date.now()
-    });
+  describe("tabs", () => {
+    test.each(tabTestCases)(
+      "%s tab",
+      async (tabLabel, tabRoute, tabEndpoint) => {
+        const mockShards = createMockShards();
+        nock("http://localhost").get(tabEndpoint).reply(200, {
+          shards: mockShards,
+          now: Date.now()
+        });
 
-    const baseUrl = "/route/to/ring-health";
-    const history = createMemoryHistory({ initialEntries: [baseUrl] });
-    const container = renderComponent(
-      <Router history={history}>
-        <RingHealth baseUrl={baseUrl} />
-      </Router>
+        const baseUrl = "/route/to/ring-health";
+        const history = createMemoryHistory({ initialEntries: [baseUrl] });
+        const container = renderComponent(
+          <Router history={history}>
+            <RingHealth baseUrl={baseUrl} />
+          </Router>
+        );
+
+        // wait for polling
+        jest.runOnlyPendingTimers();
+
+        // Select tab
+        const ingesterTab = container.getByRole("tab", { name: tabLabel });
+        userEvent.click(ingesterTab);
+
+        // wait for polling
+        jest.runOnlyPendingTimers();
+
+        // assert that reroute was successful
+        await container.findByRole("tab", { name: tabLabel, selected: true });
+        expect(history.location.pathname).toBe(baseUrl + tabRoute);
+
+        // assert table is rendered properly
+        expect(
+          await container.findByRole("cell", { name: mockShards[0].id })
+        ).toBeInTheDocument();
+      }
     );
-
-    // wait for polling
-    jest.runOnlyPendingTimers();
-
-    // Select tab
-    const ingesterTab = container.getByRole("tab", { name: tabLabel });
-    userEvent.click(ingesterTab);
-
-    // wait for polling
-    jest.runOnlyPendingTimers();
-
-    // assert that reroute was successful
-    await container.findByRole("tab", { name: tabLabel, selected: true });
-    expect(history.location.pathname).toBe(baseUrl + tabRoute);
-
-    // assert table is rendered properly
-    expect(
-      await container.findByRole("cell", { name: mockShards[0].id })
-    ).toBeInTheDocument();
-    expect(
-      await container.findByRole("cell", { name: mockShards[0].state })
-    ).toBeInTheDocument();
-    expect(
-      await container.findByRole("cell", { name: mockShards[0].zone })
-    ).toBeInTheDocument();
-    expect(
-      await container.findByRole("cell", { name: mockShards[0].address })
-    ).toBeInTheDocument();
-
-    // assert token dialog
-    const tokenDialogButton = container.getAllByRole("button", {
-      name: "show token dialog"
-    })[0];
-    userEvent.click(tokenDialogButton);
-    expect(
-      await container.findByText(mockShards[0].tokens[0])
-    ).toBeInTheDocument();
-    expect(
-      await container.findByText(mockShards[0].tokens[1])
-    ).toBeInTheDocument();
-    expect(
-      await container.findByText(mockShards[0].tokens[2])
-    ).toBeInTheDocument();
   });
 });
 

--- a/packages/app/src/client/views/ring-health/cortex/CortexRingHealth.test.tsx
+++ b/packages/app/src/client/views/ring-health/cortex/CortexRingHealth.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Opstrace, Inc.
+ * Copyright 2021 Opstrace, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/app/src/client/views/ring-health/loki/LokiRingHealth.test.tsx
+++ b/packages/app/src/client/views/ring-health/loki/LokiRingHealth.test.tsx
@@ -51,11 +51,7 @@ const createMockShards = () => {
       timestamp: "2021-05-31T13:02:47+00:00",
       zone: `shard-zone-${id}`,
       address: `shard-address-${id}`,
-      tokens: [
-        `shard-token-${id}-a`,
-        `shard-token-${id}-b`,
-        `shard-token-${id}-c`
-      ],
+      tokens: [],
       registered_timestamp: `shard-registered_timestamp-${id}`
     };
   });
@@ -75,7 +71,7 @@ describe("LokiRingHealth", () => {
     expect(ingesterTab).toHaveTextContent("Loki Ring Health");
   });
 
-  test("selects first tab by default", async () => {
+  test("selects ingester tab by default", async () => {
     const baseUrl = "/route/to/ring-health";
     const history = createMemoryHistory({ initialEntries: [baseUrl] });
     const container = renderComponent(
@@ -94,67 +90,45 @@ describe("LokiRingHealth", () => {
     path,
     endpoint
   ]);
-  test.each(tabTestCases)(
-    "%s tab",
-    async (tabLabel, tabRoute, tabEndpoint) => {
-      const mockShards = createMockShards();
-      nock("http://localhost").get(tabEndpoint).reply(200, {
-        shards: mockShards,
-        now: Date.now()
-      });
+  describe("tabs", () => {
+    test.each(tabTestCases)(
+      "%s tab",
+      async (tabLabel, tabRoute, tabEndpoint) => {
+        const mockShards = createMockShards();
+        nock("http://localhost").get(tabEndpoint).reply(200, {
+          shards: mockShards,
+          now: Date.now()
+        });
 
-      const baseUrl = "/route/to/ring-health";
-      const history = createMemoryHistory({ initialEntries: [baseUrl] });
-      const container = renderComponent(
-        <Router history={history}>
-          <RingHealth baseUrl={baseUrl} />
-        </Router>
-      );
+        const baseUrl = "/route/to/ring-health";
+        const history = createMemoryHistory({ initialEntries: [baseUrl] });
+        const container = renderComponent(
+          <Router history={history}>
+            <RingHealth baseUrl={baseUrl} />
+          </Router>
+        );
 
-      // wait for polling
-      jest.runOnlyPendingTimers();
+        // wait for polling
+        jest.runOnlyPendingTimers();
 
-      // Select tab
-      const ingesterTab = container.getByRole("tab", { name: tabLabel });
-      userEvent.click(ingesterTab);
+        // Select tab
+        const ingesterTab = container.getByRole("tab", { name: tabLabel });
+        userEvent.click(ingesterTab);
 
-      // wait for polling
-      jest.runOnlyPendingTimers();
+        // wait for polling
+        jest.runOnlyPendingTimers();
 
-      // assert that reroute was successful
-      await container.findByRole("tab", { name: tabLabel, selected: true });
-      expect(history.location.pathname).toBe(baseUrl + tabRoute);
+        // assert that reroute was successful
+        await container.findByRole("tab", { name: tabLabel, selected: true });
+        expect(history.location.pathname).toBe(baseUrl + tabRoute);
 
-      // assert table is rendered properly
-      expect(
-        await container.findByRole("cell", { name: mockShards[0].id })
-      ).toBeInTheDocument();
-      expect(
-        await container.findByRole("cell", { name: mockShards[0].state })
-      ).toBeInTheDocument();
-      expect(
-        await container.findByRole("cell", { name: mockShards[0].zone })
-      ).toBeInTheDocument();
-      expect(
-        await container.findByRole("cell", { name: mockShards[0].address })
-      ).toBeInTheDocument();
-
-      // assert token dialog
-      const tokenDialogButton = container.getAllByRole("button", {
-        name: "show token dialog"
-      })[0];
-      userEvent.click(tokenDialogButton);
-      expect(
-        await container.findByText(mockShards[0].tokens[0])
-      ).toBeInTheDocument();
-      expect(
-        await container.findByText(mockShards[0].tokens[1])
-      ).toBeInTheDocument();
-      expect(
-        await container.findByText(mockShards[0].tokens[2])
-      ).toBeInTheDocument();
-    }
-  );
+        // assert table is rendered properly
+        expect(
+          await container.findByRole("cell", { name: mockShards[0].id })
+        ).toBeInTheDocument();
+      }
+    );
+  });
 });
 
 const renderComponent = (children: React.ReactNode) => {

--- a/packages/app/src/client/views/ring-health/testUtils.ts
+++ b/packages/app/src/client/views/ring-health/testUtils.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Shard } from "./RingTable";
+
+// shard to be used as mock request response
+export const createMockShard = (id: string): Required<Shard> => ({
+  id: `shard-id-${id}`,
+  state: `shard-state-${id}`,
+  timestamp: "2021-05-31T13:02:47+00:00",
+  zone: `shard-zone-${id}`,
+  address: `shard-address-${id}`,
+  tokens: [],
+  registered_timestamp: `shard-registered_timestamp-${id}`
+});

--- a/packages/app/src/client/views/ring-health/testUtils.ts
+++ b/packages/app/src/client/views/ring-health/testUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Opstrace, Inc.
+ * Copyright 2021 Opstrace, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Superset of #915  

Moving some of tests of implementations of `RingHealth` to the reusable component, to facilitate better testing of different aspects, e.g. fetching and error handling.

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [x] Written new tests for your changes?
* [x] Thought about which docs need updating?
