### PR TITLE
controller: revert loki bump

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -17,7 +17,7 @@
   "kubeRBACProxy": "quay.io/brancz/kube-rbac-proxy:v0.8.0",
   "kubeStateMetrics": "quay.io/coreos/kube-state-metrics:v1.7.2",
   "localVolumeProvisioner": "quay.io/external_storage/local-volume-provisioner:v2.2.0",
-  "loki": "grafana/loki:2.2.1",
+  "loki": "grafana/loki:2.2.0",
   "lokiApiProxy": "opstrace/loki-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
   "memcached": "memcached:1.6.9-alpine",
   "memcachedExporter": "prom/memcached-exporter:v0.6.0",


### PR DESCRIPTION
Until we root cause https://github.com/opstrace/opstrace/issues/905 and fix the failing upgrades test let's revert the Loki bump.

I'll run the upgrades test pipeline for this PR when the cli build artifacts are published.