### PR TITLE
ui: minor cleanup

### DIFF
--- a/packages/app/src/client/views/login/index.tsx
+++ b/packages/app/src/client/views/login/index.tsx
@@ -287,22 +287,16 @@ function LoginPageParent() {
   >();
   useEffect(() => {
     (async () => {
-      // Without this early exit criterion, `fetchLoginConfig()` is going to
-      // be called with every render cycle.
-      if (loginConfig !== undefined) {
-        return;
-      }
-
       const lcfg = await fetchLoginConfig();
       setLoginConfig(lcfg);
     })();
-  });
+  }, []);
 
   // Do not render child until loginconfig is populated. Kudos to
   // https://stackoverflow.com/a/57312722/145400 for the `{...loginConfig}` to
   // work around `not assignable to type 'IntrinsicAttributes..` kind of errors
   // when doing `loginconfig={loginconfig}`.
-  return <div>{loginConfig && <LoginPageChild {...loginConfig} />}</div>;
+  return loginConfig ? <LoginPageChild {...loginConfig} /> : null;
 }
 
 function LoginPageChild(lcfg: LoginConfigInterface) {


### PR DESCRIPTION
Minor cleanup of useEffect

> If you want to run an effect and clean it up only once (on mount and unmount), you can pass an empty array ([]) as a second argument. - [react-docs](https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects)

# Have you...

* [x] Added an explanation of what your changes do?
* [x] Thought about which docs need updating?
