### PR TITLE
[wip] ui: ensure new tenant name is unique

### DIFF
--- a/packages/app/src/client/services/Picker/PickerService.tsx
+++ b/packages/app/src/client/services/Picker/PickerService.tsx
@@ -107,9 +107,10 @@ function PickerService({ children }: { children: React.ReactNode }) {
     ?.replace(activePicker?.activationPrefix || "", "")
     .replace(/^\s+/, "");
 
-  const hasValidationError = activePicker?.textValidator
-    ? !activePicker?.textValidator.test(filterValue || "")
-    : false;
+  const textValidatorResponse = activePicker?.textValidator
+    ? activePicker.textValidator(filterValue || "")
+    : true;
+  const isFilterValueValid = textValidatorResponse === true;
 
   const onSelect = useCallback(
     (selected: PickerOption) => {
@@ -192,7 +193,7 @@ function PickerService({ children }: { children: React.ReactNode }) {
                   );
                 }
                 if (e.key === "Enter") {
-                  if (!hasValidationError) {
+                  if (isFilterValueValid) {
                     onSelect(filteredOptions[selectedIndex]);
                   }
                 }
@@ -213,11 +214,10 @@ function PickerService({ children }: { children: React.ReactNode }) {
           </Box>
           <Divider />
         </Box>
-        {hasValidationError ? (
+        {!isFilterValueValid ? (
           <Box width={PICKER_WIDTH} height={PICKER_HEIGHT} textAlign="center">
             <Typography variant="caption" color="textSecondary">
-              {activePicker?.textValidationFailedMessage ||
-                `Input must satisfy ${activePicker?.textValidator?.toString()}`}
+              {textValidatorResponse}
             </Typography>
           </Box>
         ) : (

--- a/packages/app/src/client/services/Picker/PickerService.tsx
+++ b/packages/app/src/client/services/Picker/PickerService.tsx
@@ -216,7 +216,11 @@ function PickerService({ children }: { children: React.ReactNode }) {
         </Box>
         {!isFilterValueValid ? (
           <Box width={PICKER_WIDTH} height={PICKER_HEIGHT} textAlign="center">
-            <Typography variant="caption" color="textSecondary">
+            <Typography
+              variant="caption"
+              color="textSecondary"
+              data-test="pickerService/dialog/errorMessage"
+            >
               {textValidatorResponse}
             </Typography>
           </Box>

--- a/packages/app/src/client/services/Picker/types.ts
+++ b/packages/app/src/client/services/Picker/types.ts
@@ -34,9 +34,8 @@ export type PickerProvider = {
   disableFilter?: boolean;
   // Disable input
   disableInput?: boolean;
-  // Validate input as user is typing
-  textValidator?: RegExp;
-  textValidationFailedMessage?: string;
+  // Validate input as user is typing, return "true" if valid or an error message to display to the user
+  textValidator?: (text: string) => true | string;
   activationPrefix: string;
   onSelected: (option: PickerOption, inputText?: string) => void;
   options: PickerOption[];

--- a/packages/app/src/client/utils/regex.ts
+++ b/packages/app/src/client/utils/regex.ts
@@ -20,4 +20,4 @@
 // 2021.07.06 - [terrcin] I've removed "-" as a valid char as we're having problems with it in Grafana
 // pod names. This means that only alphanumeric chars are allowed.
 // Related issue: https://github.com/opstrace/opstrace/issues/957
-export const tenantNameValidator = /^[a-z0-9]{1,63}$/;
+export const tenantNameValidator = /^[a-z0-9]{2,63}$/;

--- a/packages/app/src/client/views/tenants/AddTenantDialog.tsx
+++ b/packages/app/src/client/views/tenants/AddTenantDialog.tsx
@@ -33,6 +33,8 @@ const AddTenantPicker = () => {
       title: "Enter tenant name",
       activationPrefix: "add tenant:",
       disableFilter: true,
+      textValidator: tenantNameValidator,
+      textValidationFailedMessage: "Lowercase alpha-numeric characters only",
       options: [
         {
           id: "yes",
@@ -44,9 +46,8 @@ const AddTenantPicker = () => {
         }
       ],
       onSelected: (option, tenant) => {
-        if (option.id === "yes" && tenant && tenantNameValidator.test(tenant)) {
+        if (option.id === "yes" && tenant && tenantNameValidator.test(tenant))
           dispatch(addTenant(tenant));
-        }
       },
       dataTest: "addTenant"
     },

--- a/packages/app/src/client/views/tenants/AddTenantDialog.tsx
+++ b/packages/app/src/client/views/tenants/AddTenantDialog.tsx
@@ -33,8 +33,9 @@ const AddTenantPicker = () => {
       title: "Enter tenant name",
       activationPrefix: "add tenant:",
       disableFilter: true,
-      textValidator: tenantNameValidator,
-      textValidationFailedMessage: "Lowercase alpha-numeric characters only",
+      textValidator: (filterValue: string) =>
+        tenantNameValidator.test(filterValue) ||
+        "Lowercase alpha-numeric characters only",
       options: [
         {
           id: "yes",

--- a/packages/app/src/client/views/tenants/AddTenantDialog.tsx
+++ b/packages/app/src/client/views/tenants/AddTenantDialog.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from "react";
-import { none, propEq } from "ramda";
+import React from "react";
 import { useDispatch } from "react-redux";
+
 import { tenantNameValidator } from "client/utils/regex";
+import { isTenantNameUnique } from "state/tenant/utils";
 
 import { usePickerService } from "client/services/Picker";
 import { useCommandService } from "client/services/Command";
@@ -31,11 +32,6 @@ const AddTenantPicker = () => {
   const dispatch = useDispatch();
   const tenants = useTenantList();
 
-  const isTenantNameUnique = useCallback(
-    (tenantName: string) => none(propEq("name", tenantName))(tenants),
-    [tenants]
-  );
-
   const { activatePickerWithText } = usePickerService(
     {
       title: "Enter tenant name",
@@ -45,7 +41,7 @@ const AddTenantPicker = () => {
         if (filterValue.length < 1) return "Enter new Tenant name";
         else if (!tenantNameValidator.test(filterValue))
           return "2 or more lowercase alpha-numeric characters";
-        else if (!isTenantNameUnique(filterValue))
+        else if (!isTenantNameUnique(filterValue, tenants))
           return "Tenant name must be unique";
         else return true;
       },
@@ -61,17 +57,11 @@ const AddTenantPicker = () => {
         }
       ],
       onSelected: (option, tenantName) => {
-        if (
-          option.id === "yes" &&
-          tenantName &&
-          tenantNameValidator.test(tenantName) &&
-          isTenantNameUnique(tenantName)
-        )
-          dispatch(addTenant(tenantName));
+        if (option.id === "yes" && tenantName) dispatch(addTenant(tenantName));
       },
       dataTest: "addTenant"
     },
-    []
+    [tenants]
   );
 
   useCommandService({

--- a/packages/app/src/state/tenant/utils.ts
+++ b/packages/app/src/state/tenant/utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { none, propEq } from "ramda";
+
+import { Tenant } from "./types";
+
+export const isTenantNameUnique = (tenantName: string, tenants: Tenant[]) =>
+  none(propEq("name", tenantName))(tenants);

--- a/test/browser/tests/tenant.spec.ts
+++ b/test/browser/tests/tenant.spec.ts
@@ -170,13 +170,10 @@ test.describe("after auth0 authentication", () => {
       })
     );
 
-    test.only("duplicate names are NOT allowed", async ({ page }) => {
+    test("duplicate names are NOT allowed", async ({ page }) => {
       const tenantName = makeTenantName("fancytenant");
 
       await createTenant(tenantName, { page });
-      // await page.waitForTimeout(5_000);
-
-      console.log(tenantName);
 
       await checkTenantNameIsNotValid({ rawTenantName: tenantName })({ page });
 

--- a/test/browser/tests/tenant.spec.ts
+++ b/test/browser/tests/tenant.spec.ts
@@ -41,10 +41,6 @@ test.describe("after auth0 authentication", () => {
 
     await createTenant(tenantName, { page });
 
-    expect(
-      await page.waitForSelector(`[data-test='tenant/row/${tenantName}']`)
-    ).toBeTruthy();
-
     await page.click(`[data-test='tenant/row/${tenantName}']`);
     await page.waitForURL(
       `${cluster.baseUrl}/tenant/${tenantName}/getting-started`

--- a/test/browser/tests/tenant.spec.ts
+++ b/test/browser/tests/tenant.spec.ts
@@ -170,18 +170,15 @@ test.describe("after auth0 authentication", () => {
       })
     );
 
-    test("can't have two with the same name", async ({ page }) => {
+    test.only("duplicate names are NOT allowed", async ({ page }) => {
       const tenantName = makeTenantName("fancytenant");
 
       await createTenant(tenantName, { page });
-      // deliberatly wait slightly for the system to make the Tenants, on CI it progress too fast past the following line as page.$$ doesn't wait for things
-      await page.waitForSelector(`[data-test='tenant/row/${tenantName}']`, {
-        timeout: 5000
-      });
+      // await page.waitForTimeout(5_000);
 
-      // try and make another tenant with the same name, giving it 5s to appear
-      await createTenant(tenantName, { page });
-      await page.waitForTimeout(5_000);
+      console.log(tenantName);
+
+      await checkTenantNameIsNotValid({ rawTenantName: tenantName })({ page });
 
       const dupTenants = await page.$$(
         `[data-test='tenant/row/${tenantName}']`

--- a/test/browser/utils/tenant.ts
+++ b/test/browser/utils/tenant.ts
@@ -29,6 +29,9 @@ export const createTenant = async (
     `add tenant: ${tenantName}`
   );
   await page.click("[data-test='pickerService/option/yes']");
+  expect(
+    await page.waitForSelector(`[data-test='tenant/row/${tenantName}']`)
+  ).toBeTruthy();
 };
 
 export const makeTenantName = (prefix?: string) =>


### PR DESCRIPTION
In the validation callback for the AddTenantDialog we are checking the typed name against the existing list of Tenants