### PR TITLE
chore: don't use headless services in grafana datasource splitter proxy

### DIFF
--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -1998,6 +1998,35 @@ export function CortexResources(
           namespace
         },
         spec: {
+          ports: [
+            {
+              port: 9095,
+              name: "grcp"
+            },
+            {
+              port: 80,
+              name: "http"
+            }
+          ],
+          selector: {
+            name: "query-frontend"
+          }
+        }
+      },
+      kubeConfig
+    )
+  );
+
+  collection.add(
+    new Service(
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "query-frontend-discovery",
+          namespace
+        },
+        spec: {
           clusterIP: "None",
           ports: [
             {
@@ -2315,7 +2344,6 @@ export function CortexResources(
           namespace
         },
         spec: {
-          clusterIP: "None",
           ports: [
             {
               port: 80,

--- a/packages/upgrader/src/index.ts
+++ b/packages/upgrader/src/index.ts
@@ -43,6 +43,7 @@ import {
   waitForControllerDeployment
 } from "./readiness";
 import {
+  cleanupDeprecatedCortexServices,
   upgradeControllerConfigMap,
   upgradeControllerDeployment,
   upgradeInfra
@@ -188,6 +189,8 @@ function* triggerControllerDeploymentUpgrade() {
   const informers = yield fork(runInformers, kubeConfig);
 
   yield call(blockUntilCacheHydrated);
+
+  yield call(cleanupDeprecatedCortexServices);
 
   yield call(upgradeControllerConfigMap, kubeConfig);
 

--- a/packages/upgrader/src/informers.ts
+++ b/packages/upgrader/src/informers.ts
@@ -51,7 +51,8 @@ export function* runInformers(
       k8s.PersistentVolume.startInformer(kubeConfig, channel),
       k8s.StatefulSet.startInformer(kubeConfig, channel),
       k8s.StatefulSet.startInformer(kubeConfig, channel),
-      k8s.ConfigMap.startInformer(kubeConfig, channel)
+      k8s.ConfigMap.startInformer(kubeConfig, channel),
+      k8s.Service.startInformer(kubeConfig, channel)
     ];
 
     // return the unsubscribe function for eventChannel. This will be called when the channel

--- a/packages/upgrader/src/reducer.ts
+++ b/packages/upgrader/src/reducer.ts
@@ -22,7 +22,8 @@ import {
   deploymentsReducer,
   daemonSetsReducer,
   configMapsReducer,
-  V1CertificateReducer
+  V1CertificateReducer,
+  servicesReducer
 } from "@opstrace/kubernetes";
 
 export const rootReducers = {
@@ -33,7 +34,8 @@ export const rootReducers = {
       DaemonSets: daemonSetsReducer,
       PersistentVolumes: persistentVolumesReducer,
       ConfigMaps: configMapsReducer,
-      Certificates: V1CertificateReducer
+      Certificates: V1CertificateReducer,
+      Services: servicesReducer
     })
   })
 };


### PR DESCRIPTION
Instead of setting a DNS resolver in the grafana datasource proxy use services of type clusterIP. This way we avoid nginx caching issues when services restart.

On upgrade, the controller will fail to update the spec.clusterIP field because it's immutable. The proposed solution is to delete the old services before installing the new controller. To avoid deleting the services on every upgrade the CLI checks if the new `query-frontend-discovery` service exists or not. It it doesn't exist it means the Opstrace instance is running with the deprecated services.