### PR TITLE
buildinfo: better error msg for local dev

### DIFF
--- a/lib/utils/src/buildinfo.ts
+++ b/lib/utils/src/buildinfo.ts
@@ -28,7 +28,6 @@
 // import chain)
 
 import fs from "fs";
-import { log } from "./log";
 
 export interface BUILD_INFO_TYPE {
   BRANCH_NAME: string;
@@ -102,24 +101,10 @@ function readBuildInfo() {
 
   // None of the candidate file paths led to success. Fall back to env.
   if (!process.env.OPSTRACE_BUILDINFO_PATH) {
-    if (process.env.NODE_ENV === "development") {
-      log.info(
-        "using hardcoded 'local-dev' for BUILD_INFO, to override set environment variable OPSTRACE_BUILDINFO_PATH"
-      );
-      BUILD_INFO = {
-        BRANCH_NAME: "local-dev",
-        VERSION_STRING: "local-dev",
-        COMMIT: "local-dev",
-        BUILD_TIME_RFC3339: "1970-01-01 00:00:00+00:00",
-        BUILD_HOSTNAME: "localhost"
-      };
-      return;
-    } else {
-      throw Error(
-        `environment variable OPSTRACE_BUILDINFO_PATH not set ` +
-          `and none of [${JSON.stringify(CANDIDATE_PATHS)}] found/readable`
-      );
-    }
+    throw Error(
+      `environment variable OPSTRACE_BUILDINFO_PATH not set ` +
+        `and none of [${JSON.stringify(CANDIDATE_PATHS)}] found/readable`
+    );
   }
 
   // If this path is invalid / file cannot be opened, file contents are

--- a/lib/utils/src/buildinfo.ts
+++ b/lib/utils/src/buildinfo.ts
@@ -63,7 +63,7 @@ export let BUILD_INFO: BUILD_INFO_TYPE;
 // buildinfo.json file right into the root /.
 
 const CANDIDATE_PATHS = [
-  "/snapshot/opstrace/buildinfo.json",
+  "/snapshot/opstrace/buildinfo.json", // this is happening in locally-built pkt build
   "/snapshot/build/buildinfo.json", // this is happening CI-built pkg build
   "/buildinfo.json"
 ];
@@ -103,7 +103,10 @@ function readBuildInfo() {
   if (!process.env.OPSTRACE_BUILDINFO_PATH) {
     throw Error(
       `environment variable OPSTRACE_BUILDINFO_PATH not set ` +
-        `and none of [${JSON.stringify(CANDIDATE_PATHS)}] found/readable`
+        `and none of [${JSON.stringify(CANDIDATE_PATHS)}] found/readable. ` +
+        "For local development, run 'make set-build-info-constants' at the " +
+        "root of the repository to generate buildinfo.json, and point " +
+        "OPSTRACE_BUILDINFO_PATH to it."
     );
   }
 


### PR DESCRIPTION
After feedback from the team. Sorry for the hassle.

This reverts the patch which brought in a dependency on the NODE_ENV environment variable (this brought its own complications,  as reported by @MoSattler). 