### PR TITLE
[wip] ui: do auth as part of each browser test rather than per worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -687,6 +687,7 @@ test-browser:
 		-e OPSTRACE_CLUSTER_NAME \
 		-e OPSTRACE_CLOUD_PROVIDER \
 		-e OPSTRACE_INSTANCE_DNS_NAME \
+		-e OPSTRACE_AUTH_METHOD=test \
 		-e DEBUG=pw:api \
 		opstrace/test-browser:$(CHECKOUT_VERSION_STRING) \
  			yarn playwright test --workers 1 --forbid-only --retries 1

--- a/Makefile
+++ b/Makefile
@@ -688,7 +688,6 @@ test-browser:
 		-e OPSTRACE_CLOUD_PROVIDER \
 		-e OPSTRACE_INSTANCE_DNS_NAME \
 		-e OPSTRACE_AUTH_METHOD=test \
-		-e DEBUG=pw:api \
 		opstrace/test-browser:$(CHECKOUT_VERSION_STRING) \
  			yarn playwright test --workers 1 --forbid-only --retries 1
 

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -87,10 +87,10 @@ import { expect } from "@playwright/test";
 
 // Note: this is not the playwright "test" object but one that has had the authentication worker fixture added to it
 import { test } from "../fixtures/authenticated";
-import { logUserIn } from "../utils/authentication";
+import { restoreLogin } from "../utils";
 
 test.describe("after auth0 authentication", () => {
-  test.beforeEach(logUserIn);
+  test.beforeEach(restoreLogin);
 
   test("user should see homepage", async ({ page }) => {
     expect(await page.isVisible("text=Getting Started")).toBeTruthy();

--- a/test/browser/fixtures/authenticated.ts
+++ b/test/browser/fixtures/authenticated.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Cookie } from "@playwright/test";
+import { Cookie, TestType } from "@playwright/test";
 
-import { log } from "../utils";
+import { performLogin, log } from "../utils";
 
 // First, check for _required_ env vars (keep this simple, to comply with README)
 if (
@@ -81,7 +81,7 @@ type AuthenticationFixture = {
   authCookies: Cookie[];
 };
 
-export const addAuthFixture = test =>
+export const addAuthFixture = (test: TestType) =>
   test.extend<Record<string, never>, AuthenticationFixture>({
     system: [
       async ({ browser }, use) => {
@@ -118,25 +118,7 @@ export const addAuthFixture = test =>
         const context = await browser.newContext({ ignoreHTTPSErrors: true });
         const page = await context.newPage();
 
-        await page.goto(CLUSTER_BASE_URL);
-
-        // <button class="MuiButtonBase-root Mui... MuiButton-sizeLarge" tabindex="0" type="button">
-        // <span class="MuiButton-label">Log in</span>
-        await page.waitForSelector("css=button");
-
-        await page.click("text=Log in");
-
-        // Wait for CI-specific username/pw login form to appear
-        await page.waitForSelector("text=Don't remember your password?");
-
-        await page.fill("css=input[type=email]", CI_LOGIN_EMAIL);
-        await page.fill("css=input[type=password]", CI_LOGIN_PASSWORD);
-
-        await page.click("css=button[type=submit]");
-
-        // The first view after successful login is expected to be the details page
-        // for the `system` tenant, showing a link to Grafana.
-        await page.waitForSelector("[data-test=getting-started]");
+        await performLogin(page, CI_LOGIN_EMAIL, CI_LOGIN_PASSWORD);
 
         const cookies = await page.context().cookies();
         await page.close();

--- a/test/browser/fixtures/authenticated.ts
+++ b/test/browser/fixtures/authenticated.ts
@@ -18,112 +18,25 @@ import { Cookie, TestType } from "@playwright/test";
 
 import { performLogin, log } from "../utils";
 
-// First, check for _required_ env vars (keep this simple, to comply with README)
-if (
-  process.env.OPSTRACE_CLOUD_PROVIDER !== "aws" &&
-  process.env.OPSTRACE_CLOUD_PROVIDER !== "gcp"
-) {
-  log.error(
-    "env variable OPSTRACE_CLOUD_PROVIDER must be set to `aws` or `gcp`"
-  );
-  process.exit(1);
-}
-export const CLOUD_PROVIDER: string = process.env.OPSTRACE_CLOUD_PROVIDER;
-
-if (!process.env.OPSTRACE_CLUSTER_NAME) {
-  log.error("env variable OPSTRACE_CLUSTER_NAME must be set");
-  process.exit(1);
-}
-export const CLUSTER_NAME: string = process.env.OPSTRACE_CLUSTER_NAME;
-
-// Now, deal with optional env var. There is a default DNS name pointing to
-// this Opstrace instance. Use that if OPSTRACE_INSTANCE_DNS_NAME is not set
-// via env
-let OPSTRACE_INSTANCE_DNS_NAME: string;
-OPSTRACE_INSTANCE_DNS_NAME = `${CLUSTER_NAME}.opstrace.io`;
-if (process.env.OPSTRACE_INSTANCE_DNS_NAME) {
-  log.debug(
-    "env variable OPSTRACE_INSTANCE_DNS_NAME is set: %s",
-    process.env.OPSTRACE_INSTANCE_DNS_NAME
-  );
-  OPSTRACE_INSTANCE_DNS_NAME = process.env.OPSTRACE_INSTANCE_DNS_NAME;
-} else {
-  log.debug("env variable OPSTRACE_INSTANCE_DNS_NAME not set");
-}
-
-// CLUSTER_BASE_URL is fully specified by OPSTRACE_INSTANCE_DNS_NAME -- that's
-// by definition of that very DNS name. That is, the base URL does not need to
-// be injected via env.
-export const CLUSTER_BASE_URL = `https://${OPSTRACE_INSTANCE_DNS_NAME}`;
-export const CI_LOGIN_EMAIL = "ci-test@opstrace.com";
-export const CI_LOGIN_PASSWORD = "This-is-not-a-secret!";
-
-type SystemFixture = {
-  runningInCI: boolean;
-};
-
-const CLOUD_PROVIDER_DEFAULTS = { aws: false, gcp: false };
-
-type ClusterFixture = {
-  name: string;
-  baseUrl: string;
-  cloudProvider: Record<string, boolean>;
-};
-
-type UserFixture = {
-  email: string;
-};
-
 type AuthenticationFixture = {
-  system: SystemFixture;
-  cluster: ClusterFixture;
-  user: UserFixture;
   authCookies: Cookie[];
 };
 
 export const addAuthFixture = (test: TestType) =>
   test.extend<Record<string, never>, AuthenticationFixture>({
-    system: [
-      async ({ browser }, use) => {
-        const system: SystemFixture = {
-          runningInCI: process.env.BUILDKITE === "true"
-        };
-        await use(system);
-      },
-      { scope: "worker" }
-    ],
-    cluster: [
-      async ({ browser }, use) => {
-        const cluster: ClusterFixture = {
-          name: CLUSTER_NAME,
-          baseUrl: CLUSTER_BASE_URL,
-          cloudProvider: CLOUD_PROVIDER_DEFAULTS
-        };
-        cluster.cloudProvider[CLOUD_PROVIDER] = true;
-        await use(cluster);
-      },
-      { scope: "worker" }
-    ],
-    user: [
-      async ({ browser }, use) => {
-        const user: UserFixture = {
-          email: CI_LOGIN_EMAIL
-        };
-        await use(user);
-      },
-      { scope: "worker" }
-    ],
     authCookies: [
-      async ({ browser }, use) => {
-        const context = await browser.newContext({ ignoreHTTPSErrors: true });
-        const page = await context.newPage();
+      async ({ browser, system, cluster, user }, use) => {
+        if (system.workerAuth) {
+          const context = await browser.newContext({ ignoreHTTPSErrors: true });
+          const page = await context.newPage();
 
-        await performLogin(page, CI_LOGIN_EMAIL, CI_LOGIN_PASSWORD);
+          await performLogin({ page, cluster, user });
 
-        const cookies = await page.context().cookies();
-        await page.close();
+          const cookies = await page.context().cookies();
+          await page.close();
 
-        await use(cookies);
+          await use(cookies);
+        } else await use(null);
       },
       { scope: "worker", auto: true }
     ]

--- a/test/browser/fixtures/config.ts
+++ b/test/browser/fixtures/config.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestType } from "@playwright/test";
+
+import { log } from "../utils";
+
+const CLUSTER_NAME: string = process.env.OPSTRACE_CLUSTER_NAME || "unknown";
+
+const CLUSTER_BASE_URL: string = !process.env.OPSTRACE_CLUSTER_BASE_URL
+  ? `https://${CLUSTER_NAME}.opstrace.io`
+  : process.env.OPSTRACE_CLUSTER_BASE_URL;
+
+const CLOUD_PROVIDER: string = process.env.OPSTRACE_CLOUD_PROVIDER || "unknown";
+
+type SystemFixture = {
+  runningInCI: boolean;
+  workerAuth: boolean;
+};
+
+const CLOUD_PROVIDER_DEFAULTS = { aws: false, gcp: false, unknown: false };
+
+type ClusterFixture = {
+  name: string;
+  baseUrl: string;
+  cloudProvider: Record<string, boolean>;
+};
+
+type UserFixture = {
+  email: string;
+  password: string;
+};
+
+type ConfigFixture = {
+  system: SystemFixture;
+  cluster: ClusterFixture;
+  user: UserFixture;
+};
+
+export const addConfigFixture = (test: TestType) =>
+  test.extend<Record<string, never>, ConfigFixture>({
+    system: [
+      async ({ browser }, use) => {
+        const system: SystemFixture = {
+          runningInCI: process.env.BUILDKITE === "true",
+          workerAuth: process.env.OPSTRACE_AUTH_METHOD !== "test"
+        };
+        await use(system);
+      },
+      { scope: "worker" }
+    ],
+    cluster: [
+      async ({ browser }, use) => {
+        if (!CLUSTER_BASE_URL) {
+          log.error(
+            "env variables OPSTRACE_CLUSTER_NAME or OPSTRACE_CLUSTER_BASE_URL must be set"
+          );
+          process.exit(1);
+        }
+
+        if (!CLOUD_PROVIDER) {
+          log.error(
+            "env variable OPSTRACE_CLOUD_PROVIDER must be set to `aws` or `gcp`"
+          );
+          process.exit(1);
+        }
+
+        const cluster: ClusterFixture = {
+          name: CLUSTER_NAME,
+          baseUrl: CLUSTER_BASE_URL,
+          cloudProvider: CLOUD_PROVIDER_DEFAULTS
+        };
+        cluster.cloudProvider[CLOUD_PROVIDER] = true;
+        await use(cluster);
+      },
+      { scope: "worker" }
+    ],
+    user: [
+      async ({ browser }, use) => {
+        const user: UserFixture = {
+          email: "ci-test@opstrace.com",
+          password: "This-is-not-a-secret!"
+        };
+        await use(user);
+      },
+      { scope: "worker" }
+    ]
+  });

--- a/test/browser/fixtures/config.ts
+++ b/test/browser/fixtures/config.ts
@@ -63,7 +63,7 @@ export const addConfigFixture = (test: TestType) =>
         if (dnsName) {
           baseUrl = dnsName;
         } else if (clusterName) {
-          baseUrl = `https://${clusterName}.opstrace.io`;
+          baseUrl = `${clusterName}.opstrace.io`;
         } else {
           log.error(
             "env variables OPSTRACE_INSTANCE_DNS_NAME or OPSTRACE_CLUSTER_NAME must be set"
@@ -71,8 +71,13 @@ export const addConfigFixture = (test: TestType) =>
           process.exit(1);
         }
 
+        baseUrl =
+          process.env.OPSTRACE_CLUSTER_INSECURE === "true"
+            ? `http://${baseUrl}`
+            : `https://${baseUrl}`;
+
         const cloudProvider = process.env.OPSTRACE_CLOUD_PROVIDER;
-        if (!cloudProvider) {
+        if (CLOUD_PROVIDER_DEFAULTS[cloudProvider] !== false) {
           log.error(
             "env variable OPSTRACE_CLOUD_PROVIDER must be set to `aws`, `gcp` or `dev`"
           );

--- a/test/browser/fixtures/index.ts
+++ b/test/browser/fixtures/index.ts
@@ -14,7 +14,26 @@
  * limitations under the License.
  */
 
-export { pipe } from "ramda";
+import { test as base } from "@playwright/test";
 
-export { addAuthFixture } from "./authenticated";
-export { addTenantFixture } from "./tenant";
+import { pipe, props, reduce } from "ramda";
+import { ensureArray } from "ramda-adjunct";
+
+import { addConfigFixture } from "./config";
+import { addAuthFixture } from "./authenticated";
+import { addTenantFixture } from "./tenant";
+
+export const test = addConfigFixture(base);
+
+const allFixtures = {
+  auth: addAuthFixture,
+  tenant: addTenantFixture
+};
+
+export const useFixtures = (fixtures: string[] | string) =>
+  pipe(
+    props(ensureArray(fixtures)),
+    reduce((t, f) => f(t), test)
+  )(allFixtures);
+
+export default useFixtures;

--- a/test/browser/fixtures/tenant.ts
+++ b/test/browser/fixtures/tenant.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
+import { TestType } from "@playwright/test";
+
 import { makeTenantName } from "../utils/tenant";
 
 type TenantFixture = {
   newName: string;
 };
 
-export const addTenantFixture = test =>
+export const addTenantFixture = (test: TestType) =>
   test.extend<
     Record<string, never>,
     {

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -23,6 +23,6 @@
   },
   "scripts": {
     "lint": "eslint . --ext .ts --quiet",
-    "pw:localhost": "OPSTRACE_CLUSTER_BASE_URL=\"http://localhost:3000\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts"
+    "pw:localhost": "OPSTRACE_INSTANCE_DNS_NAME=\"http://localhost:3000\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts"
   }
 }

--- a/test/browser/tests/authentication.spec.ts
+++ b/test/browser/tests/authentication.spec.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { test as base, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
 
-import { addAuthFixture } from "../fixtures";
+import useFixtures from "../fixtures";
 import { restoreLogin } from "../utils";
 
-const test = addAuthFixture(base);
+const test = useFixtures("auth");
 
 test.describe("after auth0 authentication", () => {
   test.beforeEach(restoreLogin);

--- a/test/browser/tests/authentication.spec.ts
+++ b/test/browser/tests/authentication.spec.ts
@@ -17,12 +17,12 @@
 import { test as base, expect } from "@playwright/test";
 
 import { addAuthFixture } from "../fixtures";
-import { logUserIn } from "../utils/authentication";
+import { restoreLogin } from "../utils";
 
 const test = addAuthFixture(base);
 
 test.describe("after auth0 authentication", () => {
-  test.beforeEach(logUserIn);
+  test.beforeEach(restoreLogin);
 
   test("user should see homepage", async ({ page, cluster }) => {
     expect(await page.isVisible("[data-test=getting-started]")).toBeTruthy();

--- a/test/browser/tests/everywhere.spec.ts
+++ b/test/browser/tests/everywhere.spec.ts
@@ -17,12 +17,12 @@
 import { test as base, expect } from "@playwright/test";
 
 import { addAuthFixture } from "../fixtures";
-import { logUserIn } from "../utils/authentication";
+import { restoreLogin } from "../utils";
 
 const test = addAuthFixture(base);
 
 test.describe("after auth0 authentication", () => {
-  test.beforeEach(logUserIn);
+  test.beforeEach(restoreLogin);
 
   test.slow(
     "user should click around the entire site",

--- a/test/browser/tests/everywhere.spec.ts
+++ b/test/browser/tests/everywhere.spec.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { test as base, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
 
-import { addAuthFixture } from "../fixtures";
+import useFixtures from "../fixtures";
 import { restoreLogin } from "../utils";
 
-const test = addAuthFixture(base);
+const test = useFixtures("auth");
 
 test.describe("after auth0 authentication", () => {
   test.beforeEach(restoreLogin);

--- a/test/browser/tests/tenant.spec.ts
+++ b/test/browser/tests/tenant.spec.ts
@@ -19,13 +19,13 @@ import { padCharsEnd } from "ramda-adjunct";
 
 import { addAuthFixture, addTenantFixture, pipe } from "../fixtures";
 
-import { logUserIn } from "../utils/authentication";
+import { restoreLogin } from "../utils";
 import { createTenant, makeTenantName } from "../utils/tenant";
 
 const test = pipe(addAuthFixture, addTenantFixture)(base);
 
 test.describe("after auth0 authentication", () => {
-  test.beforeEach(logUserIn);
+  test.beforeEach(restoreLogin);
 
   test.beforeEach(async ({ page }) => {
     await page.hover("[data-test='sidebar/clusterAdmin/Tenants']");

--- a/test/browser/tests/tenant.spec.ts
+++ b/test/browser/tests/tenant.spec.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-import { test as base, expect, Page } from "@playwright/test";
+import { expect, Page } from "@playwright/test";
 import { padCharsEnd } from "ramda-adjunct";
 
-import { addAuthFixture, addTenantFixture, pipe } from "../fixtures";
-
+import useFixtures from "../fixtures";
 import { restoreLogin } from "../utils";
 import { createTenant, makeTenantName } from "../utils/tenant";
 
-const test = pipe(addAuthFixture, addTenantFixture)(base);
+const test = useFixtures(["auth", "tenant"]);
 
 test.describe("after auth0 authentication", () => {
   test.beforeEach(restoreLogin);

--- a/test/browser/utils/authentication.ts
+++ b/test/browser/utils/authentication.ts
@@ -14,7 +14,39 @@
  * limitations under the License.
  */
 
-export const logUserIn = async ({ page, context, authCookies, cluster }) => {
+import { expect, Page } from "@playwright/test";
+
+import { CLUSTER_BASE_URL } from "../fixtures/authenticated";
+
+export const performLogin = async (
+  page: Page,
+  email: string,
+  password: string
+) => {
+  await page.goto(CLUSTER_BASE_URL);
+
+  // <button class="MuiButtonBase-root Mui... MuiButton-sizeLarge" tabindex="0" type="button">
+  // <span class="MuiButton-label">Log in</span>
+  await page.waitForSelector("css=button");
+
+  await page.click("text=Log in");
+
+  // Wait for CI-specific email/password login form to appear
+  await page.waitForSelector("text=Don't remember your password?");
+
+  await page.fill("css=input[type=email]", email);
+  await page.fill("css=input[type=password]", password);
+
+  await page.click("css=button[type=submit]");
+
+  // The first view after successful login is expected to be the details page
+  // for the `system` tenant, showing a link to Grafana.
+  await page.waitForSelector("[data-test=getting-started]");
+
+  expect(await page.isVisible("[data-test=getting-started]")).toBeTruthy();
+};
+
+export const restoreLogin = async ({ page, context, authCookies, cluster }) => {
   context.addCookies(authCookies);
   await page.goto(cluster.baseUrl);
   await page.waitForSelector("[data-test=getting-started]");

--- a/test/browser/utils/authentication.ts
+++ b/test/browser/utils/authentication.ts
@@ -16,14 +16,8 @@
 
 import { expect, Page } from "@playwright/test";
 
-import { CLUSTER_BASE_URL } from "../fixtures/authenticated";
-
-export const performLogin = async (
-  page: Page,
-  email: string,
-  password: string
-) => {
-  await page.goto(CLUSTER_BASE_URL);
+export const performLogin = async ({ page, cluster, user }) => {
+  await page.goto(cluster.baseUrl);
 
   // <button class="MuiButtonBase-root Mui... MuiButton-sizeLarge" tabindex="0" type="button">
   // <span class="MuiButton-label">Log in</span>
@@ -34,8 +28,8 @@ export const performLogin = async (
   // Wait for CI-specific email/password login form to appear
   await page.waitForSelector("text=Don't remember your password?");
 
-  await page.fill("css=input[type=email]", email);
-  await page.fill("css=input[type=password]", password);
+  await page.fill("css=input[type=email]", user.email);
+  await page.fill("css=input[type=password]", user.password);
 
   await page.click("css=button[type=submit]");
 
@@ -46,8 +40,25 @@ export const performLogin = async (
   expect(await page.isVisible("[data-test=getting-started]")).toBeTruthy();
 };
 
-export const restoreLogin = async ({ page, context, authCookies, cluster }) => {
-  context.addCookies(authCookies);
-  await page.goto(cluster.baseUrl);
-  await page.waitForSelector("[data-test=getting-started]");
+export const restoreLogin = async ({
+  page,
+  context,
+  authCookies,
+  system,
+  cluster,
+  user
+}) => {
+  if (system.workerAuth) {
+    context.addCookies(authCookies);
+    await page.goto(cluster.baseUrl);
+    await page.waitForSelector("[data-test=getting-started]");
+  } else {
+    await performLogin({ page, cluster, user });
+  }
 };
+
+// export const logout = async ({ page, context, authCookies, cluster }) => {
+//   context.addCookies(authCookies);
+//   await page.goto(cluster.baseUrl);
+//   await page.waitForSelector("[data-test=getting-started]");
+// };

--- a/test/browser/utils/index.ts
+++ b/test/browser/utils/index.ts
@@ -16,6 +16,8 @@
 
 import winston from "winston";
 
+export { performLogin, restoreLogin } from "./authentication";
+
 const logFormat = winston.format.printf(
   ({ level, message, label, timestamp }) => {
     return `${timestamp} ${level}: ${message}`;


### PR DESCRIPTION
We're having some frustrating intermittent timeout issues on CI with the browser tests at the moment. Sometimes it's looking to be occuring during the auth setup as part of the worker. When this happens we get no debug artefacts from playwright.

This change allows toggling the auth to occur either once per worker as it current occurs, or to happen before each test - which the CI tests are now set to do. Hopefully this will help debug the problems we're having.