### PR TITLE
cli(status): bump check cluster status wait timeout

### DIFF
--- a/packages/cli/src/status.ts
+++ b/packages/cli/src/status.ts
@@ -103,7 +103,7 @@ async function checkClusterStatus() {
 function* rootTaskStatusCore() {
   const { timeout } = yield race({
     status: call(checkClusterStatus),
-    timeout: delay(60 * SECOND)
+    timeout: delay(300 * SECOND)
   });
 
   if (timeout) {


### PR DESCRIPTION
Tried bumping the [request timeout](https://github.com/opstrace/opstrace/blob/29bb931b2ff765b445ce0632d1d76f0971e6879e/packages/installer/src/index.ts#L479) in the hopes it would help fix the issue but it didn't seem to make a difference.

Might as well bump the timeout as [suggested here](https://github.com/opstrace/opstrace/issues/981#issuecomment-877114437).  
