### PR TITLE
bump: cortex-operator 3318f7bf9-ci

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -5,7 +5,7 @@
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
   "configApi": "opstrace/config-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
   "cortex": "cortexproject/cortex:master-fde0a62",
-  "cortexOperator": "opstrace/cortex-operator:v2021.07.23",
+  "cortexOperator": "opstrace/cortex-operator:3318f7bf9-ci",
   "cortexApiProxy": "opstrace/cortex-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
   "ddApi": "opstrace/ddapi:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
   "exporterAzure": "opstrace/azure_metrics_exporter:4f85a01",


### PR DESCRIPTION
The [cortex-operator](https://github.com/opstrace/cortex-operator/pull/14) by default enables Cortex api response compression. This setting got lost in the transition.

Testing if we see any impact to recent issues in #1107. 