### PR TITLE
ui: updated Tenant reducer to handle delete action

### DIFF
--- a/packages/app/src/state/tenant/reducer.ts
+++ b/packages/app/src/state/tenant/reducer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { pluck, zipObj, pick, mergeDeepRight } from "ramda";
+import { pluck, zipObj, pick, mergeDeepRight, omit } from "ramda";
 
 import { createReducer, ActionType } from "typesafe-actions";
 import { TenantRecords } from "./types";
@@ -42,6 +42,15 @@ export const reducer = createReducer<TenantState, TenantActions>(
       const tenantIds: string[] = pluck("name", action.payload);
       const tenants: TenantRecords = zipObj(tenantIds, action.payload);
       return mergeDeepRight(state, { loading: false, tenants: tenants });
+    }
+  )
+  .handleAction(
+    actions.deleteTenant,
+    (state, action): TenantState => {
+      return {
+        loading: state.loading,
+        tenants: omit([action.payload])(state.tenants)
+      };
     }
   )
   .handleAction(

--- a/test/browser/tests/tenant.spec.ts
+++ b/test/browser/tests/tenant.spec.ts
@@ -54,9 +54,6 @@ test.describe("after auth0 authentication", () => {
   });
 
   test("user can delete a Tenant", async ({ page, cluster }) => {
-    // TODO: when deleting tenants is fixed remove this line,
-    // https://github.com/opstrace/opstrace/issues/993
-    test.fail();
     const tenantName = makeTenantName();
     expect(
       await page.isVisible(`[data-test='tenant/row/${tenantName}']`)


### PR DESCRIPTION
doing this doesn't resolve the Apollo Client warning, but now it works from the user's perspective.
