### PR TITLE
looker: Shift label randomness into invocation_id, allow configuration 

### DIFF
--- a/test/test-remote/looker/src/args.ts
+++ b/test/test-remote/looker/src/args.ts
@@ -400,7 +400,7 @@ export function parseCmdlineArgs(): void {
     }
   }
 
-  if (CFG.max_concurrent_writes === 0) { // TODO this is always zero - remove from CFG?
+  if (CFG.max_concurrent_writes === 0) {
     CFG.max_concurrent_writes = CFG.n_concurrent_streams;
   }
 

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -188,12 +188,14 @@ async function createNewSeries(
             CFG.metrics_past_start_range_min_seconds,
             CFG.metrics_past_start_range_max_seconds
         );
+      // TODO some sort of adjustable cardinality here, where the number of distinct label
+      //      permutations across a series is configurable? (e.g. 10k distinct labels across a series)
       stream = new MetricSeries(
         {
-          // the same across concurrent streams, contains invocation_id
+          // kept distinct across concurrent streams, see above TODO about sharing metric names
           // ensure any dashes in metric name are switched to underscores: required by prometheus
           // see also: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-          metricName: guniqueCycleId.replace(/-/g, "_"),
+          metricName: streamname.replace(/-/g, "_"),
           // must not collide among concurrent streams
           uniqueName: streamname,
           n_samples_per_series_fragment: CFG.n_entries_per_stream_fragment,

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -190,9 +190,12 @@ async function createNewSeries(
         );
       stream = new MetricSeries(
         {
-          // fixed according to the cycle id
-          metricName: guniqueCycleId, // the same across concurrent streams, contains invocation_id
-          uniqueName: streamname, // must not collide among concurrent streams
+          // the same across concurrent streams, contains invocation_id
+          // ensure any dashes in metric name are switched to underscores: required by prometheus
+          // see also: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+          metricName: guniqueCycleId.replace(/-/g, "_"),
+          // must not collide among concurrent streams
+          uniqueName: streamname,
           n_samples_per_series_fragment: CFG.n_entries_per_stream_fragment,
 
           // With Cortex' Blocks Storage system, we cannot go into the future

--- a/test/test-remote/looker/src/metrics/dummyseries.ts
+++ b/test/test-remote/looker/src/metrics/dummyseries.ts
@@ -407,7 +407,7 @@ export class MetricSeries extends TimeseriesBase {
       return [shiftIntoPastSeconds, undefined];
     }
 
-    const t0 = mtime();
+    //const t0 = mtime();
     const fragment = new MetricSeriesFragment(
       this.labels,
       this.nFragmentsConsumed + 1,
@@ -418,11 +418,11 @@ export class MetricSeries extends TimeseriesBase {
       fragment.addSample(this.nextSample());
     }
 
-    const genduration = mtimeDiffSeconds(t0);
-    log.debug(
-      "MetricSeriesFragment addSample loop took: %s s",
-      genduration.toFixed(3)
-    );
+    //const genduration = mtimeDiffSeconds(t0);
+    //log.debug(
+    //  "MetricSeriesFragment addSample loop took: %s s",
+    //  genduration.toFixed(3)
+    //);
     return [shiftIntoPastSeconds, fragment];
   }
 

--- a/test/test-remote/looker/src/metrics/dummyseries.ts
+++ b/test/test-remote/looker/src/metrics/dummyseries.ts
@@ -205,7 +205,7 @@ export class MetricSeries extends TimeseriesBase {
 
   protected buildLabelSetFromOpts(opts: MetricSeriesOpts): LabelSet {
     // Merge the metric name into it using the well-known special prom label
-    // __name__. Always set `__name__`. If `opts.labelset` is
+    // __name__. Always set `uniquename` and `__name__`. If `opts.labelset` is
     // provided then treat this as _additional_ label set.
     let ls: LabelSet;
     if (opts.labelset !== undefined) {

--- a/test/test-remote/looker/src/metrics/dummyseries.ts
+++ b/test/test-remote/looker/src/metrics/dummyseries.ts
@@ -205,7 +205,7 @@ export class MetricSeries extends TimeseriesBase {
 
   protected buildLabelSetFromOpts(opts: MetricSeriesOpts): LabelSet {
     // Merge the metric name into it using the well-known special prom label
-    // __name__. Always set `uniquename` and `__name__`. If `opts.labelset` is
+    // __name__. Always set `__name__`. If `opts.labelset` is
     // provided then treat this as _additional_ label set.
     let ls: LabelSet;
     if (opts.labelset !== undefined) {


### PR DESCRIPTION
Randomness is provided via `invocation_id`, and then uniqueness across cycles and concurrent_streams is added on top via the indexes. End result:
- Metrics:
    - metricName: `<invocation_id>-<cycle#>`
    - uniqueName: `<invocation_id>-<cycle#>-<stream#>`
- Logs:
    - uniqueName: `<invocation_id>-<cycle#>-<stream#>`
    
With all the randomness moved into `invocation_id` (and with it exposed in the args), it can be overridden manually, allowing e.g. series counts to remain stable across looker runs - or the caller can guarantee unique values by using a custom randomness.

---

ALSO:

Add args for configuring range of metric series start times: Allow using ranges other than default 20-30 minutes.