### PR TITLE
feat(cli,config): info command prints stored/read cluster metadata

### DIFF
--- a/ci/test-cli/cli-tests-with-cluster.sh
+++ b/ci/test-cli/cli-tests-with-cluster.sh
@@ -74,8 +74,26 @@ test_tenant_authenticator_custom_keypair_flow() {
   # fail with a 401 response.
 }
 
+# test_info tests the "info" command.
+test_info() {
+  # Ensure info command returns exit code 0 and output has required keys.
+  local info_output=$(./build/bin/opstrace info ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME})
+  local exit_code=$?
+  if (( $exit_code )); then
+    echo "expected exit code 0, got $exit_code"
+    exit 1
+  fi
+  for key in "kubernetes_version" "controller_version" "installer_version"; do
+    if ! echo "$info_output" | grep -q "$key"; then
+      echo "key $key not found in info output"
+      exit 1
+    fi
+  done
+}
+
 test_list
 test_tenant_authenticator_custom_keypair_flow
+test_info
 
 # Confirm status command returns exit code 0
 ./build/bin/opstrace status ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} --instance-config ./ci/cluster-config.yaml

--- a/lib/utils/src/docker.ts
+++ b/lib/utils/src/docker.ts
@@ -84,3 +84,13 @@ export async function checkIfDockerImageExistsOrErrorOut(imageName: string) {
     log.debug(`response body, first 500 bytes: ${bodyPrefix}`);
   }
 }
+
+/**
+ *
+ * @param tag is an image tag.
+ * @returns the content of tag following the first ":"
+ */
+ export function parseVersionFromImageTag(imageName: string): string {
+  const splitName = imageName.split(":");
+  return splitName.length > 1 ? splitName[1] : "latest";
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,7 @@ import * as create from "./create";
 import * as destroy from "./destroy";
 import * as list from "./list";
 import * as status from "./status";
+import * as info from "./info";
 import * as upgrade from "./upgrade";
 import * as util from "./util";
 import * as ctoken from "./createTenantAuthToken";
@@ -84,58 +85,45 @@ async function main() {
   if (CLIARGS.instanceName !== undefined) {
     util.validateClusterNameOrDie(CLIARGS.instanceName);
   }
-
-  if (CLIARGS.command == "destroy") {
-    await destroy.destroy();
-    throw new ExitSuccess();
+  switch (CLIARGS.command) {
+    case "destroy":
+      await destroy.destroy();
+      break;
+    case "create":
+      await create.create();
+      break;
+    case "list":
+      await list.list();
+      break;
+    case "status":
+      await status.status();
+      break;
+    case "info":
+      await info.info();
+      break;
+    case "upgrade":
+      await upgrade.upgrade();
+      break;
+    case "ta-create-token":
+      await ctoken.create();
+      break;
+    case "ta-create-keypair":
+      await aks.createKeypair();
+      break;
+    case "ta-pubkeys-add":
+      await aks.addKeyToAuthenticatorConfig();
+      break;
+    case "ta-pubkeys-list":
+      await aks.listKeys();
+      break;
+    case "ta-pubkeys-remove":
+      await aks.removeKey();
+      break;
+    default:
+      throw Error("should never be here");
   }
 
-  if (CLIARGS.command == "create") {
-    await create.create();
-    throw new ExitSuccess();
-  }
-
-  if (CLIARGS.command == "list") {
-    await list.list();
-    throw new ExitSuccess();
-  }
-
-  if (CLIARGS.command == "status") {
-    await status.status();
-    throw new ExitSuccess();
-  }
-
-  if (CLIARGS.command == "upgrade") {
-    await upgrade.upgrade();
-    throw new ExitSuccess();
-  }
-
-  if (CLIARGS.command == "ta-create-token") {
-    await ctoken.create();
-    throw new ExitSuccess();
-  }
-
-  if (CLIARGS.command == "ta-create-keypair") {
-    await aks.createKeypair();
-    throw new ExitSuccess();
-  }
-
-  if (CLIARGS.command == "ta-pubkeys-add") {
-    await aks.addKeyToAuthenticatorConfig();
-    throw new ExitSuccess();
-  }
-
-  if (CLIARGS.command == "ta-pubkeys-list") {
-    await aks.listKeys();
-    throw new ExitSuccess();
-  }
-
-  if (CLIARGS.command == "ta-pubkeys-remove") {
-    await aks.removeKey();
-    throw new ExitSuccess();
-  }
-
-  throw Error("should never be here");
+  throw new ExitSuccess();
 }
 
 /**
@@ -190,6 +178,10 @@ function parseCmdlineArgs() {
   const parserStatus = subparsers.add_parser("status", {
     help:
       "Check the status of an Opstrace instance (experimental, no promises)."
+  });
+  const parserInfo = subparsers.add_parser("info", {
+    help:
+      "Get infrastructure and Opstrace instance version information (experimental, no promises)."
   });
   const parserUpgrade = subparsers.add_parser("upgrade", {
     help: "Upgrade an existing Opstrace instance."
@@ -248,6 +240,7 @@ function parseCmdlineArgs() {
     parserDestroy,
     parserList,
     parserStatus,
+    parserInfo,
     parserUpgrade,
     mainParser
   ]) {
@@ -266,6 +259,7 @@ function parseCmdlineArgs() {
     parserDestroy,
     parserList,
     parserStatus,
+    parserInfo,
     parserUpgrade
   ]) {
     p.add_argument("cloudProvider", {
@@ -276,7 +270,13 @@ function parseCmdlineArgs() {
     });
   }
 
-  for (const p of [parserCreate, parserDestroy, parserStatus, parserUpgrade]) {
+  for (const p of [
+    parserCreate,
+    parserDestroy,
+    parserStatus,
+    parserInfo,
+    parserUpgrade
+  ]) {
     p.add_argument("instanceName", {
       help:
         "The Opstrace instance name ([a-z0-9-_], no more than 23 characters).",

--- a/packages/cli/src/info.ts
+++ b/packages/cli/src/info.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { call, race, delay } from "redux-saga/effects";
+import createSagaMiddleware from "redux-saga";
+import { createStore, applyMiddleware } from "redux";
+
+import {
+  smErrorLastResort,
+  getKubeConfigForOpstraceClusterOrDie
+} from "./util";
+import * as cli from "./index";
+import { log, die, SECOND, parseVersionFromImageTag } from "@opstrace/utils";
+import {
+  STORAGE_KEY,
+  CONFIGMAP_NAME,
+  CONTROLLER_NAME,
+  CONTROLLER_NAMESPACE,
+  LatestControllerConfigSchema
+} from "@opstrace/controller-config";
+import {
+  AppsV1Api,
+  CoreV1Api,
+  VersionApi,
+  VersionInfo,
+  V1ConfigMap,
+  V1Deployment
+} from "@kubernetes/client-node";
+
+/**
+ * getClusterInfo reads Kubernetes and Opstrace cluster state
+ * from the apiserver then prints this information in human-readable format.
+ */
+async function getClusterInfo() {
+  // All information printed by this command hinges on k8s cluster availability.
+  // getKubeConfigForOpstraceClusterOrDie will log an indicative message and
+  // throw an exception if the kubeconfig it generates cannot contact a cluster
+  // at the expected host, which is desirable here.
+  const kcfg = await getKubeConfigForOpstraceClusterOrDie(
+    cli.CLIARGS.cloudProvider,
+    cli.CLIARGS.instanceName
+  );
+
+  // Read controller ConfigMap and die if not found.
+  let cm: V1ConfigMap;
+  try {
+    const coreClient = kcfg.makeApiClient(CoreV1Api);
+    cm = (await coreClient.readNamespacedConfigMap(CONFIGMAP_NAME, "default"))
+      .body;
+  } catch (err) {
+    die(
+      `failed to read Opstrace controller config map: ${
+        err.response ? err.response.body.message : err
+      }`
+    );
+  }
+  const cfgJSON = JSON.parse(cm.data?.[STORAGE_KEY] ?? "");
+  if (cfgJSON === "") {
+    die(`invalid Opstrace controller config map`);
+  }
+
+  log.debug(`controller config: ${JSON.stringify(cfgJSON, null, 2)}`);
+
+  // Set lastCLIVersion to the config's latest value if available. CLI metadata
+  // will be present in the latest config version(s) only, but its non-existence should
+  // not result in a command error.
+  let lastCLIVersion = "undefined";
+  if (LatestControllerConfigSchema.isValidSync(cfgJSON)) {
+    const cfg = LatestControllerConfigSchema.validateSync(cfgJSON);
+    lastCLIVersion =
+      cfg.cliMetadata.allCLIVersions[cfg.cliMetadata.allCLIVersions.length - 1]
+        ?.version;
+  }
+
+  // Determine the current controller version.
+  let cd: V1Deployment;
+  try {
+    const appsClient = kcfg.makeApiClient(AppsV1Api);
+    cd = (
+      await appsClient.readNamespacedDeployment(
+        CONTROLLER_NAME,
+        CONTROLLER_NAMESPACE
+      )
+    ).body;
+  } catch (err) {
+    die(
+      `failed to read Opstrace controller deployment: ${
+        err.response ? err.response.body.message : err
+      }`
+    );
+  }
+  // Image will always be defined since it is retrieved from the controller deployment's podspec.
+  const controllerVersion = parseVersionFromImageTag(
+    cd.spec!.template.spec!.containers[0].image!
+  );
+
+  // Read Kubernetes cluster info for the full server version.
+  let k8sSrvInfo: VersionInfo;
+  try {
+    k8sSrvInfo = (await kcfg.makeApiClient(VersionApi).getCode()).body;
+  } catch (err) {
+    die(`failed to read Kubernetes server info: ${err}`);
+  }
+
+  // Finally, write cluster info.
+  console.log(`
+cluster info:
+  kubernetes_version: ${k8sSrvInfo.gitVersion}
+  controller_version: ${controllerVersion}
+  installer_version: ${lastCLIVersion}
+  `);
+}
+
+// Race to get cluster info and fail if it takes longer than 60 seconds.
+function* rootTaskInfoCore() {
+  const { timeout } = yield race({
+    info: call(getClusterInfo),
+    timeout: delay(60 * SECOND)
+  });
+
+  if (timeout) {
+    throw new Error("timeout getting Opstrace cluster info");
+  }
+}
+
+// Wrapper to make redux-saga happy.
+function* rootTaskInfo() {
+  yield call(rootTaskInfoCore);
+}
+
+// Empty reducer to make redux-saga happy.
+const reducer = (state = 0) => state;
+
+export async function info(): Promise<void> {
+  const sm = createSagaMiddleware({ onError: smErrorLastResort });
+  createStore(reducer, applyMiddleware(sm));
+  await sm.run(rootTaskInfo).toPromise();
+}

--- a/packages/cli/src/info.ts
+++ b/packages/cli/src/info.ts
@@ -78,7 +78,7 @@ async function getClusterInfo() {
   // will be present in the latest config version(s) only, but its non-existence should
   // not result in a command error.
   let lastCLIVersion = "undefined";
-  if (LatestControllerConfigSchema.isValidSync(cfgJSON)) {
+  if (LatestControllerConfigSchema.isValidSync(cfgJSON, { strict: true })) {
     const cfg = LatestControllerConfigSchema.validateSync(cfgJSON);
     lastCLIVersion =
       cfg.cliMetadata.allCLIVersions[cfg.cliMetadata.allCLIVersions.length - 1]

--- a/packages/controller-config/package.json
+++ b/packages/controller-config/package.json
@@ -19,6 +19,6 @@
     "@opstrace/aws": "^0.0.0",
     "@opstrace/gcp": "^0.0.0",
     "@opstrace/kubernetes": "^0.0.0",
-    "date-fns": "^2.23.0"
+    "@js-joda/core": "^3.1.0"
   }
 }

--- a/packages/controller-config/package.json
+++ b/packages/controller-config/package.json
@@ -16,8 +16,9 @@
     "lint": "echo noop"
   },
   "dependencies": {
-    "@opstrace/kubernetes": "^0.0.0",
     "@opstrace/aws": "^0.0.0",
-    "@opstrace/gcp": "^0.0.0"
+    "@opstrace/gcp": "^0.0.0",
+    "@opstrace/kubernetes": "^0.0.0",
+    "date-fns": "^2.23.0"
   }
 }

--- a/packages/controller-config/src/index.ts
+++ b/packages/controller-config/src/index.ts
@@ -24,7 +24,7 @@ export * from "./docker-images";
 export * from "./aks";
 export * from "./resources/dockerhub";
 
-export { CONTROLLER_NAME } from "./resources/controller";
+export { CONTROLLER_NAME, CONTROLLER_NAMESPACE } from "./resources/controller";
 export {
   CONFIGMAP_NAME,
   STORAGE_KEY,

--- a/packages/controller-config/src/resources/controller.ts
+++ b/packages/controller-config/src/resources/controller.ts
@@ -26,6 +26,7 @@ import { generateSecretValue } from "../helpers";
 import { getImagePullSecrets, dockerHubCredsSecret } from "./dockerhub";
 
 export const CONTROLLER_NAME = "opstrace-controller";
+export const CONTROLLER_NAMESPACE = "kube-system";
 
 export function ControllerResources({
   controllerImage,
@@ -37,7 +38,7 @@ export function ControllerResources({
   kubeConfig: KubeConfig;
 }): ResourceCollection {
   const collection = new ResourceCollection();
-  const namespace = "kube-system";
+  const namespace = CONTROLLER_NAMESPACE;
   const name = CONTROLLER_NAME;
 
   const controllerCmdlineArgs = [`${opstraceClusterName}`];

--- a/packages/controller-config/src/schema.ts
+++ b/packages/controller-config/src/schema.ts
@@ -99,8 +99,13 @@ export function upgradeControllerConfigMapToLatest(
   }
 
   if (cfgV2 !== undefined) {
+    log.debug("upgrading from v2 to v3");
     return V2toV3(cfgV2);
   }
+
+  log.debug(
+    "no valid controller config schema found, attempting sync with latest"
+  );
 
   // Possible user error. Parse again and it'll throw a meaningful error
   // message.

--- a/packages/controller-config/src/schemav3.ts
+++ b/packages/controller-config/src/schemav3.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yup from "yup";
+import { GCPConfig } from "@opstrace/gcp";
+import { AWSConfig } from "@opstrace/aws";
+
+export const ControllerConfigSchemaV3 = yup
+  .object({
+    name: yup.string(),
+    target: yup
+      .mixed<"gcp" | "aws">()
+      .oneOf(["gcp", "aws"])
+      .required("must specify a target (gcp | aws)"),
+    region: yup.string().required("must specify region"),
+    logRetentionDays: yup
+      .number()
+      .required("must specify log retention in number of days"),
+    metricRetentionDays: yup
+      .number()
+      .required("must specify metric retention in number of days"),
+    dnsName: yup.string().required(),
+
+    custom_dns_name: yup.string().notRequired(),
+    custom_auth0_client_id: yup.string().notRequired(),
+
+    terminate: yup.bool().default(false),
+    // https://stackoverflow.com/a/63944333/145400 `data_api_authn_pubkey_pem`
+    // is optional, is a legacy controller config option, a noop right now
+    // (future: set fallback key for authenticator).
+    data_api_authn_pubkey_pem: yup.string().optional(),
+    tenant_api_authenticator_pubkey_set_json: yup
+      .string()
+      .typeError()
+      .strict(true),
+    disable_data_api_authentication: yup.bool().required(),
+    uiSourceIpFirewallRules: yup.array(yup.string()).ensure(),
+    apiSourceIpFirewallRules: yup.array(yup.string()).ensure(),
+    postgreSQLEndpoint: yup.string().notRequired(),
+    opstraceDBName: yup.string().notRequired(),
+    envLabel: yup.string(),
+    // Note: remove one of cert_issuer and `tlsCertificateIssuer`.
+    cert_issuer: yup
+      .string()
+      .oneOf(["letsencrypt-prod", "letsencrypt-staging"])
+      .required(),
+    tlsCertificateIssuer: yup
+      .mixed<"letsencrypt-staging" | "letsencrypt-prod">()
+      .oneOf(["letsencrypt-staging", "letsencrypt-prod"])
+      .required(),
+    infrastructureName: yup.string().required(),
+    aws: yup.mixed<AWSConfig | undefined>(),
+    gcp: yup.mixed<GCPConfig | undefined>(),
+    controllerTerminated: yup.bool().default(false),
+    cliMetadata: yup.object({
+      allCLIVersions: yup
+        .array(
+          yup.object({
+            version: yup.string(),
+            timestamp: yup.date()
+          })
+        )
+        .ensure()
+    })
+  })
+  .noUnknown()
+  .defined();
+
+export type ControllerConfigTypeV3 = yup.InferType<
+  typeof ControllerConfigSchemaV3
+>;

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -18,6 +18,8 @@ import fs from "fs";
 import { strict as assert } from "assert";
 
 import got, { Response as GotResponse, Options as GotOptions } from "got";
+import { ZonedDateTime, ZoneOffset, DateTimeFormatter } from "@js-joda/core";
+
 import { fork, call, race, delay, cancel } from "redux-saga/effects";
 import { createStore, applyMiddleware } from "redux";
 import createSagaMiddleware from "redux-saga";
@@ -184,7 +186,12 @@ function* createClusterCore() {
       allCLIVersions: [
         {
           version: BUILD_INFO.VERSION_STRING,
-          timestamp: new Date().toISOString()
+          // Current time in UTC using RFC3339 string representation (w/o
+          // fractional seconds, with Z tz specififer), e.g.
+          // '2021-07-28T15:43:07Z'
+          timestamp: ZonedDateTime.now(ZoneOffset.UTC).format(
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+          )
         }
       ]
     }

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -26,6 +26,7 @@ import {
   log,
   sleep,
   SECOND,
+  BUILD_INFO,
   retryUponAnyError,
   Dict,
   checkIfDockerImageExistsOrErrorOut
@@ -178,7 +179,15 @@ function* createClusterCore() {
       ccfg.tenant_api_authenticator_pubkey_set_json,
     disable_data_api_authentication: ccfg.data_api_authentication_disabled,
     custom_dns_name: ccfg.custom_dns_name,
-    custom_auth0_client_id: ccfg.custom_auth0_client_id
+    custom_auth0_client_id: ccfg.custom_auth0_client_id,
+    cliMetadata: {
+      allCLIVersions: [
+        {
+          version: BUILD_INFO.VERSION_STRING,
+          timestamp: new Date()
+        }
+      ]
+    }
   };
 
   // Fail fast if specified controller docker image cannot be found on docker

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -184,7 +184,7 @@ function* createClusterCore() {
       allCLIVersions: [
         {
           version: BUILD_INFO.VERSION_STRING,
-          timestamp: new Date()
+          timestamp: new Date().toISOString()
         }
       ]
     }

--- a/packages/upgrader/src/index.ts
+++ b/packages/upgrader/src/index.ts
@@ -198,8 +198,6 @@ function* triggerControllerDeploymentUpgrade() {
     // handle upgrades from clusters that are not running the cortex-operator
     yield call(cortexOperatorPreamble, kubeConfig);
 
-    yield call(upgradeControllerConfigMap, kubeConfig);
-
     const rolloutStarted: boolean = yield call(upgradeControllerDeployment, {
       opstraceClusterName: upgradeConfig.clusterName,
       kubeConfig: kubeConfig

--- a/packages/upgrader/src/upgrade.ts
+++ b/packages/upgrader/src/upgrade.ts
@@ -106,7 +106,7 @@ export function* upgradeControllerConfigMap(
     cfg = upgradeControllerConfigMapToLatest(cfgJSON);
     cfg.cliMetadata.allCLIVersions.push({
       version: BUILD_INFO.VERSION_STRING,
-      timestamp: new Date()
+      timestamp: new Date().toISOString()
     });
   } catch (e) {
     die(`failed to upgrade controller configuration: ${e.message}`);

--- a/packages/upgrader/src/upgrade.ts
+++ b/packages/upgrader/src/upgrade.ts
@@ -104,6 +104,10 @@ export function* upgradeControllerConfigMap(
   let cfg: LatestControllerConfigType;
   try {
     cfg = upgradeControllerConfigMapToLatest(cfgJSON);
+    cfg.cliMetadata.allCLIVersions.push({
+      version: BUILD_INFO.VERSION_STRING,
+      timestamp: new Date()
+    });
   } catch (e) {
     die(`failed to upgrade controller configuration: ${e.message}`);
   }

--- a/packages/upgrader/src/upgrade.ts
+++ b/packages/upgrader/src/upgrade.ts
@@ -15,6 +15,7 @@
  */
 
 import { all, select, call, Effect } from "redux-saga/effects";
+import { ZonedDateTime, ZoneOffset, DateTimeFormatter } from "@js-joda/core";
 import { KubeConfig } from "@kubernetes/client-node";
 
 import { getClusterConfig } from "@opstrace/config";
@@ -29,9 +30,8 @@ import {
   set as updateControllerConfig,
   upgradeControllerConfigMapToLatest
 } from "@opstrace/controller-config";
-
 import { Deployment, K8sResource, updateResource } from "@opstrace/kubernetes";
-
+import { getValidatedGCPAuthOptionsFromFile } from "@opstrace/gcp";
 import {
   EnsureInfraExistsResponse,
   ensureAWSInfraExists,
@@ -39,7 +39,6 @@ import {
 } from "@opstrace/installer";
 
 import { State } from "./reducer";
-import { getValidatedGCPAuthOptionsFromFile } from "@opstrace/gcp";
 import { waitForControllerDeployment } from "./readiness";
 
 const CONTROLLER_IMAGE_DEFAULT = `opstrace/controller:${BUILD_INFO.VERSION_STRING}`;
@@ -106,7 +105,12 @@ export function* upgradeControllerConfigMap(
     cfg = upgradeControllerConfigMapToLatest(cfgJSON);
     cfg.cliMetadata.allCLIVersions.push({
       version: BUILD_INFO.VERSION_STRING,
-      timestamp: new Date().toISOString()
+      // Current time in UTC using RFC3339 string representation (w/o
+      // fractional seconds, with Z tz specififer), e.g.
+      // '2021-07-28T15:43:07Z'
+      timestamp: ZonedDateTime.now(ZoneOffset.UTC).format(
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+      )
     });
   } catch (e) {
     die(`failed to upgrade controller configuration: ${e.message}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7296,7 +7296,15 @@ bintrees@1.0.1:
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
   integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
 
-bl@^1.0.0, bl@^4.0.3:
+bl@^1.0.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.3.tgz#1e8dd80142eac80d7158c9dccc047fb620e035e7"
+  integrity sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
+bl@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -7820,7 +7828,7 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
-camelcase@5.3.1, camelcase@^5.3.1:
+camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -9175,6 +9183,11 @@ date-fns@^2.15.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.18.0.tgz#08e50aee300ad0d2c5e054e3f0d10d8f9cdfe09e"
   integrity sha512-NYyAg4wRmGVU4miKq5ivRACOODdZRY3q5WLmOJSq8djyzftYphU7dTHLcEtLqEvfqMKQ0jVv91P4BAwIjsXIcw==
 
+date-fns@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
+  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
+
 debounce@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
@@ -9719,7 +9732,7 @@ dot-object@^2.1.4:
     commander "^4.0.0"
     glob "^7.1.5"
 
-dot-prop@^5.1.0, dot-prop@^5.1.1, dot-prop@^5.2.0:
+dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
@@ -16535,7 +16548,7 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-path@^0.11.4, object-path@^0.11.5:
+object-path@^0.11.4:
   version "0.11.5"
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.5.tgz#d4e3cf19601a5140a55a16ad712019a9c50b577a"
   integrity sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==
@@ -19102,7 +19115,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -20122,10 +20135,22 @@ serialize-error@^7.0.1:
   dependencies:
     type-fest "^0.13.1"
 
-serialize-javascript@5.0.1, serialize-javascript@^2.1.2, serialize-javascript@^3.1.0, serialize-javascript@^4.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
-  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
+serialize-javascript@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
   dependencies:
     randombytes "^2.1.0"
 
@@ -23601,10 +23626,31 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@20.2.4, yargs-parser@20.x, yargs-parser@^13.1.2, yargs-parser@^18.1.2, yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.6:
+yargs-parser@20.2.4:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
+yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-unparser@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
`opstrace info <aws|gcp> <cluster name>` will print Opstrace and Kubernetes cluster info in the following format:

```
cluster info:
  cluster_version: <kubernetes version>
  controller_version: <image tag>
  installer_version: <installer commit string>
```

Installer version is stored in the controller's configmap and updated on each upgrade event, while other version information is read from k8s cluster configuration at runtime.

Closes #454

Might also address part of #1023

/cc @sreis 

# Have you...

* [x] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [x] Written new tests for your changes?
* [x] Thought about which docs need updating?
