### PR TITLE
ci(upgrades): dissociate test-core

### DIFF
--- a/.buildkite/test-upgrade-pipeline.yml
+++ b/.buildkite/test-upgrade-pipeline.yml
@@ -1,3 +1,5 @@
+env:
+  CHECKOUT_VERSION_STRING: "${BUILDKITE_COMMIT:0:8}-ci"
 steps:
   - label: "🔨 preamble"
     key: "preamble"

--- a/ci/test-upgrade/create-cluster-artifacts.sh
+++ b/ci/test-upgrade/create-cluster-artifacts.sh
@@ -63,5 +63,10 @@ do
 done
 
 # make sure that looker-related artifacts are collected
-cp /build/looker*log /build/bk-artifacts
-cp /build/looker*report.json /build/bk-artifacts
+cp /build/looker*log /build/bk-artifacts || true
+cp /build/looker*report.json /build/bk-artifacts || true
+
+cp test-remote-artifacts/uishot-*.png /build/bk-artifacts || true
+
+mkdir -p /build/bk-artifacts/browser-test-result || true
+mv browser-test-results /build/bk-artifacts/ || true

--- a/ci/test-upgrade/run.sh
+++ b/ci/test-upgrade/run.sh
@@ -56,6 +56,11 @@ export OPSTRACE_INSTANCE_DNS_NAME="${OPSTRACE_CLUSTER_NAME}.opstrace.io"
 # using the make ci-testupgrade-* method.
 source ci/test-upgrade/set-up-test-tenant.sh
 
+#
+# TODO(sreis): remove this step when the OPSTRACE_CLI_VERSION_FROM is bumped
+#
+make ci-testupgrade-wait-for-loki-ring
+
 make test-remote
 make test-remote-ui
 make test-browser

--- a/ci/test-upgrade/run.sh
+++ b/ci/test-upgrade/run.sh
@@ -46,6 +46,19 @@ make ci-testupgrade-upgrade-cluster
 # Define default for OPSTRACE_INSTANCE_DNS_NAME.
 export OPSTRACE_INSTANCE_DNS_NAME="${OPSTRACE_CLUSTER_NAME}.opstrace.io"
 
-# This runs the bulk of the tests against the Opstrace instance. Also invoked
-# from the regular test pipeline and therefore in its own file.
-OPSTRACE_BIN=./to/opstrace source ci/test-core.sh
+# This step is required for the create_tenant_and_use_custom_authn_token in the
+# test-remote test suite. This step sets up the tenant keys in the opstrace
+# instance and exports the required env vars:
+# - TENANT_RND_NAME_FOR_TESTING_ADD_TENANT
+# - TENANT_RND_AUTHTOKEN
+#
+# We need the env vars to be exported that is why it's source'd here instead of
+# using the make ci-testupgrade-* method.
+source ci/test-upgrade/set-up-test-tenant.sh
+
+make test-remote
+make test-remote-ui
+make test-browser
+
+export OPSTRACE_BUILD_DIR=$(pwd)
+source ci/invoke-looker.sh

--- a/ci/test-upgrade/set-up-test-tenant.sh
+++ b/ci/test-upgrade/set-up-test-tenant.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+RNDSTRING=$( tr -dc a-z < /dev/urandom | head -c 6 || true)
+export TENANT_RND_NAME_FOR_TESTING_ADD_TENANT="testtenant${RNDSTRING}"
+
+function run_in_docker() {
+	docker run -ti \
+		-v $(pwd):/build:rw \
+	    -v ${HOME}/.aws:/awsconfig:ro \
+	    -v /etc/passwd:/etc/passwd \
+	    -e AWS_SHARED_CREDENTIALS_FILE=/awsconfig/credentials \
+	    -e AWS_CLI_REGION \
+	    -e GCLOUD_CLI_REGION \
+	    -e GCLOUD_CLI_ZONE \
+	    -e GOOGLE_APPLICATION_CREDENTIALS \
+	    -e OPSTRACE_GCP_PROJECT_ID \
+	    -e AWS_ACCESS_KEY_ID \
+	    -e AWS_SECRET_ACCESS_KEY \
+	    -e HOME=/build \
+	    -e OPSTRACE_CLUSTER_NAME \
+	    -e OPSTRACE_CLOUD_PROVIDER \
+	    -e BUILDKITE_BUILD_NUMBER \
+	    -e BUILDKITE_PULL_REQUEST \
+	    -e BUILDKITE_COMMIT \
+	    -e BUILDKITE_BRANCH \
+	    -e CHECKOUT_VERSION_STRING \
+        -w /build \
+	    --dns $(ci/dns_cache.sh) \
+	    opstrace/opstrace-ci:${CHECKOUT_VERSION_STRING} \
+        $*
+}
+
+echo "--- running ta-create-keypair"
+run_in_docker /build/to/opstrace ta-create-keypair ./ta-custom-keypair.pem
+
+echo "--- running ta-create-token"
+run_in_docker /build/to/opstrace ta-create-token "${OPSTRACE_CLUSTER_NAME}" \
+    "${TENANT_RND_NAME_FOR_TESTING_ADD_TENANT}" ta-custom-keypair.pem > tenant-rnd-auth-token-from-custom-keypair
+
+echo "--- running ta-create-token"
+run_in_docker /build/to/opstrace ta-pubkeys-add \
+    "${OPSTRACE_CLOUD_PROVIDER}" "${OPSTRACE_CLUSTER_NAME}" ta-custom-keypair.pem
+
+export TENANT_RND_AUTHTOKEN="$(cat tenant-rnd-auth-token-from-custom-keypair)"

--- a/ci/test-upgrade/wait-for-loki-ring.sh
+++ b/ci/test-upgrade/wait-for-loki-ring.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "--- waiting for loki ring to be ready"
+
+for cycle in {1..30}
+do
+    SHARDS=$(kubectl get --raw /api/v1/namespaces/loki/services/distributor:1080/proxy/ring | jq .shards | jq length)
+    echo "number of shards in ring: ${SHARDS}"
+    [[ ${SHARDS} < 3 ]] || exit 0
+
+    sleep 30
+done
+
+echo "timeout waiting for loki ring to be ready"
+exit 1


### PR DESCRIPTION
~In upgrades pipeline, run test-core.sh in a container using CI docker image. This is required to fix the missing gcloud and aws binaries to refresh credentials.~

~Did some changes to make docker create the test artifact folders but need to check it still runs the PR pipeline.~

See https://github.com/opstrace/opstrace/pull/1065#issuecomment-881414748 bello