### PR TITLE
loki: move memberlist bind port to 7947

### DIFF
--- a/packages/controller/src/resources/loki/index.ts
+++ b/packages/controller/src/resources/loki/index.ts
@@ -170,6 +170,8 @@ export function LokiResources(
     env: []
   };
 
+  const memberlist_bind_port = 7947;
+
   const lokiDefaultConfig = {
     server: {
       http_listen_port: 1080,
@@ -266,11 +268,11 @@ export function LokiResources(
       // don't allow split-brain / individual components that think they are
       // not part of a cluster.
       abort_if_cluster_join_fails: true,
-      bind_port: 7946,
+      bind_port: memberlist_bind_port,
       join_members: [
         // use a kubernetes headless service for all distributor, ingester and
         // querier components
-        `loki-gossip-ring.${namespace}.svc.cluster.local:7946`
+        `loki-gossip-ring.${namespace}.svc.cluster.local:${memberlist_bind_port}`
       ],
       // these settings are taken from examples in  official documentation
       // https://github.com/grafana/loki/blob/master/docs/sources/configuration/examples.md
@@ -457,9 +459,9 @@ export function LokiResources(
           ports: [
             {
               name: "loki-gossip-ring",
-              port: 7946,
+              port: memberlist_bind_port,
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              targetPort: 7946 as any
+              targetPort: memberlist_bind_port as any
             }
           ],
           selector: {


### PR DESCRIPTION
Move to another port to avoid any possibility of joining pods belonging to cortex memberlist ring.

Copying the comment from https://github.com/opstrace/private/issues/169#issuecomment-879736441

> Just conjecture at this point but the constant crash looping of the pods could lead to the kubelet recycling IP addresses. Meaning, at some point, a pod belonging to one memberlist ring (cortex) could get an IP that was recently assigned to a pod in the other memberlist ring (loki). This would mean the new pod would connect to cortex memberlist ring but get connections from members of the loki ring. This would create the "bridge" between the two rings. I thought about this because left_ingesters_timeout is set to 5m0s which seems like enough time for an ingester to be up and advertise itself on the memberlist ring and accept connections from the other ring before crashing again.

In #869 I'm already taking care of renaming the gossip-ring service in cortex to avoid any confusion. 
