### PR TITLE
ci: use magic token for authn towards DNS service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ fetch-secrets:
 	--include "ci.id_rsa.pub" \
 	--include "opstrace-collection-cluster-authtoken-secrets.yaml" \
 	--include "dns-service-login-for-ci.json" \
+	--include "dns-service-magic-id-token-for-ci" \
 	--include "gcp-svc-acc-dev-dns-service.json" \
 	--include "gcp-svc-acc-ci-shard-aaa.json" \
 	--include "gcp-svc-acc-ci-shard-bbb.json" \

--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -192,11 +192,8 @@ echo "--- file system usage after entering CI container"
 df -h
 
 echo "--- set up dns-service credentials"
-curl --request POST \
-    --url https://opstrace-dev.us.auth0.com/oauth/token \
-    --header 'content-type: application/json' \
-    --data-binary "@secrets/dns-service-login-for-ci.json" \
-    | jq -jr .access_token > access.jwt
+# The `access.jwt` file is what the CLI is going to look for.
+cp secrets/dns-service-magic-id-token-for-ci access.jwt
 
 
 # CI_DATA_COLLECTION is an env var set in the Buildkite pipeline -- when set to

--- a/lib/dns/src/opstrace.ts
+++ b/lib/dns/src/opstrace.ts
@@ -231,10 +231,12 @@ export class DNSClient {
         ACCESS_TOKEN_FILE_PATH
       );
 
-      this.accessToken = fs.readFileSync(ACCESS_TOKEN_FILE_PATH, {
-        encoding: "utf8",
-        flag: "r"
-      });
+      this.accessToken = fs
+        .readFileSync(ACCESS_TOKEN_FILE_PATH, {
+          encoding: "utf8",
+          flag: "r"
+        })
+        .trim();
       this.additionalHeaders["authorization"] = `Bearer ${this.accessToken}`;
     }
 
@@ -244,10 +246,12 @@ export class DNSClient {
         ID_TOKEN_FILE_PATH
       );
 
-      this.idToken = fs.readFileSync(ID_TOKEN_FILE_PATH, {
-        encoding: "utf8",
-        flag: "r"
-      });
+      this.idToken = fs
+        .readFileSync(ID_TOKEN_FILE_PATH, {
+          encoding: "utf8",
+          flag: "r"
+        })
+        .trim();
       this.additionalHeaders["x-opstrace-id-token"] = this.idToken;
     }
   }


### PR DESCRIPTION
We re-deployed the DNS service with authentication architecture changes. This here is the corresponding change in our CI, so that CI can successfully authenticate itself towards the DNS service.