### PR TITLE
fix: typo in grafana datasource splitter loki proxy_pass config

### DIFF
--- a/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
@@ -255,7 +255,7 @@ http {
               ${generalProxyConfig}
 
               resolver ${dnsResolver};
-              set $backend http://querier.loki.svc.cluster.local:1080/$request_uri;
+              set $backend http://querier.loki.svc.cluster.local:1080$request_uri;
               proxy_pass $backend;
             }
 


### PR DESCRIPTION
Close #908 
