### PR TITLE
ci: collect unbound logs

### DIFF
--- a/ci/create-cluster-artifacts.sh
+++ b/ci/create-cluster-artifacts.sh
@@ -1,5 +1,7 @@
 # to be `source`d as part of teardown after test-remote
 
+docker logs --since "2h" unbound > /build/bk-artifacts/unbound.log
+
 kubectl describe all --all-namespaces 2> kubectl_describe_all.stderr > kubectl_describe_all-${OPSTRACE_CLUSTER_NAME}.log
 
 # Filter out a specific warning that may appear thousands of times on AWS:

--- a/ci/dns_cache.sh
+++ b/ci/dns_cache.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # script adapted from https://adaptjs.org/blog/2019/10/14/fixing-dns-timeouts-in-docker, thank you!
 
-: "${IMAGE:=mvance/unbound:1.12.0}"
+: "${IMAGE:=mvance/unbound:1.13.1}"
 : "${NAME:=unbound}"
 : "${DNS_IP_FILE:=/tmp/dns_cache_ip}"
 


### PR DESCRIPTION
To help track down recent DNS not found errors as reported in #834. 
