### PR TITLE
controller: add namespace to 'redis-slave' service

### DIFF
--- a/packages/controller/src/resources/redis/index.ts
+++ b/packages/controller/src/resources/redis/index.ts
@@ -96,6 +96,7 @@ export function RedisResources(
         kind: "Service",
         metadata: {
           name: "redis-slave",
+          namespace,
           labels: {
             app: "redis",
             role: "slave"


### PR DESCRIPTION
Happened to noticed it in the 'default' namespace.

Signed-off-by: Nick Parker <nick@opstrace.com>