### PR TITLE
ci: set up gcloud in test-remote container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -633,7 +633,7 @@ test-remote-looker:
 #     suite/test name. `make test-remote-ui` runs all tests that match.
 #     Note: `--invert, -i  Inverts --grep and --fgrep matches`.
 .PHONY: test-remote-ui
-test-remote-ui: kubectl-cluster-info
+test-remote-ui:
 	echo "--- running test-remote-ui"
 	mkdir -p ${OPSTRACE_BUILD_DIR}/test-remote-artifacts
 	docker run --tty --interactive --rm \
@@ -668,7 +668,7 @@ test-remote-ui: kubectl-cluster-info
 
 # This runs our set of browser based tests using the Playwright Test Runner
 .PHONY: test-browser
-test-browser: kubectl-cluster-info
+test-browser:
 	echo "--- running test-browser"
 	mkdir -p ${OPSTRACE_BUILD_DIR}/browser-test-results
 	docker run --tty --interactive --rm \

--- a/Makefile
+++ b/Makefile
@@ -555,15 +555,22 @@ rebuild-looker-container-image:
 	make -C test/test-remote/looker image
 
 
+#
+# Mounts the secrets in the container for gcloud to access the GCP credentials.
+#
 .PHONY: kubectl-cluster-info
 kubectl-cluster-info:
 	docker run --tty --interactive --rm \
 		-v ${OPSTRACE_KUBE_CONFIG_HOST}:/kubeconfig:ro \
+		-v ${OPSTRACE_BUILD_DIR}/secrets:/secrets:ro \
 		-u $(shell id -u):${DOCKER_GID_HOST} \
 		-v /etc/passwd:/etc/passwd \
 		-e KUBECONFIG=/kubeconfig/config \
 		-e AWS_ACCESS_KEY_ID \
 		-e AWS_SECRET_ACCESS_KEY \
+		-e GCLOUD_CLI_REGION \
+		-e GCLOUD_CLI_ZONE \
+		-e GOOGLE_APPLICATION_CREDENTIALS \
 		--dns $(shell ci/dns_cache.sh) \
 		opstrace/test-remote:$(CHECKOUT_VERSION_STRING) \
 		kubectl cluster-info

--- a/test/test-remote/nodejs-testrunner.Dockerfile
+++ b/test/test-remote/nodejs-testrunner.Dockerfile
@@ -19,6 +19,18 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install && \
     rm awscliv2.zip
 
+# gcloud CLI, required to refresh kubeconfig credentials
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+RUN apt-get update && apt-get install -y -q --no-install-recommends google-cloud-sdk
+RUN apt-get -y autoclean
+
+RUN gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image
+
 # Make the /build/test/test-remote directory in the container image be the NPM package dir
 # for the `test-remote` package. Bake the NPM package dependencies into the container image
 # by running `yarn install`, based on package.json and yarn lock file.


### PR DESCRIPTION
* Some of the test targets don't require kubeconfig to be set up.
* Add gcloud cli to test-remote container. The cli is required to refresh expired kubeconfig credentials.

Close #977
