### PR TITLE
utils: when running local dev env use a default BUILD_INFO if there isn't a real one to use

### DIFF
--- a/lib/utils/src/buildinfo.ts
+++ b/lib/utils/src/buildinfo.ts
@@ -28,6 +28,7 @@
 // import chain)
 
 import fs from "fs";
+import { log } from "./log";
 
 export interface BUILD_INFO_TYPE {
   BRANCH_NAME: string;
@@ -101,10 +102,24 @@ function readBuildInfo() {
 
   // None of the candidate file paths led to success. Fall back to env.
   if (!process.env.OPSTRACE_BUILDINFO_PATH) {
-    throw Error(
-      `environment variable OPSTRACE_BUILDINFO_PATH not set ` +
-        `and none of [${JSON.stringify(CANDIDATE_PATHS)}] found/readable`
-    );
+    if (process.env.NODE_ENV === "development") {
+      log.info(
+        "using hardcoded 'local-dev' for BUILD_INFO, to override set environment variable OPSTRACE_BUILDINFO_PATH"
+      );
+      BUILD_INFO = {
+        BRANCH_NAME: "local-dev",
+        VERSION_STRING: "local-dev",
+        COMMIT: "local-dev",
+        BUILD_TIME_RFC3339: "1970-01-01 00:00:00+00:00",
+        BUILD_HOSTNAME: "localhost"
+      };
+      return;
+    } else {
+      throw Error(
+        `environment variable OPSTRACE_BUILDINFO_PATH not set ` +
+          `and none of [${JSON.stringify(CANDIDATE_PATHS)}] found/readable`
+      );
+    }
   }
 
   // If this path is invalid / file cannot be opened, file contents are


### PR DESCRIPTION
Local dev for the `packages/app` stopped working with [this commit](https://github.com/opstrace/opstrace/commit/b13281f18da1). So as to not add further complexity to running the app locally I've updated `readBuildInfo` to use a default set of values instead of erroring when `process.env.NODE_ENV === "development"`. 