### PR TITLE
test-remote: use containerized Fluentbit (with Grafana's Loki plugin), use Basic auth scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,6 +548,7 @@ rebuild-testrunner-container-images:
 	docker pull opstrace/systemlog-fluentd:fe6d0d84-dev
 	docker pull prom/prometheus:v2.21.0
 	docker pull gcr.io/datadoghq/agent:7
+	docker pull grafana/fluent-bit-plugin-loki:main-4a8f62b-amd64
 
 .PHONY: rebuild-looker-container-image
 rebuild-looker-container-image:

--- a/test/test-remote/containers/fluentbit/fbit.config.template
+++ b/test/test-remote/containers/fluentbit/fbit.config.template
@@ -1,0 +1,23 @@
+[SERVICE]
+    Flush           1
+    Daemon          off
+    Log_Level       debug
+
+[INPUT]
+    Name        tail
+    Read_from_Head true
+    Path        {{{samples_log_file_path}}}
+
+[OUTPUT]
+    Name   stdout
+    Match  *
+
+[OUTPUT]
+    Name grafana-loki
+    Match *
+    Url {{{lokiPushUrl}}}
+    Labels { {{{indexFieldName}}}="{{{indexFieldValue}}}"}
+    BatchWait 1s
+    BatchSize 3000
+    insecure_skip_verify true
+

--- a/test/test-remote/test_loki_log_ingest_api.ts
+++ b/test/test-remote/test_loki_log_ingest_api.ts
@@ -201,7 +201,7 @@ suite("Loki API test suite", function () {
     );
   });
 
-  test("insert w/ cntnrzd Fluentbit(grafana loki plugin), then query", async function () {
+  test("fluentbit(grafana loki plugin) with basic auth", async function () {
     const loglines = ["aaaaaaa", "bbbbbb", "cccccccc"];
 
     const idxfieldname = "indexfieldname";

--- a/test/test-remote/testutils/fbit.ts
+++ b/test/test-remote/testutils/fbit.ts
@@ -60,9 +60,8 @@ export async function sendLogsWithFluentbitContainer(
 
   // Construct URL with basic auth info. username is ignored, password is
   // interpreted as tenant API authentication token
-
-  //const lokiPushUrl = `https://uname:${apiToken}@${lokiApiDnsName}/loki/api/v1/push`;
-  const lokiPushUrl = `https://uname:${process.env.REDTEAM_APITOKEN}@loki.redteam.jpdemo.opstrace.io/loki/api/v1/push`;
+  const lokiPushUrl = `https://uname:${apiToken}@${lokiApiDnsName}/loki/api/v1/push`;
+  //const lokiPushUrl = `https://uname:${process.env.REDTEAM_APITOKEN}@loki.redteam.jpdemo.opstrace.io/loki/api/v1/push`;
 
   const renderedConfigText = mustache.render(
     fs.readFileSync(

--- a/test/test-remote/testutils/fbit.ts
+++ b/test/test-remote/testutils/fbit.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import events from "events";
+import fs from "fs";
+
+import mustache from "mustache";
+import Docker from "dockerode";
+
+import {
+  log,
+  createTempfile,
+  readDockerDNSSettings,
+  readFirstNBytes,
+  mtimeDeadlineInSeconds,
+  terminateContainer,
+  mtime,
+  sleep
+} from "./index";
+
+export async function sendLogsWithFluentbitContainer(
+  lokiApiDnsName: string,
+  apiTokenFilePath: string | undefined,
+  logLines: Array<string>,
+  indexFieldName: string,
+  indexFieldValue: string,
+  fbitConfigTemplateFile: string,
+  logNeedle: string
+): Promise<void> {
+  // The trailing newline is required for fluentd to pick up the last log
+  // record.
+  const logFileText = logLines.join("\n") + "\n";
+
+  log.info("log file content (fluentbit tail input):\n%s", logFileText);
+  const contentBytes = Buffer.from(logFileText, "utf-8");
+  const logFilePath = createTempfile("fluentd-log-input-", ".log");
+  fs.writeFileSync(logFilePath, contentBytes);
+
+  // Send a noop string when no tenant API token was passed
+  let apiToken = "noop";
+  if (apiTokenFilePath) {
+    apiToken = fs.readFileSync(apiTokenFilePath, {
+      encoding: "utf-8"
+    });
+    log.info("using api token: %s", apiToken);
+  }
+
+  // Construct URL with basic auth info. username is ignored, password is
+  // interpreted as tenant API authentication token
+
+  //const lokiPushUrl = `https://uname:${apiToken}@${lokiApiDnsName}/loki/api/v1/push`;
+  const lokiPushUrl = `https://uname:${process.env.REDTEAM_APITOKEN}@loki.redteam.jpdemo.opstrace.io/loki/api/v1/push`;
+
+  const renderedConfigText = mustache.render(
+    fs.readFileSync(
+      `${__dirname}/../containers/fluentbit/${fbitConfigTemplateFile}`,
+      {
+        encoding: "utf-8"
+      }
+    ),
+    {
+      lokiPushUrl: lokiPushUrl,
+      samples_log_file_path: logFilePath,
+      indexFieldName: indexFieldName,
+      indexFieldValue: indexFieldValue
+    }
+  );
+
+  const fbitConfigFilePath = createTempfile("fluentd-config-", ".conf");
+  fs.writeFileSync(fbitConfigFilePath, renderedConfigText, {
+    encoding: "utf-8"
+  });
+
+  log.info("wrote config file to %s", fbitConfigFilePath);
+  const outfilePath = createTempfile("fbfbit-container-", ".outerr");
+  const outstream = fs.createWriteStream(outfilePath);
+  await events.once(outstream, "open");
+
+  log.info(
+    "start containerized fluentbit with config:\n%s",
+    renderedConfigText
+  );
+  const docker = new Docker({ socketPath: "/var/run/docker.sock" });
+
+  const dockerDNS = readDockerDNSSettings();
+  log.info(`docker container dns settings: ${dockerDNS}`);
+
+  const mounts: Docker.MountConfig = [
+    {
+      Type: "bind",
+      Source: "/tmp",
+      Target: "/tmp",
+      ReadOnly: false
+    }
+  ];
+
+  const cont = await docker.createContainer({
+    // TODO: specific version
+    Image: "grafana/fluent-bit-plugin-loki:latest",
+    AttachStdin: false,
+    AttachStdout: false,
+    AttachStderr: false,
+    Tty: false,
+    // Rely for `fbitConfigFilePath` to be in `/tmp` which is mounted into
+    // container
+    Cmd: [
+      "/fluent-bit/bin/fluent-bit",
+      "-e",
+      "/fluent-bit/bin/out_grafana_loki.so",
+      "-c",
+      fbitConfigFilePath
+    ],
+    HostConfig: {
+      NetworkMode: "host",
+      Mounts: mounts,
+      Dns: readDockerDNSSettings()
+    }
+  });
+
+  log.info("attach file-backed stream");
+
+  // Attach file-backed stream for progress analysis.
+  const stream = await cont.attach({
+    stream: true,
+    stdout: true,
+    stderr: true
+  });
+  stream.pipe(outstream);
+
+  log.info("container start()");
+  await cont.start();
+
+  const maxWaitSeconds = 15;
+  const deadline = mtimeDeadlineInSeconds(maxWaitSeconds);
+  log.info(
+    "Waiting for needle to appear in container log, deadline in %s s. Needle: %s",
+    maxWaitSeconds,
+    logNeedle
+  );
+
+  // When using the grafana loki output plugin there is no part of the
+  // log that is a definite '204-accepted' criterion.
+
+  while (true) {
+    if (mtime() > deadline) {
+      log.info("deadline hit");
+      await terminateContainer(cont, outfilePath);
+      throw new Error("fluentd container setup (or send) failed: deadline hit");
+    }
+    const fileHeadBytes = await readFirstNBytes(outfilePath, 10 ** 4);
+    if (fileHeadBytes.includes(Buffer.from(logNeedle, "utf-8"))) {
+      // note that if the log needle is "bytes to loki" as in
+      // "sending 500 bytes to loki" then this is right before an HTTP
+      // request is fired off.
+      log.info("log needle found in container log, proceed");
+      break;
+    }
+    await sleep(0.1);
+  }
+
+  // Note: abstract container into a class, perform cleanup upon test runner
+  // exit. Also: handle errors, don't let errors get in the way of cleanup.
+  await terminateContainer(cont, outfilePath);
+}

--- a/test/test-remote/testutils/fbit.ts
+++ b/test/test-remote/testutils/fbit.ts
@@ -108,7 +108,7 @@ export async function sendLogsWithFluentbitContainer(
 
   const cont = await docker.createContainer({
     // TODO: specific version
-    Image: "grafana/fluent-bit-plugin-loki:latest",
+    Image: "grafana/fluent-bit-plugin-loki:main-4a8f62b-amd64",
     AttachStdin: false,
     AttachStdout: false,
     AttachStderr: false,

--- a/test/test-remote/testutils/fbit.ts
+++ b/test/test-remote/testutils/fbit.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Opstrace, Inc.
+ * Copyright 2021 Opstrace, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/test-remote/testutils/fbit.ts
+++ b/test/test-remote/testutils/fbit.ts
@@ -46,7 +46,7 @@ export async function sendLogsWithFluentbitContainer(
 
   log.info("log file content (fluentbit tail input):\n%s", logFileText);
   const contentBytes = Buffer.from(logFileText, "utf-8");
-  const logFilePath = createTempfile("fluentd-log-input-", ".log");
+  const logFilePath = createTempfile("fbit-log-input-", ".log");
   fs.writeFileSync(logFilePath, contentBytes);
 
   // Send a noop string when no tenant API token was passed
@@ -63,6 +63,8 @@ export async function sendLogsWithFluentbitContainer(
   const lokiPushUrl = `https://uname:${apiToken}@${lokiApiDnsName}/loki/api/v1/push`;
   //const lokiPushUrl = `https://uname:${process.env.REDTEAM_APITOKEN}@loki.redteam.jpdemo.opstrace.io/loki/api/v1/push`;
 
+  log.info("constructed loki push URL: %s", lokiPushUrl);
+
   const renderedConfigText = mustache.render(
     fs.readFileSync(
       `${__dirname}/../containers/fluentbit/${fbitConfigTemplateFile}`,
@@ -78,13 +80,13 @@ export async function sendLogsWithFluentbitContainer(
     }
   );
 
-  const fbitConfigFilePath = createTempfile("fluentd-config-", ".conf");
+  const fbitConfigFilePath = createTempfile("fbit-config-", ".conf");
   fs.writeFileSync(fbitConfigFilePath, renderedConfigText, {
     encoding: "utf-8"
   });
 
   log.info("wrote config file to %s", fbitConfigFilePath);
-  const outfilePath = createTempfile("fbfbit-container-", ".outerr");
+  const outfilePath = createTempfile("fbit-container-", ".outerr");
   const outstream = fs.createWriteStream(outfilePath);
   await events.once(outstream, "open");
 

--- a/test/test-remote/testutils/index.ts
+++ b/test/test-remote/testutils/index.ts
@@ -937,6 +937,7 @@ async function sigkillContInNSeconds(
 ): Promise<void> {
   await sleep(n);
   try {
+    log.info("send SIGKILL");
     cont.kill({ signal: "SIGKILL" });
   } catch (err) {
     log.warning("error sending SIGKILL: %s", err.message);
@@ -955,8 +956,9 @@ export async function terminateContainer(
     log.warning("could not kill container: %s", err.message);
   }
 
-  // spawn function that sends SIGKILL in 15 seconds, but don't wait for this
-  // yet
+  // Spawn function that sends SIGKILL in 15 seconds, but don't wait for this
+  // yet. This is because ususally a _clean_ shutdown procedure is initiated
+  // by SIGTERM, but that may actually not lead to timely termination.
   const killjob = sigkillContInNSeconds(cont, 10);
 
   log.info("wait for container to stop");


### PR DESCRIPTION
This test covers a legacy tenant API authentication mechanism which landed [yesterday](https://github.com/opstrace/opstrace/pull/1035), where the tenant API authentication token is communicated via the `Basic` Authorization header scheme.

Notes about the non-obvious considerations:

* A containerized Fluent Bit is used as the log source.
* The Fluent Bit image used in this test is built by Grafana CI. Dockerfile in the Loki repo at `/clients/cmd/fluent-bit/Dockerfile`, e.g. https://github.com/grafana/loki/blob/a9d85de4aa5290cf2f8b2dca5d08645bbd0dc66c/clients/cmd/fluent-bit/Dockerfile -- documentation is here: https://grafana.com/docs/loki/latest/clients/fluentbit/ (and it's out of date)
* The Grafana Fluent Bit image is not based on most recent Fluent Bit releases, actually quite behind as of today (`FROM fluent/fluent-bit:1.4` vs the most recent Fluent Bit release 1.8.1).
* The grafana-loki Fluent Bit output plugin used in that image uses the Go stdlib HTTP client for actually pushing data out  -- which is why basic auth can be triggered by encoding username and password in the URL in standard `scheme://uname:pw@...` notation (stdlib then takes care of translating that into an `Authorization: Basic ...` header)




