### PR TITLE
ui: add container metrics scrape targets to K8s metrics integration

### DIFF
--- a/packages/app/src/client/integrations/k8sMetrics/Show/templates/config.ts
+++ b/packages/app/src/client/integrations/k8sMetrics/Show/templates/config.ts
@@ -111,7 +111,7 @@ data:
         target_label: __scheme__
         replacement: https
 
-    # Collection of per-node metrics
+    # Collection of metrics about the kubelets themselves (request queues, pod launches, etc)
     - job_name: 'kubernetes-nodes'
       kubernetes_sd_configs:
       - role: node
@@ -133,6 +133,90 @@ data:
       - source_labels: []
         target_label: job
         replacement: kubelet
+      # Include integration ID for autodetection in opstrace
+      - source_labels: []
+        target_label: integration_id
+        replacement: ${integrationId}
+
+    # Collection of full container resource usage metrics from kubelets
+    - job_name: 'kubernetes-cadvisor'
+      kubernetes_sd_configs:
+      - role: node
+
+      metrics_path: /metrics/cadvisor
+      scheme: https
+      # TLS config for getting list of nodes to scrape, not querying nodes themselves
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      authorization:
+        credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      relabel_configs:
+      - target_label: __scheme__
+        replacement: https
+      # Include node hostname
+      - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+        target_label: instance
+      # Include job label for the nodes
+      - source_labels: []
+        target_label: job
+        replacement: kubelet-cadvisor
+      # Include integration ID for autodetection in opstrace
+      - source_labels: []
+        target_label: integration_id
+        replacement: ${integrationId}
+
+    # Collection of summary container resource usage metrics from kubelets
+    - job_name: 'kubernetes-resource'
+      kubernetes_sd_configs:
+      - role: node
+
+      metrics_path: /metrics/resource
+      scheme: https
+      # TLS config for getting list of nodes to scrape, not querying nodes themselves
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      authorization:
+        credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      relabel_configs:
+      - target_label: __scheme__
+        replacement: https
+      # Include node hostname
+      - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+        target_label: instance
+      # Include job label for the nodes
+      - source_labels: []
+        target_label: job
+        replacement: kubelet-resource
+      # Include integration ID for autodetection in opstrace
+      - source_labels: []
+        target_label: integration_id
+        replacement: ${integrationId}
+
+    # Collection of readinessProbe/livenessProbe/etc stats from kubelets
+    - job_name: 'kubernetes-probes'
+      kubernetes_sd_configs:
+      - role: node
+
+      metrics_path: /metrics/probes
+      scheme: https
+      # TLS config for getting list of nodes to scrape, not querying nodes themselves
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      authorization:
+        credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      relabel_configs:
+      - target_label: __scheme__
+        replacement: https
+      # Include node hostname
+      - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+        target_label: instance
+      # Include job label for the nodes
+      - source_labels: []
+        target_label: job
+        replacement: kubelet-probes
       # Include integration ID for autodetection in opstrace
       - source_labels: []
         target_label: integration_id

--- a/packages/app/src/client/integrations/k8sMetrics/Show/templates/config.ts
+++ b/packages/app/src/client/integrations/k8sMetrics/Show/templates/config.ts
@@ -101,7 +101,7 @@ data:
       # Include integration ID for separation in opstrace
       - source_labels: []
         target_label: integration_id
-        replacement: ${integrationId}
+        replacement: '${integrationId}'
 
       # Internal labels used by prometheus itself
       # Always use HTTPS for scraping the api server
@@ -136,7 +136,7 @@ data:
       # Include integration ID for autodetection in opstrace
       - source_labels: []
         target_label: integration_id
-        replacement: ${integrationId}
+        replacement: '${integrationId}'
 
     # Collection of full container resource usage metrics from kubelets
     - job_name: 'kubernetes-cadvisor'
@@ -164,7 +164,7 @@ data:
       # Include integration ID for autodetection in opstrace
       - source_labels: []
         target_label: integration_id
-        replacement: ${integrationId}
+        replacement: '${integrationId}'
 
     # Collection of summary container resource usage metrics from kubelets
     - job_name: 'kubernetes-resource'
@@ -192,7 +192,7 @@ data:
       # Include integration ID for autodetection in opstrace
       - source_labels: []
         target_label: integration_id
-        replacement: ${integrationId}
+        replacement: '${integrationId}'
 
     # Collection of readinessProbe/livenessProbe/etc stats from kubelets
     - job_name: 'kubernetes-probes'
@@ -220,7 +220,7 @@ data:
       # Include integration ID for autodetection in opstrace
       - source_labels: []
         target_label: integration_id
-        replacement: ${integrationId}
+        replacement: '${integrationId}'
 
     # Collection of the kubernetes apiserver
     - job_name: 'kubernetes-service'
@@ -246,7 +246,7 @@ data:
       # Include integration ID for autodetection in opstrace
       - source_labels: []
         target_label: integration_id
-        replacement: ${integrationId}
+        replacement: '${integrationId}'
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
We currently scrape kubelet `/metrics`. This adds `/metrics/cadvisor`, `/metrics/probes`, and `/metrics/resource`, which provide resource utilization metrics about the containers themselves.
A separate commit for this PR will add prebuilt dashboards for these new metrics.

See also #1070

Signed-off-by: Nick Parker <nick@opstrace.com>