### PR TITLE
controller: switch pull policy from Always to IfNotPresent to reduce requests

### DIFF
--- a/packages/controller-config/src/resources/controller.ts
+++ b/packages/controller-config/src/resources/controller.ts
@@ -106,7 +106,7 @@ export function ControllerResources({
                 {
                   name: "opstrace-controller",
                   image: `${controllerImage}`,
-                  imagePullPolicy: "Always",
+                  imagePullPolicy: "IfNotPresent",
                   command: ["node", "--prof", "./cmd.js"],
                   args: controllerCmdlineArgs,
                   resources: {
@@ -131,15 +131,18 @@ export function ControllerResources({
                     },
                     {
                       name: "GRAPHQL_ENDPOINT",
-                      value: "http://graphql.application.svc.cluster.local:8080/v1/graphql"
+                      value:
+                        "http://graphql.application.svc.cluster.local:8080/v1/graphql"
                     },
                     {
                       name: "ALERTMANAGER_ENDPOINT",
-                      value: "http://alertmanager.cortex.svc.cluster.local/api/v1/alerts"
+                      value:
+                        "http://alertmanager.cortex.svc.cluster.local/api/v1/alerts"
                     },
                     {
                       name: "RULER_ENDPOINT",
-                      value: "http://ruler.cortex.svc.cluster.local/api/v1/rules"
+                      value:
+                        "http://ruler.cortex.svc.cluster.local/api/v1/rules"
                     }
                   ],
                   readinessProbe: {

--- a/packages/controller/src/resources/apis/cortex.ts
+++ b/packages/controller/src/resources/apis/cortex.ts
@@ -135,7 +135,7 @@ export function CortexAPIResources(
                 {
                   name: "cortex-api",
                   image: DockerImages.cortexApiProxy,
-                  imagePullPolicy: "Always",
+                  imagePullPolicy: "IfNotPresent",
                   args: cortexApiProxyCliArgs,
                   ports: [
                     {

--- a/packages/controller/src/resources/apis/dd.ts
+++ b/packages/controller/src/resources/apis/dd.ts
@@ -130,7 +130,7 @@ export function DDAPIResources(
                 {
                   name: "dd-api",
                   image: DockerImages.ddApi,
-                  imagePullPolicy: "Always",
+                  imagePullPolicy: "IfNotPresent",
                   args: ddApiCliArgs,
                   ports: [
                     {

--- a/packages/controller/src/resources/apis/loki.ts
+++ b/packages/controller/src/resources/apis/loki.ts
@@ -126,7 +126,7 @@ export function LokiAPIResources(
                 {
                   name: "loki-api",
                   image: DockerImages.lokiApiProxy,
-                  imagePullPolicy: "Always",
+                  imagePullPolicy: "IfNotPresent",
                   args: lokiApiProxyCliArgs,
                   ports: [
                     {

--- a/packages/controller/src/resources/app/api.ts
+++ b/packages/controller/src/resources/app/api.ts
@@ -138,7 +138,7 @@ export function OpstraceAPIResources(
                 {
                   name,
                   image: DockerImages.configApi,
-                  imagePullPolicy: "Always",
+                  imagePullPolicy: "IfNotPresent",
                   args: commandArgs,
                   env: commandEnv,
                   ports: [

--- a/packages/controller/src/resources/app/app.ts
+++ b/packages/controller/src/resources/app/app.ts
@@ -253,7 +253,7 @@ export function OpstraceApplicationResources(
                 {
                   name: "opstrace-application",
                   image: DockerImages.app,
-                  imagePullPolicy: "Always",
+                  imagePullPolicy: "IfNotPresent",
                   command: ["node", "dist/server.js"],
                   env: [
                     {

--- a/packages/controller/src/resources/storage/gcp.ts
+++ b/packages/controller/src/resources/storage/gcp.ts
@@ -198,7 +198,7 @@ export function StorageResources(
               containers: [
                 {
                   image: DockerImages.localVolumeProvisioner,
-                  imagePullPolicy: "Always",
+                  imagePullPolicy: "IfNotPresent",
                   name: "provisioner",
                   securityContext: {
                     privileged: true


### PR DESCRIPTION
As far as I can tell, there is no real reason to use an image pull policy of `Always` for some of our pods; this just adds extra requests to the registry which can trigger rate limits.  Instead, this PR switches the policy to `IfNotPresent`, similar to most of the other pods.