### PR TITLE
Try to fix nginx datasource splitter reverse proxy config

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -13,7 +13,7 @@
   "exporterStackdriver": "prometheuscommunity/stackdriver-exporter:v0.11.0",
   "externalDNS": "k8s.gcr.io/external-dns/external-dns:v0.7.4",
   "systemlogFluentd": "opstrace/systemlog-fluentd:fe6d0d84-dev",
-  "grafana": "grafana/grafana:8.0.0-ubuntu",
+  "grafana": "grafana/grafana:8.0.3-ubuntu",
   "kubeRBACProxy": "quay.io/brancz/kube-rbac-proxy:v0.8.0",
   "kubeStateMetrics": "quay.io/coreos/kube-state-metrics:v1.7.2",
   "localVolumeProvisioner": "quay.io/external_storage/local-volume-provisioner:v2.2.0",

--- a/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
@@ -317,61 +317,30 @@ http {
             `
           location / {
             ${generalProxyConfig}
-
             resolver ${dnsResolver};
             set $backend "http://query-frontend.cortex.svc.cluster.local:80";
             proxy_pass $backend;
           }
 
-          location /api/v1/rules {
+          location ~ ^/api/v1/rules(?<urlsuffix>.*)$
             ${generalProxyConfig}
-
             resolver ${dnsResolver};
-            set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/rules$is_args$query_string";
-            proxy_pass $backend;
-
-          }
-
-          location /api/v1/rules/ {
-            ${generalProxyConfig}
-
-
-            resolver ${dnsResolver};
-            set $backend http://ruler.cortex.svc.cluster.local/prometheus/api/v1/rules$is_args$query_string;
-
-          }
-
-          location /api/v1/alerts {
-            ${generalProxyConfig}
-
-            resolver ${dnsResolver};
-            set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/alerts$is_args$query_string";
+            set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/rules$urlsuffix";
             proxy_pass $backend;
           }
 
-          location /api/v1/alerts/ {
+          location ~ ^/api/v1/alerts(?<urlsuffix>.*)$
             ${generalProxyConfig}
-
             resolver ${dnsResolver};
-            set $backend http://ruler.cortex.svc.cluster.local/prometheus/api/v1/alerts$is_args$query_string;
+            set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/alerts$urlsuffix";
             proxy_pass $backend;
           }
 
           # Cortex specific ruler routes (legacy routes which the Grafana 8 alerting feature uses)
-
-          location /rules {
+          location ~ ^/rules(?<urlsuffix>.*)$
             ${generalProxyConfig}
-
             resolver ${dnsResolver};
-            set $backend http://ruler.cortex.svc.cluster.local/api/v1/rules$is_args$query_string;
-            proxy_pass $backend;
-          }
-
-          location /rules/ {
-            ${generalProxyConfig}
-
-            resolver ${dnsResolver};
-            set $backend http://ruler.cortex.svc.cluster.local/api/v1/rules$is_args$query_string;
+            set $backend http://ruler.cortex.svc.cluster.local/api/v1/rules$urlsuffix;
             proxy_pass $backend;
           }
           `

--- a/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
@@ -255,43 +255,39 @@ http {
               ${generalProxyConfig}
 
               resolver ${dnsResolver};
-              set $backend http://querier.loki.svc.cluster.local:1080/$request_uri;
+              set $backend http://querier.loki.svc.cluster.local:1080;
               proxy_pass $backend;
             }
 
             location /prometheus/api/v1/rules {
               ${generalProxyConfig}
 
-              # Check https://github.com/opstrace/opstrace/issues/896 for more details.
               resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/rules$request_uri;
+              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/rules$is_args$query_string;
               proxy_pass $backend;
             }
 
             location /prometheus/api/v1/rules/ {
               ${generalProxyConfig}
 
-              # Check https://github.com/opstrace/opstrace/issues/896 for more details.
               resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/rules/$request_uri;
+              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/rules$is_args$query_string;
               proxy_pass $backend;
             }
 
             location /prometheus/api/v1/alerts {
               ${generalProxyConfig}
 
-              # Check https://github.com/opstrace/opstrace/issues/896 for more details.
               resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/alerts$request_uri;
+              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/alerts$is_args$query_string;
               proxy_pass $backend;
             }
 
             location /prometheus/api/v1/alerts/ {
               ${generalProxyConfig}
 
-              # Check https://github.com/opstrace/opstrace/issues/896 for more details.
               resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/alerts/$request_uri;
+              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/alerts$is_args$query_string;
               proxy_pass $backend;
             }
 
@@ -300,18 +296,16 @@ http {
             location /loki/api/v1/rules {
               ${generalProxyConfig}
 
-              # Check https://github.com/opstrace/opstrace/issues/896 for more details.
               resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules$request_uri;
+              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules$is_args$query_string;
               proxy_pass $backend;
             }
 
             location /loki/api/v1/rules/ {
               ${generalProxyConfig}
 
-              # Check https://github.com/opstrace/opstrace/issues/896 for more details.
               resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules/$request_uri;
+              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules$is_args$query_string;
               proxy_pass $backend;
             }
 
@@ -319,9 +313,8 @@ http {
             location /api/prom/rules/ {
               ${generalProxyConfig}
 
-              # Check https://github.com/opstrace/opstrace/issues/896 for more details.
               resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules/$request_uri;
+              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules$is_args$query_string;
               proxy_pass $backend;
             }
             `

--- a/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
@@ -283,13 +283,6 @@ http {
               proxy_pass $backend;
             }
 
-            location /prometheus/api/v1/alerts/ {
-              ${generalProxyConfig}
-
-              resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/alerts$is_args$query_string;
-              proxy_pass $backend;
-            }
 
             # Loki specific ruler routes
 
@@ -297,15 +290,10 @@ http {
               ${generalProxyConfig}
 
               resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules$is_args$query_string;
-              proxy_pass $backend;
-            }
-
-            location /loki/api/v1/rules/ {
-              ${generalProxyConfig}
-
-              resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules$is_args$query_string;
+              # Do not change the request URL, this works for the following endpoints:
+              # /loki/api/v1/rules
+              # /loki/api/v1/rules/{namespace}
+              set $backend http://ruler.loki.svc.cluster.local:1080;
               proxy_pass $backend;
             }
 

--- a/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
@@ -340,18 +340,16 @@ http {
           location / {
             ${generalProxyConfig}
 
-            # Check https://github.com/opstrace/opstrace/issues/896 for more details.
             resolver ${dnsResolver};
-            set $backend "http://query-frontend.cortex.svc.cluster.local:80$request_uri";
+            set $backend "http://query-frontend.cortex.svc.cluster.local:80";
             proxy_pass $backend;
           }
 
           location /api/v1/rules {
             ${generalProxyConfig}
 
-            # Check https://github.com/opstrace/opstrace/issues/896 for more details.
             resolver ${dnsResolver};
-            set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/rules$request_uri";
+            set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/rules$is_args$query_string";
             proxy_pass $backend;
 
           }
@@ -359,10 +357,9 @@ http {
           location /api/v1/rules/ {
             ${generalProxyConfig}
 
-            # Check https://github.com/opstrace/opstrace/issues/896 for more details.
 
             resolver ${dnsResolver};
-            set $backend http://ruler.cortex.svc.cluster.local/prometheus/api/v1/rules/$request_uri;
+            set $backend http://ruler.cortex.svc.cluster.local/prometheus/api/v1/rules$is_args$query_string;
 
           }
 
@@ -370,7 +367,7 @@ http {
             ${generalProxyConfig}
 
             resolver ${dnsResolver};
-            set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/alerts$request_uri";
+            set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/alerts$is_args$query_string";
             proxy_pass $backend;
           }
 
@@ -378,7 +375,7 @@ http {
             ${generalProxyConfig}
 
             resolver ${dnsResolver};
-            set $backend http://ruler.cortex.svc.cluster.local/prometheus/api/v1/alerts/$request_uri;
+            set $backend http://ruler.cortex.svc.cluster.local/prometheus/api/v1/alerts$is_args$query_string;
             proxy_pass $backend;
           }
 
@@ -388,7 +385,7 @@ http {
             ${generalProxyConfig}
 
             resolver ${dnsResolver};
-            set $backend http://ruler.cortex.svc.cluster.local/api/v1/rules$request_uri;
+            set $backend http://ruler.cortex.svc.cluster.local/api/v1/rules$is_args$query_string;
             proxy_pass $backend;
           }
 
@@ -396,7 +393,7 @@ http {
             ${generalProxyConfig}
 
             resolver ${dnsResolver};
-            set $backend http://ruler.cortex.svc.cluster.local/api/v1/rules/$request_uri;
+            set $backend http://ruler.cortex.svc.cluster.local/api/v1/rules$is_args$query_string;
             proxy_pass $backend;
           }
           `

--- a/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
@@ -74,9 +74,22 @@ export function GrafanaDatasourceResources(
   }
 
   if (target === "gcp") {
-    dnsResolver = "10.0.0.10";
+    // This IP address depends on the GKE cluster, see
+    // https://cloud.google.com/kubernetes-engine/docs/concepts/service-discovery
+    // We could parse /etc/resolv.conf but it seems like
+    // a _dynamic_ resolver should also work:
+    // kube-dns.kube-system.svc.cluster.local valid=5s;
+    // Refs:
+    //   https://www.nginx.com/blog/announcing-nginx-ingress-controller-for-kubernetes-release-1-4-0/
+    //   https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/
+    // Does/should this work for AWS, too?
+    dnsResolver = "kube-dns.kube-system.svc.cluster.local valid=5s";
   }
 
+  // Warning: the order in the `datasources` array defines the IDs assigned to
+  // individual data sources -- these IDs are being used in certain tests,
+  // and changing the order might break them. Also see
+  // https://github.com/opstrace/opstrace/pull/914
   const datasources = {
     apiVersion: 1,
     deleteDatasources: getDatasourcesToDelete(),

--- a/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
@@ -310,11 +310,11 @@ http {
             }
 
             # Loki legacy route for saving rules (legacy routes which the Grafana 8 alerting feature uses)
-            location /api/prom/rules/ {
+            location ~ ^/api/prom/rules(?<urlsuffix>.*)$
               ${generalProxyConfig}
 
               resolver ${dnsResolver};
-              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules$is_args$query_string;
+              set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules$urlsuffix;
               proxy_pass $backend;
             }
             `

--- a/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
+++ b/packages/controller/src/resources/monitoring/tenants/grafanaDatasources.ts
@@ -289,7 +289,7 @@ http {
             }
 
             # Loki legacy route for saving rules (legacy routes which the Grafana 8 alerting feature uses)
-            location ~ ^/api/prom/rules(?<urlsuffix>.*)$
+            location ~ ^/api/prom/rules(?<urlsuffix>.*)$ {
               ${generalProxyConfig}
               resolver ${dnsResolver};
               set $backend http://ruler.loki.svc.cluster.local:1080/loki/api/v1/rules$urlsuffix;
@@ -322,14 +322,14 @@ http {
             proxy_pass $backend;
           }
 
-          location ~ ^/api/v1/rules(?<urlsuffix>.*)$
+          location ~ ^/api/v1/rules(?<urlsuffix>.*)$ {
             ${generalProxyConfig}
             resolver ${dnsResolver};
             set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/rules$urlsuffix";
             proxy_pass $backend;
           }
 
-          location ~ ^/api/v1/alerts(?<urlsuffix>.*)$
+          location ~ ^/api/v1/alerts(?<urlsuffix>.*)$ {
             ${generalProxyConfig}
             resolver ${dnsResolver};
             set $backend "http://ruler.cortex.svc.cluster.local/prometheus/api/v1/alerts$urlsuffix";
@@ -337,7 +337,7 @@ http {
           }
 
           # Cortex specific ruler routes (legacy routes which the Grafana 8 alerting feature uses)
-          location ~ ^/rules(?<urlsuffix>.*)$
+          location ~ ^/rules(?<urlsuffix>.*)$ {
             ${generalProxyConfig}
             resolver ${dnsResolver};
             set $backend http://ruler.cortex.svc.cluster.local/api/v1/rules$urlsuffix;

--- a/test/test-remote/test_ui.ts
+++ b/test/test-remote/test_ui.ts
@@ -140,7 +140,7 @@ async function waitFor200Resp(
 ): Promise<GotResponse<string>> {
   const maxWaitSeconds = 2100;
   const deadline = mtimeDeadlineInSeconds(maxWaitSeconds);
-  log.info("Waiting for rules to be returned by %s", url);
+  log.info("Waiting for a 200 OK response to be returned by %s", url);
 
   while (true) {
     if (mtime() > deadline) {

--- a/test/test-remote/test_ui.ts
+++ b/test/test-remote/test_ui.ts
@@ -58,8 +58,6 @@ import {
 import type { ChromiumBrowser, Browser, Cookie } from "playwright";
 import { chromium } from "playwright";
 import { sleep } from "@opstrace/utils";
-import { query } from "express";
-import { http } from "winston";
 
 let BROWSER: ChromiumBrowser;
 

--- a/test/test-remote/test_ui.ts
+++ b/test/test-remote/test_ui.ts
@@ -227,6 +227,8 @@ suite("test_ui_api", function () {
       c => `${c.name}=${c.value}`
     ).join("; ");
 
+    // This relies on proxy/2 pointing to Loki. Depends on the order of
+    // data sources defined in grafanaDatasources.ts
     const url = `https://system.${CLUSTER_NAME}.opstrace.io/grafana/api/datasources/proxy/2/loki/api/v1/label`;
 
     const ts = ZonedDateTime.now();
@@ -261,7 +263,8 @@ suite("test_ui_api", function () {
       c => `${c.name}=${c.value}`
     ).join("; ");
 
-    // proxy/1 means: Cortex
+    // This relies on proxy/1 pointing to Cortex. Depends on the order of
+    // data sources defined in grafanaDatasources.ts
     // Grafana 8 accesses /rules of the Cortex ruler
     // "GET /rules HTTP/1.1" 404 21 "-" "Grafana/8.0.0"
     const url = `https://system.${CLUSTER_NAME}.opstrace.io/grafana/api/datasources/proxy/1/rules`;
@@ -280,6 +283,8 @@ suite("test_ui_api", function () {
       c => `${c.name}=${c.value}`
     ).join("; ");
 
+    // This relies on proxy/2 pointing to Loki. Depends on the order of
+    // data sources defined in grafanaDatasources.ts
     // Documented with "List all rules configured for the authenticated tenant"
     const url = `https://system.${CLUSTER_NAME}.opstrace.io/grafana/api/datasources/proxy/2/loki/api/v1/rules`;
 
@@ -305,6 +310,8 @@ suite("test_ui_api", function () {
       c => `${c.name}=${c.value}`
     ).join("; ");
 
+    // This relies on proxy/2 pointing to Loki. Depends on the order of
+    // data sources defined in grafanaDatasources.ts
     // GET /prometheus/api/v1/alerts
     // Prometheus-compatible rules endpoint to list all active alerts.
     const url = `https://system.${CLUSTER_NAME}.opstrace.io/grafana/api/datasources/proxy/2/prometheus/api/v1/alerts`;

--- a/test/test-remote/test_ui.ts
+++ b/test/test-remote/test_ui.ts
@@ -243,6 +243,33 @@ suite("test_ui_api", function () {
     throw new Error("unexpected response");
   });
 
+  test("test_grafana_datasource_proxy_cortex_get_rules_legacy", async function () {
+    assert(COOKIES_AFTER_LOGIN);
+
+    const cookie_header_value = COOKIES_AFTER_LOGIN.map(
+      c => `${c.name}=${c.value}`
+    ).join("; ");
+
+    // proxy/1 means: Cortex
+    // Grafana 8 accesses /rules of the Cortex ruler
+    // "GET /rules HTTP/1.1" 404 21 "-" "Grafana/8.0.0"
+    const url = `https://system.${CLUSTER_NAME}.opstrace.io/grafana/api/datasources/proxy/1/rules`;
+
+    const httpopts = {
+      throwHttpErrors: false,
+      timeout: {
+        connect: 5000,
+        request: 30000
+      },
+      headers: {
+        Cookie: cookie_header_value
+      },
+      https: { rejectUnauthorized: false }
+    };
+    const resp = await waitFor200Resp(url, httpopts);
+    log.info("got rules doc: %s", resp.body);
+  });
+
   test("test_grafana_datasource_proxy_loki_get_rules", async function () {
     assert(COOKIES_AFTER_LOGIN);
 


### PR DESCRIPTION
Let's look at
```
            location / {
        ...
              set $backend http://querier.loki.svc.cluster.local:1080/$request_uri;
              proxy_pass $backend;
            }
```

### Special case: `location /`

Let's distinguish four cases.

* This adds a double slash from Loki's point of view, because `$request_uri` always starts with a slash (probably a cause for #908, see https://github.com/opstrace/opstrace/issues/908#issuecomment-863960135):
```
set $backend http://querier.loki.svc.cluster.local:1080/$request_uri;
```

* This always presents just `/` to Loki, forgets about the incoming URL path:
```
set $backend http://querier.loki.svc.cluster.local:1080/;
```

* These two are correct and equivalent for the special case of `location /`:
```
set $backend http://querier.loki.svc.cluster.local:1080;
```
```
set $backend http://querier.loki.svc.cluster.local:1080$request_uri;
```

### Other cases: `location /foo/bar`

Let's look at

```
            location /prometheus/api/v1/rules/ {
              set $backend http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/rules$request_uri;
              proxy_pass $backend;
            }
```

`$request_uri` is documented as full original request URI (with arguments).

When there is a request incoming at `/prometheus/api/v1/rules/foo/bar` then this location handler handles the request and `$request_uri` is `/prometheus/api/v1/rules/foo/bar`.

The request is then passed on to Loki with the URL

`http://ruler.loki.svc.cluster.local:1080/prometheus/api/v1/rules/prometheus/api/v1/rules/foo/bar`;

Clearly bogus. If the goal is to rewrite parts of the URL and to use the DNS caching workaround one cannot rely on the proxy_pass URL rewriting behavior documented at http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass

That would be this:

> If the proxy_pass directive is specified with a URI, then when a request is passed to the server, the part of a normalized request URI matching the location is *replaced* by a URI specified in the directive:

(emphasis mine)

That replacement does not work when using variables in the proxy_pass target URL. The generic solution is to extract the relevant portion in the incoming URL with regex in the location directive and to re-use that in the proxy_pass statement. Example:
```
location ~ ^/system/v1/leader/mesos(?<url>.*)$ {
    ...
    set $system_v1_leader_mesos "http://leader.mesos/system/v1$url$is_args$query_string";
    proxy_pass $system_v1_leader_mesos;
}
```
(from DC/OS' Admin Router). See the `(?<url>.*)` bit in the first line. Reused that via `$url` in the proxy_pass target.

When one only wants to carry over query args, one can use `$is_args$query_string`
