### PR TITLE
app: ts-ignore: TS7075 generator lacks return type

### DIFF
--- a/packages/app/src/state/cortex-config/sagas/cortexConfigSubscription.ts
+++ b/packages/app/src/state/cortex-config/sagas/cortexConfigSubscription.ts
@@ -55,6 +55,7 @@ export function* executeActionsChannel(channel: any) {
     }
   } finally {
     // If task cancelled, close the channel
+    //@ts-ignore: TS7075 generator lacks return type (TS 4.3)
     if (yield cancelled()) {
       chan.close();
     }
@@ -78,6 +79,7 @@ export default function* cortexConfigSubscriptionManager() {
         return;
       }
 
+      //@ts-ignore: TS7075 generator lacks return type (TS 4.3)
       const channel = yield call(cortexConfigSubscriptionEventChannel);
 
       // Fork the subscription task

--- a/packages/app/src/state/integration/sagas/integrationListSubscription.ts
+++ b/packages/app/src/state/integration/sagas/integrationListSubscription.ts
@@ -47,6 +47,7 @@ export function* executeActionsChannel(channel: any) {
     }
   } finally {
     // If task cancelled, close the channel
+    //@ts-ignore: TS7075 generator lacks return type (TS 4.3)
     if (yield cancelled()) {
       chan.close();
     }
@@ -83,6 +84,7 @@ export default function* integrationListSubscriptionManager() {
         return;
       }
 
+      //@ts-ignore: TS7075 generator lacks return type (TS 4.3)
       const channel = yield call(
         integrationListSubscriptionEventChannel(action.payload.tenant)
       );

--- a/packages/app/src/state/store.ts
+++ b/packages/app/src/state/store.ts
@@ -13,25 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createStore as createReduxStore, applyMiddleware } from "redux";
+import { createStore as createReduxStore, applyMiddleware, Store } from "redux";
 import createSagaMiddleware from "redux-saga";
 import { composeWithDevTools } from "redux-devtools-extension";
 
 import { mainReducer } from "./reducer";
 import mainSaga from "./sagas";
 
-type StoreType = ReturnType<typeof createMainStore>;
+let _store: Store;
 
-let _store: StoreType;
-
-export default function getStore(): StoreType {
+export default function getStore(): Store {
   if (!_store) {
     _store = createMainStore();
   }
   return _store;
 }
 
-function createMainStore(): StoreType {
+function createMainStore(): Store {
   const sagaMiddleware = createSagaMiddleware();
   const middlewares = [sagaMiddleware];
 

--- a/packages/app/src/state/store.ts
+++ b/packages/app/src/state/store.ts
@@ -20,16 +20,18 @@ import { composeWithDevTools } from "redux-devtools-extension";
 import { mainReducer } from "./reducer";
 import mainSaga from "./sagas";
 
-let _store: ReturnType<typeof createMainStore>;
+type StoreType = ReturnType<typeof createMainStore>;
 
-export default function getStore() {
+let _store: StoreType;
+
+export default function getStore(): StoreType {
   if (!_store) {
     _store = createMainStore();
   }
   return _store;
 }
 
-function createMainStore() {
+function createMainStore(): StoreType {
   const sagaMiddleware = createSagaMiddleware();
   const middlewares = [sagaMiddleware];
 

--- a/packages/app/src/state/user/sagas/userListSubscription.ts
+++ b/packages/app/src/state/user/sagas/userListSubscription.ts
@@ -53,6 +53,7 @@ export function* executeActionsChannel(channel: any) {
     }
   } finally {
     // If task cancelled, close the channel
+    //@ts-ignore: TS7075 generator lacks return type (TS 4.3)
     if (yield cancelled()) {
       chan.close();
     }
@@ -79,6 +80,7 @@ export default function* userListSubscriptionManager() {
         return;
       }
 
+      //@ts-ignore: TS7075 generator lacks return type (TS 4.3)
       const channel = yield call(userListSubscriptionEventChannel);
 
       // Fork the subscription task


### PR DESCRIPTION
Quick fix for https://github.com/opstrace/opstrace/issues/967. 

Of course we may want to set proper return types instead.