### PR TITLE
Bump unit test timeout to 5 mins for experimentation

### DIFF
--- a/packages/app/config/jest/setupTests.js
+++ b/packages/app/config/jest/setupTests.js
@@ -31,14 +31,16 @@ jest.mock("workers", () => {
   };
 });
 
-jest.setTimeout(15000)
+const testTimeout = 5 * 60 * 1000; // 5 mins
+
+jest.setTimeout(testTimeout);
 configure({
-  asyncUtilTimeout: 15000
-})
+  asyncUtilTimeout: testTimeout
+});
 /* limiting net requests to localhost, see
  * https://github.com/nock/nock#enabledisable-real-http-requests
  */
-nock.disableNetConnect()
+nock.disableNetConnect();
 nock.enableNetConnect(
-  host => host.includes('127.0.0.1') || host.includes('localhost')
-)
+  host => host.includes("127.0.0.1") || host.includes("localhost")
+);


### PR DESCRIPTION
CI has a flake where unit tests sometimes timeout when the timeout is 15 seconds.
Increasing timeout _significantly_ will hopefully tell us if the timeout just needs to be increased, or if the test setup has a flaw (if this still fails).

Signed-off-by: Mat Appelman <mat@opstrace.com>

