### PR TITLE
ci(test-upgrade): correct version of cluster config schema

### DIFF
--- a/ci/test-upgrade/create-cluster.sh
+++ b/ci/test-upgrade/create-cluster.sh
@@ -15,7 +15,7 @@ fi
 
 echo "--- creating cluster"
 ./from/opstrace create ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} \
-    --instance-config ci/cluster-config.yaml \
+    --instance-config ci/test-upgrade/initial-cluster-config.yaml \
     --log-level=debug \
     --yes
 

--- a/ci/test-upgrade/initial-cluster-config.yaml
+++ b/ci/test-upgrade/initial-cluster-config.yaml
@@ -1,0 +1,7 @@
+tenants:
+  - default
+env_label: opstrace-ci
+cert_issuer: letsencrypt-staging
+aws:
+  eks_admin_roles:
+    - AWSReservedSSO_AdministratorAccess_8488c3da2f880f06


### PR DESCRIPTION
Copy the cluster-config.yaml to test-upgrade folder and remove the new field. Use that as the instance config for the initial cluster because the cli cannot parse the file.

Close #1013 
