### PR TITLE
[wip] ui: update constraint violating tenant names before constraint is added

### DIFF
--- a/packages/app/migrations/1626017036575_simplify-existing-tenant-names/down.sql
+++ b/packages/app/migrations/1626017036575_simplify-existing-tenant-names/down.sql
@@ -1,0 +1,4 @@
+do $$
+begin
+  --nothing to do
+end $$

--- a/packages/app/migrations/1626017036575_simplify-existing-tenant-names/up.sql
+++ b/packages/app/migrations/1626017036575_simplify-existing-tenant-names/up.sql
@@ -13,22 +13,22 @@ begin
     if not cleaned_name = tenant_row.name then
       raise notice 'updating tenant name: "%"', tenant_row.name;
 
-    updated_name := cleaned_name;
-    loop
-      select * from tenant
+      updated_name := cleaned_name;
+      loop
+        select * from tenant
           into existing_tenant
           where tenant.name = updated_name;
 
-      exit when not found;
+        exit when not found;
 
-      updated_name = CONCAT(cleaned_name, (select floor(random() * 1000 + 1)::int));
-    end loop;
+        updated_name = CONCAT(cleaned_name, (select floor(random() * 1000 + 1)::int));
+      end loop;
 
-    raise notice 'new tenant name: "%"', updated_name;
+      raise notice 'new tenant name: "%"', updated_name;
 
-    update tenant
-      set name = "updated_name"
-      where name = tenant_row.name;
+      update tenant
+        set name = "updated_name"
+        where name = tenant_row.name;
 
     end if;
 

--- a/packages/app/migrations/1626017036575_simplify-existing-tenant-names/up.sql
+++ b/packages/app/migrations/1626017036575_simplify-existing-tenant-names/up.sql
@@ -1,0 +1,37 @@
+do $$
+declare
+  tenant_row tenant%rowtype;
+  existing_tenant tenant%rowtype;
+  cleaned_name tenant.name%type;
+  updated_name tenant.name%type;
+begin
+
+  for tenant_row in (select * from tenant) loop
+
+    cleaned_name := (select regexp_replace(lower(tenant_row.name), '[^a-z0-9]', '', 'g'));
+
+    if not cleaned_name = tenant_row.name then
+      raise notice 'updating tenant name: "%"', tenant_row.name;
+
+    updated_name := cleaned_name;
+    loop
+      select * from tenant
+          into existing_tenant
+          where tenant.name = updated_name;
+
+      exit when not found;
+
+      updated_name = CONCAT(cleaned_name, (select floor(random() * 1000 + 1)::int));
+    end loop;
+
+    raise notice 'new tenant name: "%"', updated_name;
+
+    update tenant
+      set name = "updated_name"
+      where name = tenant_row.name;
+
+    end if;
+
+  end loop;
+
+end $$


### PR DESCRIPTION
If a cluster has tenant names that contain chars that violate the newly added constraint on the tenant.name field upgrading the cluster will fail (well, atleast the hasura migrations will) with the following error:

```
FATA[0000] apply failed: [postgres-error] query execution failed ($.args[0].args)
File: '1626132643036_alter_table_public_tenant_add_check_constraint_tenant_name_validation/up.sql'
{
    "check_metadata_consistency": false,
    "sql": "alter table \"public\".\"tenant\" add constraint \"tenant_name_validation\" check (name ~ '^[a-z0-9]{2,63}$'::text);\n"
}
[23514] FatalError: check constraint "tenant_name_validation" is violated by some row 
```

This PR inserts a migration that runs immediately before the constraint is added. It ensures all tenant names will pass the new constraint by removing unsupport charts and appending a random number if the new name is not unique.
