### PR TITLE
ui: changes to enable FF in browser tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -680,16 +680,13 @@ test-browser:
 	mkdir -p ${OPSTRACE_BUILD_DIR}/browser-test-results
 	docker run --tty --interactive --rm \
 		--net=host \
+		--dns $(shell ci/dns_cache.sh) \
 		-v ${OPSTRACE_BUILD_DIR}/browser-test-results:/build/test/browser/test-results \
-		-v /tmp:/tmp \
-		-u $(shell id -u):${DOCKER_GID_HOST} \
-		-v /etc/passwd:/etc/passwd \
 		-e OPSTRACE_CLUSTER_NAME \
 		-e OPSTRACE_CLOUD_PROVIDER \
-		--dns $(shell ci/dns_cache.sh) \
-		--workdir /build/test/browser \
-		opstrace/test-browser:$(CHECKOUT_VERSION_STRING) \
+	  opstrace/test-browser:$(CHECKOUT_VERSION_STRING) \
  		yarn playwright test --workers 1 --forbid-only
+
 
 # Used by CI:
 # three outcomes:

--- a/ci/cd/run.sh
+++ b/ci/cd/run.sh
@@ -31,7 +31,7 @@ make ci-cd-upgrade-cluster
 # TODO(sreis): the system logs test suite (check loki ingester logs, check
 # cortex ingester logs, check systemlog Fluentd instance logs) needs to account
 # for long running clusters.
+make test-browser
 make test-remote || true
 make test-remote-looker
 make test-remote-ui
-make test-browser

--- a/ci/test-upgrade/run.sh
+++ b/ci/test-upgrade/run.sh
@@ -42,7 +42,7 @@ make ci-testupgrade-create-cluster
 
 make ci-testupgrade-upgrade-cluster
 
+make test-browser
 make test-remote
 make test-remote-looker
 make test-remote-ui
-make test-browser

--- a/test/browser/Dockerfile
+++ b/test/browser/Dockerfile
@@ -1,6 +1,4 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/playwright:v1.12.3-focal
-
-ENV DOCKER v14.15.4
+FROM mcr.microsoft.com/playwright:v1.12.3-focal
 
 RUN mkdir -p /build/test/browser/test-results
 WORKDIR /build/test/browser

--- a/test/browser/fixtures/authenticated.ts
+++ b/test/browser/fixtures/authenticated.ts
@@ -20,14 +20,15 @@ import { log } from "../utils";
 
 const CLUSTER_NAME: string = process.env.OPSTRACE_CLUSTER_NAME || "unknown";
 
-const CLUSTER_BASE_URL: string = !process.env.OPSTRACE_CLUSTER_BASE_URL
+export const CLUSTER_BASE_URL: string = !process.env.OPSTRACE_CLUSTER_BASE_URL
   ? `https://${CLUSTER_NAME}.opstrace.io`
   : process.env.OPSTRACE_CLUSTER_BASE_URL;
 
-const CLOUD_PROVIDER: string = process.env.OPSTRACE_CLOUD_PROVIDER || "unknown";
+export const CLOUD_PROVIDER: string =
+  process.env.OPSTRACE_CLOUD_PROVIDER || "unknown";
 
-const CI_LOGIN_EMAIL = "ci-test@opstrace.com";
-const CI_LOGIN_PASSWORD = "This-is-not-a-secret!";
+export const CI_LOGIN_EMAIL = "ci-test@opstrace.com";
+export const CI_LOGIN_PASSWORD = "This-is-not-a-secret!";
 
 type SystemFixture = {
   runningInCI: boolean;

--- a/test/browser/playwright.config.ts
+++ b/test/browser/playwright.config.ts
@@ -15,7 +15,7 @@
  */
 
 import { PlaywrightTestConfig } from "@playwright/test";
-// import { devices } from "@playwright/test";
+import { devices } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
   reporter: "dot",
@@ -33,37 +33,34 @@ const config: PlaywrightTestConfig = {
     {
       name: "Chromium",
       use: {
-        browserName: "chromium"
-
-        // terrcin - this is from the old test-remote running of chrome, does not appear to be needed yet and also not sure how to specify it with playwright test runner
-        // args: [
-        //   // https://github.com/microsoft/playwright/blob/761bd78879c83ed810ae38ef39513b2d874badb1/docs/ci.md#docker
-        //   "--disable-dev-shm-usage"
-        // ]
+        browserName: "chromium",
+        launchOptions: {
+          args: ["--disable-dev-shm-usage"] // https://playwright.dev/python/docs/ci/#docker
+        }
       }
     },
-    // {
-    //   name: "Firefox",
-    //   use: { browserName: "firefox" }
-    // },
+    {
+      name: "Firefox",
+      use: { browserName: "firefox" }
+    },
     {
       name: "WebKit",
       use: { browserName: "webkit" }
+    },
+    {
+      name: "Pixel-4",
+      use: {
+        browserName: "chromium",
+        ...devices["Pixel 4"]
+      }
+    },
+    {
+      name: "iPhone-11",
+      use: {
+        browserName: "webkit",
+        ...devices["iPhone 11"]
+      }
     }
-    // {
-    //   name: "Pixel-4",
-    //   use: {
-    //     browserName: "chromium",
-    //     ...devices["Pixel 4"]
-    //   }
-    // },
-    // {
-    //   name: "iPhone-11",
-    //   use: {
-    //     browserName: "webkit",
-    //     ...devices["iPhone 11"]
-    //   }
-    // }
   ]
 };
 

--- a/test/browser/tests/debugging.spec.ts
+++ b/test/browser/tests/debugging.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from "@playwright/test";
+
+import {
+  CLUSTER_BASE_URL,
+  CLOUD_PROVIDER,
+  CI_LOGIN_EMAIL,
+  CI_LOGIN_PASSWORD
+} from "../fixtures/authenticated";
+
+test.describe("debugging", () => {
+  test("this should PASS all the time", async ({ page }) => {
+    expect(true).toBeTruthy();
+  });
+
+  test.skip("this should FAIL all the time", async ({ page }) => {
+    expect(false).toBeTruthy();
+  });
+
+  test.skip("can I get Firefox to login this way?", async ({ page }) => {
+    await page.goto(CLUSTER_BASE_URL);
+
+    // <button class="MuiButtonBase-root Mui... MuiButton-sizeLarge" tabindex="0" type="button">
+    // <span class="MuiButton-label">Log in</span>
+    await page.waitForSelector("css=button");
+
+    await page.click("text=Log in");
+
+    // Wait for CI-specific username/pw login form to appear
+    await page.waitForSelector("text=Don't remember your password?");
+
+    await page.fill("css=input[type=email]", CI_LOGIN_EMAIL);
+    await page.fill("css=input[type=password]", CI_LOGIN_PASSWORD);
+
+    await page.click("css=button[type=submit]");
+
+    // The first view after successful login is expected to be the details page
+    // for the `system` tenant, showing a link to Grafana.
+    await page.waitForSelector("[data-test=getting-started]");
+
+    expect(await page.isVisible("[data-test=getting-started]")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
This is a re-do of https://github.com/opstrace/opstrace/pull/956 to get around an automated merge with main issue and so as to not pollute main with all my debugging CI commits.

The problem this resolves is that FF was not running on CI at all, was getting no debug output from fail tests etc.. It would do the initial auth step for the worker. What was happening was that the user ID being set in the `docker run` command was causing FF to not run. I don't have any links to this but from the huge amount of reading through various github issues that's what was likely the cause and then when I let it run as root everything worked.