### PR TITLE
cli(upgrades): fix invalid instance dns name

### DIFF
--- a/ci/test-cli/cli-tests-with-cluster.sh
+++ b/ci/test-cli/cli-tests-with-cluster.sh
@@ -77,3 +77,8 @@ test_tenant_authenticator_custom_keypair_flow
 
 # Confirm status command returns exit code 0
 ./build/bin/opstrace status ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} --instance-config ./ci/cluster-config.yaml
+
+# Sanity check upgrade command. This test is not supposed to run the full
+# upgrade. Instead, it just checks the config load, and status checking
+# procedures are not broken.
+DRY_RUN_UPGRADES=true ./build/bin/opstrace upgrade ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} --instance-config ./ci/cluster-config.yaml --yes

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -337,7 +337,9 @@ function* createClusterCore() {
   log.info(`Log in here: https://${opstraceInstanceDNSname}`);
 }
 
-function instanceDNSNameFromClusterConfig(ccfg: LatestClusterConfigType) {
+export function instanceDNSNameFromClusterConfig(
+  ccfg: LatestClusterConfigType
+) {
   let opstraceInstanceDNSname = `${ccfg.cluster_name}.opstrace.io`;
   if (ccfg.custom_dns_name !== undefined) {
     opstraceInstanceDNSname = ccfg.custom_dns_name;

--- a/packages/upgrader/src/index.ts
+++ b/packages/upgrader/src/index.ts
@@ -51,9 +51,7 @@ import { getClusterConfig, LatestClusterConfigType } from "@opstrace/config";
 import {
   ClusterCreateConfigInterface,
   setCreateConfig,
-  waitUntilDataAPIEndpointsAreReachable,
-  waitUntilDDAPIEndpointsAreReachable,
-  waitUntilUIIsReachable
+  waitUntilHTTPEndpointsAreReachable
 } from "@opstrace/installer";
 
 // Note: a largish number of attempts as long as micro retries are not yet
@@ -207,17 +205,7 @@ function* triggerControllerDeploymentUpgrade() {
   yield cancel(informers);
 
   // ensure the data endpoint, datadog api endpoints and ui are reachable
-  yield call(
-    waitUntilDataAPIEndpointsAreReachable,
-    ucc.cluster_name,
-    ucc.tenants
-  );
-  yield call(
-    waitUntilDDAPIEndpointsAreReachable,
-    ucc.cluster_name,
-    ucc.tenants
-  );
-  yield call(waitUntilUIIsReachable, ucc.cluster_name, ucc.tenants);
+  yield call(waitUntilHTTPEndpointsAreReachable, ucc);
 }
 
 function readTenantApiTokenFiles(tenantNames: string[]): Dict<string> {


### PR DESCRIPTION
From a recent upgrades pipeline [build](https://buildkite.com/opstrace/upgrade-tests/builds/953#8d5e2359-b655-4505-97a0-87c0f4f45610/2115-3404)

```
[2021-07-09T12:45:18Z] 2021-07-09T12:45:18.838Z debug: https://cortex.default.upgrade-bk-953-29b-g/api/v1/labels: HTTP request failed with: getaddrinfo ENOTFOUND cortex.default.upgrade-bk-953-29b-g
```

It's missing the `opstrace.io` domain.