### PR TITLE
go: log as debug message

### DIFF
--- a/go/pkg/authenticator/jwt.go
+++ b/go/pkg/authenticator/jwt.go
@@ -117,7 +117,7 @@ func keyLookupCallback(unveriftoken *jwt.Token) (interface{}, error) {
 			)
 		}
 
-		log.Info("kid not set in auth token, use fallback key (is configured)")
+		log.Debug("kid not set in auth token, use fallback key (is configured)")
 		return authtokenVerificationPubKeyFallback, nil
 	}
 }


### PR DESCRIPTION
Default log level is info and in busy instances, handling hundreds of requests per second, this message spams the logs.

Found this tracking down why systemlog fluentd CPU usage was higher than expected;

![screenshot](https://user-images.githubusercontent.com/495294/124141983-5d87a200-da79-11eb-8c18-a26e848fb75b.png)

cortex-api pod logs:

![Screenshot from 2021-07-01 14-36-05](https://user-images.githubusercontent.com/495294/124142399-b5260d80-da79-11eb-8df6-9291df444730.png)
