### PR TITLE
ci(test-upgrade): exit early if a command fails

### DIFF
--- a/ci/test-upgrade/preamble.sh
+++ b/ci/test-upgrade/preamble.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eou pipefail
+
 make rebuild-ci-container-image
 # testrunner run tsc which requires buildinfo package to be set
 make set-build-info-constants


### PR DESCRIPTION
Upgrades were failing to build the test-remote docker image but kept running anyway because the preamble step was missing the bash incantantion.

Upgrades error:
```
[2021-07-04T20:55:41Z] error Command failed with exit code 2.
[2021-07-04T20:55:41Z] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
https://buildkite.com/opstrace/upgrade-tests/builds/928#f3ac88f3-790c-46ef-ad50-a8d648d49297/1064-2569

