### PR TITLE
ui: added UI tenant name regex validation as postgresql contraint check

### DIFF
--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -341,7 +341,7 @@ source ci/test-cli/cli-tests-with-cluster.sh
 # - the path to the authentication token file
 set -x
 set +e; RNDSTRING=$( tr -dc a-z < /dev/urandom | head -c 6 ); set -e
-TENANT_RND_NAME_FOR_TESTING_ADD_TENANT="testtenant-${RNDSTRING}"
+TENANT_RND_NAME_FOR_TESTING_ADD_TENANT="testtenant${RNDSTRING}"
 ./build/bin/opstrace ta-create-keypair ./ta-custom-keypair.pem
 ./build/bin/opstrace ta-create-token "${OPSTRACE_CLUSTER_NAME}" \
     "${TENANT_RND_NAME_FOR_TESTING_ADD_TENANT}" ta-custom-keypair.pem > tenant-rnd-auth-token-from-custom-keypair

--- a/packages/app/migrations/1626132643036_alter_table_public_tenant_add_check_constraint_tenant_name_validation/down.sql
+++ b/packages/app/migrations/1626132643036_alter_table_public_tenant_add_check_constraint_tenant_name_validation/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."tenant" drop constraint "tenant_name_validation";

--- a/packages/app/migrations/1626132643036_alter_table_public_tenant_add_check_constraint_tenant_name_validation/up.sql
+++ b/packages/app/migrations/1626132643036_alter_table_public_tenant_add_check_constraint_tenant_name_validation/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."tenant" add constraint "tenant_name_validation" check (name ~ '^[a-z0-9]{2,63}$'::text);


### PR DESCRIPTION
Done in support of https://github.com/opstrace/opstrace/issues/710

Worth noting that presently we are being extermely restrictive on what can be in a Tenant named - only lowercase alphanumeric chars. This migration will fail when applied to existing data that violates the constraint.
