### PR TITLE
ui: have CI retry failed browser tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -685,7 +685,7 @@ test-browser:
 		-e OPSTRACE_CLUSTER_NAME \
 		-e OPSTRACE_CLOUD_PROVIDER \
 	  opstrace/test-browser:$(CHECKOUT_VERSION_STRING) \
- 		yarn playwright test --workers 1 --forbid-only
+ 		yarn playwright test --workers 1 --forbid-only --retries 1
 
 
 # Used by CI:

--- a/test/browser/Dockerfile
+++ b/test/browser/Dockerfile
@@ -12,4 +12,11 @@ RUN yarn playwright test -h
 
 COPY . /build/test/browser
 
+# add a random string to the begining of each spec filename so that they run in a random order each time
+# this doesn't change the order tests in each spec run
+WORKDIR /build/test/browser/tests
+RUN for i in *.spec.ts; do mv "$i" `cat /dev/random | tr -dc 'a-zA-Z0-9' | fold -w 5 | head -n 1`_"$i"; done
+
+WORKDIR /build/test/browser
+
 CMD ["/bin/bash"]

--- a/test/browser/tests/authentication.spec.ts
+++ b/test/browser/tests/authentication.spec.ts
@@ -23,11 +23,7 @@ test.describe("after auth0 authentication", () => {
   test.beforeEach(logUserIn);
 
   test("user should see homepage", async ({ page, cluster }) => {
-    expect(
-      await page.isVisible("[data-test=getting-started]", {
-        timeout: cluster.cloudProvider.aws ? 60_000 : 30_000 // timeout: keeps failing on AWS CI and not GCP probably because AWS is much slower that GCP
-      })
-    ).toBeTruthy();
+    expect(await page.isVisible("[data-test=getting-started]")).toBeTruthy();
   });
 
   test("user should see own email in user list", async ({ page, user }) => {

--- a/test/browser/tests/debugging.spec.ts
+++ b/test/browser/tests/debugging.spec.ts
@@ -24,10 +24,6 @@ import {
 } from "../fixtures/authenticated";
 
 test.describe("debugging", () => {
-  test("this should PASS all the time", async ({ page }) => {
-    expect(true).toBeTruthy();
-  });
-
   test.skip("this should FAIL all the time", async ({ page }) => {
     expect(false).toBeTruthy();
   });

--- a/test/browser/tests/debugging.spec.ts
+++ b/test/browser/tests/debugging.spec.ts
@@ -25,6 +25,7 @@ import {
 
 test.describe("debugging", () => {
   test("this should FAIL all the time", async ({ page }) => {
+    test.skip();
     expect(false).toBeTruthy();
   });
 

--- a/test/browser/tests/debugging.spec.ts
+++ b/test/browser/tests/debugging.spec.ts
@@ -24,11 +24,12 @@ import {
 } from "../fixtures/authenticated";
 
 test.describe("debugging", () => {
-  test.skip("this should FAIL all the time", async ({ page }) => {
+  test("this should FAIL all the time", async ({ page }) => {
     expect(false).toBeTruthy();
   });
 
-  test.skip("can I get Firefox to login this way?", async ({ page }) => {
+  test("can I get Firefox to login this way?", async ({ page }) => {
+    test.skip();
     await page.goto(CLUSTER_BASE_URL);
 
     // <button class="MuiButtonBase-root Mui... MuiButton-sizeLarge" tabindex="0" type="button">


### PR DESCRIPTION
refer to the related issue: https://github.com/opstrace/opstrace/issues/991

I will be hitting rebuild a few times on this PR to exercise the change on CI to see what effect the `--retries 1` setting has.