### PR TITLE
cli(upgrades): force distributor roll out after loki upgrade finishes 

### DIFF
--- a/ci/test-upgrade/run.sh
+++ b/ci/test-upgrade/run.sh
@@ -52,9 +52,9 @@ export OPSTRACE_INSTANCE_DNS_NAME="${OPSTRACE_CLUSTER_NAME}.opstrace.io"
 # - TENANT_RND_NAME_FOR_TESTING_ADD_TENANT
 # - TENANT_RND_AUTHTOKEN
 #
-# We need the env vars to be exported that is why it's source'd here instead of
-# using the make ci-testupgrade-* method.
-source ci/test-upgrade/set-up-test-tenant.sh
+make ci-testupgrade-set-up-test-tenant
+export TENANT_RND_NAME_FOR_TESTING_ADD_TENANT=$(cat tenant-rnd-name)
+export TENANT_RND_AUTHTOKEN=$(cat tenant-rnd-auth-token-from-custom-keypair)
 
 #
 # TODO(sreis): remove this step when the OPSTRACE_CLI_VERSION_FROM is bumped

--- a/ci/test-upgrade/set-up-test-tenant.sh
+++ b/ci/test-upgrade/set-up-test-tenant.sh
@@ -1,44 +1,15 @@
 #!/bin/bash
 
 RNDSTRING=$( tr -dc a-z < /dev/urandom | head -c 6 || true)
-export TENANT_RND_NAME_FOR_TESTING_ADD_TENANT="testtenant${RNDSTRING}"
-
-function run_in_docker() {
-	docker run -ti \
-		-v $(pwd):/build:rw \
-	    -v ${HOME}/.aws:/awsconfig:ro \
-	    -v /etc/passwd:/etc/passwd \
-	    -e AWS_SHARED_CREDENTIALS_FILE=/awsconfig/credentials \
-	    -e AWS_CLI_REGION \
-	    -e GCLOUD_CLI_REGION \
-	    -e GCLOUD_CLI_ZONE \
-	    -e GOOGLE_APPLICATION_CREDENTIALS \
-	    -e OPSTRACE_GCP_PROJECT_ID \
-	    -e AWS_ACCESS_KEY_ID \
-	    -e AWS_SECRET_ACCESS_KEY \
-	    -e HOME=/build \
-	    -e OPSTRACE_CLUSTER_NAME \
-	    -e OPSTRACE_CLOUD_PROVIDER \
-	    -e BUILDKITE_BUILD_NUMBER \
-	    -e BUILDKITE_PULL_REQUEST \
-	    -e BUILDKITE_COMMIT \
-	    -e BUILDKITE_BRANCH \
-	    -e CHECKOUT_VERSION_STRING \
-        -w /build \
-	    --dns $(ci/dns_cache.sh) \
-	    opstrace/opstrace-ci:${CHECKOUT_VERSION_STRING} \
-        $*
-}
+TENANT_RND_NAME_FOR_TESTING_ADD_TENANT="testtenant${RNDSTRING}"
+echo ${TENANT_RND_NAME_FOR_TESTING_ADD_TENANT} > /build/tenant-rnd-name
 
 echo "--- running ta-create-keypair"
-run_in_docker /build/to/opstrace ta-create-keypair ./ta-custom-keypair.pem
+/build/to/opstrace ta-create-keypair /build/ta-custom-keypair.pem
 
 echo "--- running ta-create-token"
-run_in_docker /build/to/opstrace ta-create-token "${OPSTRACE_CLUSTER_NAME}" \
-    "${TENANT_RND_NAME_FOR_TESTING_ADD_TENANT}" ta-custom-keypair.pem > tenant-rnd-auth-token-from-custom-keypair
+/build/to/opstrace ta-create-token "${OPSTRACE_CLUSTER_NAME}" \
+    "${TENANT_RND_NAME_FOR_TESTING_ADD_TENANT}" ta-custom-keypair.pem > /build/tenant-rnd-auth-token-from-custom-keypair
 
 echo "--- running ta-create-token"
-run_in_docker /build/to/opstrace ta-pubkeys-add \
-    "${OPSTRACE_CLOUD_PROVIDER}" "${OPSTRACE_CLUSTER_NAME}" ta-custom-keypair.pem
-
-export TENANT_RND_AUTHTOKEN="$(cat tenant-rnd-auth-token-from-custom-keypair)"
+/build/to/opstrace ta-pubkeys-add "${OPSTRACE_CLOUD_PROVIDER}" "${OPSTRACE_CLUSTER_NAME}" /build/ta-custom-keypair.pem

--- a/ci/test-upgrade/wait-for-loki-ring.sh
+++ b/ci/test-upgrade/wait-for-loki-ring.sh
@@ -2,14 +2,31 @@
 
 echo "--- waiting for loki ring to be ready"
 
-for cycle in {1..30}
-do
-    SHARDS=$(kubectl get --raw /api/v1/namespaces/loki/services/distributor:1080/proxy/ring | jq .shards | jq length)
-    echo "number of shards in ring: ${SHARDS}"
-    [[ ${SHARDS} < 3 ]] || exit 0
+function check_distributor() {
+    local pod=${1}
+    echo "set up port-forward to pod ${pod}"
+    # Pick a random port in the given range.
+    local PORT=$(shuf -i 8080-9000 -n 1)
+    # This process is killed when the container running this script exits.
+    kubectl --namespace loki port-forward pod/${pod} ${PORT}:1080 &
+    echo "waiting for pod ${pod} to report ring is ready"
+    for cycle in {1..20}
+    do
+        # The initial sleep here waits for the port forwarding to be set up.
+        sleep 30
+        SHARDS=$(curl -m 20 -s -H "Accept: application/json, */*"  http://localhost:${PORT}/ring | jq .shards | jq length)
+        echo "pod ${pod}: reports number of shards in ring: ${SHARDS}"
 
-    sleep 30
+        (( ${SHARDS} >= 3 )) && break
+    done
+}
+
+DISTRIBUTORS=$(kubectl --namespace loki get pods --no-headers -o custom-columns=":metadata.name" | grep distributor)
+
+for pod in ${DISTRIBUTORS}
+do
+    check_distributor ${pod}
+    (( ${SHARDS} < 3 )) && echo "timeout waiting for loki ring to be ready" && exit 1
 done
 
-echo "timeout waiting for loki ring to be ready"
-exit 1
+exit 0

--- a/ci/test-upgrade/wait-for-loki-ring.sh
+++ b/ci/test-upgrade/wait-for-loki-ring.sh
@@ -9,20 +9,21 @@ function check_distributor() {
     local PORT=$(shuf -i 8080-9000 -n 1)
     # This process is killed when the container running this script exits.
     kubectl --namespace loki port-forward pod/${pod} ${PORT}:1080 &
+    # Wait for the port forwarding to be set up.
+    sleep 5
+
     echo "waiting for pod ${pod} to report ring is ready"
     for cycle in {1..20}
     do
-        # The initial sleep here waits for the port forwarding to be set up.
-        sleep 30
         SHARDS=$(curl -m 20 -s -H "Accept: application/json, */*"  http://localhost:${PORT}/ring | jq .shards | jq length)
         echo "pod ${pod}: reports number of shards in ring: ${SHARDS}"
 
         (( ${SHARDS} >= 3 )) && break
+        sleep 30
     done
 }
 
 DISTRIBUTORS=$(kubectl --namespace loki get pods --no-headers -o custom-columns=":metadata.name" | grep distributor)
-
 for pod in ${DISTRIBUTORS}
 do
     check_distributor ${pod}

--- a/packages/upgrader/src/index.ts
+++ b/packages/upgrader/src/index.ts
@@ -53,6 +53,7 @@ import {
   setCreateConfig,
   waitUntilHTTPEndpointsAreReachable
 } from "@opstrace/installer";
+import { workaroundRestartLokiDistributors } from "./workaround";
 
 // Note: a largish number of attempts as long as micro retries are not yet
 // implemented carefully and thoughtfully.
@@ -204,6 +205,9 @@ function* triggerControllerDeploymentUpgrade() {
         'wait for upgrade to complete ("wait for deployments/..." phase)'
       );
       yield call(upgradeProgressReporter);
+
+      // Workaround for https://github.com/opstrace/opstrace/issues/1066
+      yield call(workaroundRestartLokiDistributors);
     }
   }
 

--- a/packages/upgrader/src/workaround.ts
+++ b/packages/upgrader/src/workaround.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SECOND } from "@opstrace/utils";
+import { select, call, all, delay, Effect } from "redux-saga/effects";
+import { upgradeProgressReporter } from "./readiness";
+import { State } from "./reducer";
+
+export function* workaroundRestartLokiDistributors(): Generator<
+  Effect,
+  void,
+  State
+> {
+  const state: State = yield select();
+  const { Deployments } = state.kubernetes.cluster;
+
+  const cd = Deployments.resources.filter(
+    d => d.name === "distributor" && d.namespace === "loki"
+  );
+  if (cd === undefined) {
+    throw new Error("loki distributor deployment not found");
+  }
+
+  // Delete the deployment and wait for the controller to recreate it.
+  yield all(cd.map(d => d.delete()));
+  yield delay(10 * SECOND);
+  yield call(upgradeProgressReporter);
+}


### PR DESCRIPTION
Close #1066

The distributors need a kick start to find the ingesters, otherwise, we might get distributors thinking the ring is still empty. This is a consequence of the controller not deploying resources in a specific order. The ring state [eventually gets consistent](https://github.com/opstrace/opstrace/pull/1053#issuecomment-880288386) but it might take a long time. To make things faster go ahead and kick start the distributors after the initial rollout completes.