### PR TITLE
ui: bug fix - app can load without a tenant being selected via cluster routes

### DIFF
--- a/packages/app/src/client/app.tsx
+++ b/packages/app/src/client/app.tsx
@@ -88,10 +88,6 @@ const AuthProtectedApplication = () => {
   const tenant = useLastSelectedTenant();
   const integrationCount = useIntegrationListCount();
 
-  if (tenant === null) {
-    // Still loading tenants
-    return null;
-  }
   if (typeof tenant === "undefined" && !clusterRoutesMatch) {
     // Tenant not found, redirect to the system tenant since it's known
     return <Redirect key="invalid-tenant" from="*" to="/tenant/system" />;


### PR DESCRIPTION
Removed condition in the root App component that would only allow the rendering to continue if there was a selected tenant.
