### PR TITLE
ci: run upgrade tests on GCP as part of PR pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,6 +58,25 @@ steps:
       - bash ci/check-if-docs-pr.sh || make ci-deploy-testremote-teardown
     artifact_paths:
       - "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-aws/bk-artifacts/**/*"
+  - label: "🔨 test upgrades (GCP)"
+    key: "testupgrades-gcp"
+    depends_on:
+      - "unit-tests"
+    env:
+      # Fetch the latest Opstrace CLI artifact from S3 and use that as the
+      # initial cluster version.
+      OPSTRACE_CLI_VERSION_FROM: cli/main/latest/opstrace-cli-linux-amd64-latest.tar.bz2
+      # Use the Opstrace CLI artifact built from the PR branch to upgrade the
+      # cluster.
+      OPSTRACE_CLI_VERSION_TO: ${OPSTRACE_PREBUILD_DIR}/build/bin/opstrace
+      OPSTRACE_CLUSTER_NAME: "pr-upgr-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-g"
+      OPSTRACE_CLOUD_PROVIDER: "gcp"
+      GCLOUD_CLI_REGION: "us-west2"
+      GCLOUD_CLI_ZONE: "us-west2-a"
+    command:
+      - ci/test-upgrade/run.sh
+    artifact_paths:
+      - "/tmp/opstrace-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:7}-1-gcp/bk-artifacts/**/*"
   - label: "🔨 cleanup /tmp"
     key: "cleanup-tmp"
     depends_on:

--- a/ci/test-upgrade/fetch-cli-artifacts.sh
+++ b/ci/test-upgrade/fetch-cli-artifacts.sh
@@ -18,16 +18,25 @@ fi
 # Funtion that downloads cli artifact from s3 bucket and extracts it to a target
 # dir.
 #
-fetch_cli_artifact() {
-    local artifact=${1}
-    local dir=${2}
-
+fetch_cli_s3_artifact() {
     echo "downloading ${artifact}"
-    mkdir -p ${dir}
     aws s3 cp --only-show-errors s3://opstrace-ci-main-artifacts/${artifact} .
 
     echo "extracting ${artifact} to target dir ${dir}"
     tar xjf $(basename ${artifact}) -C ${dir}
+}
+
+fetch_cli_artifact() {
+    local artifact=${1}
+    local dir=${2}
+
+    mkdir -p ${dir}
+
+    if [ -f "${artifact}" ]; then
+        cp ${artifact} ${dir}
+    else
+        fetch_cli_s3_artifact ${artifact} ${dir}
+    fi
 }
 
 echo "--- fetching cli artifacts"


### PR DESCRIPTION
As discussed in slack:

> I propose running the upgrades pipeline (for GCP only) in all PRs for the next two weeks. This way, we can quantify how much it affects developer productivity. 
