### PR TITLE
ci: upgrade: use last release as base (FROM)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,9 +63,9 @@ steps:
     depends_on:
       - "unit-tests"
     env:
-      # Fetch the latest Opstrace CLI artifact from S3 and use that as the
-      # initial cluster version.
-      OPSTRACE_CLI_VERSION_FROM: cli/main/latest/opstrace-cli-linux-amd64-latest.tar.bz2
+      # Fetch the latest Opstrace CLI release and use that as the initial
+      # cluster version.
+      OPSTRACE_CLI_VERSION_FROM: https://go.opstrace.com/cli-latest-release-linux
       # Use the Opstrace CLI artifact built from the PR branch to upgrade the
       # cluster.
       OPSTRACE_CLI_VERSION_TO: ${OPSTRACE_PREBUILD_DIR}/build/bin/opstrace


### PR DESCRIPTION
We now run the upgrade build step in each PR. This is great!

The initial cluster version should now be the "last release", and not the "latest build from main" anymore.

The last release for Linux can be found at `https://go.opstrace.com/cli-latest-release-linux` -- and for downloading this, I changed the `fetch_cli_s3_artifact` function to be a `fetch_cli_artifact` function (not S3-specific anymore). So that `OPSTRACE_CLI_VERSION_FROM/TO` can be either a path in the local file system or a remote URL.

Please review @sreis -- thanks! :)