### PR TITLE
[wip] ui: Show Opstrace Build Info in app

### DIFF
--- a/packages/app/src/client/app.tsx
+++ b/packages/app/src/client/app.tsx
@@ -194,6 +194,10 @@ const AuthProtectedApplication = () => {
               {
                 title: "Cortex",
                 path: `/cluster/configuration/cortex`
+              },
+              {
+                title: "Opstrace",
+                path: `/cluster/configuration/opstrace`
               }
             ]
           }
@@ -303,6 +307,12 @@ const AuthProtectedApplication = () => {
               exact
               key="cluster-config-cortex"
               path="/cluster/configuration/cortex"
+              component={ClusterConfig}
+            />
+            <Route
+              exact
+              key="cluster-config-opstrace"
+              path="/cluster/configuration/opstrace"
               component={ClusterConfig}
             />
             <Route

--- a/packages/app/src/client/views/cluster-config/index.tsx
+++ b/packages/app/src/client/views/cluster-config/index.tsx
@@ -21,6 +21,7 @@ import Typography from "client/components/Typography/Typography";
 import { Tabs } from "client/components/Tabs";
 
 import CortexConfig from "./cortex";
+import OpstraceConfig from "./opstrace";
 
 const ClusterConfig = () => {
   return (
@@ -34,6 +35,11 @@ const ClusterConfig = () => {
             path: `/cluster/configuration/cortex`,
             title: "Cortex",
             component: CortexConfig
+          },
+          {
+            path: `/cluster/configuration/opstrace`,
+            title: "Opstrace",
+            component: OpstraceConfig
           }
         ]}
       />

--- a/packages/app/src/client/views/cluster-config/opstrace.tsx
+++ b/packages/app/src/client/views/cluster-config/opstrace.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { format, parseISO } from "date-fns";
+
+import useOpstraceConfig from "state/opstrace-config/hooks/useOpstraceConfig";
+
+import Loading from "client/components/Loadable/Loading";
+
+import {
+  TableContainer,
+  Table,
+  TableRow,
+  TableCell,
+  TableBody
+} from "@material-ui/core";
+import { Card } from "client/components/Card";
+import { Typography } from "client/components/Typography";
+import { Box } from "client/components/Box";
+
+type FieldType = {
+  key: string;
+  label: string;
+  formatter?: Function;
+};
+
+const fields: FieldType[] = [
+  { key: "version", label: "Version" },
+  { key: "commit", label: "Commit" },
+  { key: "branch", label: "Branch" },
+  {
+    key: "buildTime",
+    label: "Build Time",
+    formatter: (val: string) => format(parseISO(val), "Pppp")
+  },
+  { key: "buildHostname", label: "Build Hostname" }
+];
+
+const OpstraceConfig = () => {
+  const { buildInfo } = useOpstraceConfig();
+
+  if (!buildInfo) return <Loading />;
+
+  return (
+    <>
+      <Box pt={3} pb={4} display="flex" justifyContent="space-between">
+        <Typography variant="h5">Opstrace Build Info</Typography>
+      </Box>
+
+      <Box pt={1}>
+        <TableContainer component={Card}>
+          <Table aria-label="tenants" data-test="tenant/list">
+            <TableBody>
+              {fields.map(field => (
+                <TableRow key={field.key}>
+                  <TableCell component="th" scope="row">
+                    {field.label}
+                  </TableCell>
+
+                  <TableCell>
+                    {field.formatter
+                      ? //@ts-ignore No index signature with a parameter of type 'string' was found on type 'OpstraceBuildInfo'.
+                        field.formatter(buildInfo[field.key])
+                      : //@ts-ignore No index signature with a parameter of type 'string' was found on type 'OpstraceBuildInfo'.
+                        buildInfo[field.key]}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </>
+  );
+};
+
+export default OpstraceConfig;

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -26,7 +26,7 @@ import authRequired from "server/middleware/auth";
 
 import graphqlClient from "state/clients/graphqlClient";
 
-import { auth0Config } from "./uicfg";
+import { AUTH0_CONFIG, BUILD_INFO } from "./uicfg";
 
 // Authorization middleware. When used, the
 // Access Token must exist and be verified against
@@ -136,8 +136,15 @@ function createAuthHandler(): express.Router {
     res.status(200).json({
       currentUserId: req.session?.userId,
       auth0Config: {
-        domain: auth0Config.auth0_domain,
-        clientId: auth0Config.auth0_client_id
+        domain: AUTH0_CONFIG.auth0_domain,
+        clientId: AUTH0_CONFIG.auth0_client_id
+      },
+      buildInfo: {
+        branch: BUILD_INFO.BRANCH_NAME,
+        version: BUILD_INFO.VERSION_STRING,
+        commit: BUILD_INFO.COMMIT,
+        buildTime: BUILD_INFO.BUILD_TIME_RFC3339,
+        buildHostname: BUILD_INFO.BUILD_HOSTNAME
       }
     });
   });

--- a/packages/app/src/state/cortex-config/hooks/useCortexConfig.ts
+++ b/packages/app/src/state/cortex-config/hooks/useCortexConfig.ts
@@ -42,7 +42,7 @@ export function useCortexConfigLoaded() {
  * on unmount.
  */
 export default function useCortexConfig() {
-  const currentUser = useSelector(getCortexConfig);
+  const cortexConfig = useSelector(getCortexConfig);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -53,5 +53,5 @@ export default function useCortexConfig() {
     };
   }, [dispatch]);
 
-  return currentUser;
+  return cortexConfig;
 }

--- a/packages/app/src/state/opstrace-config/actions.ts
+++ b/packages/app/src/state/opstrace-config/actions.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createAction } from "typesafe-actions";
+
+import { OpstraceBuildInfo } from "./types";
+
+export const updateOpstraceBuildInfo = createAction(
+  "UPDATE_OPSTRACE_BUILD_INFO"
+)<{
+  buildInfo: OpstraceBuildInfo;
+}>();

--- a/packages/app/src/state/opstrace-config/hooks/useOpstraceConfig.ts
+++ b/packages/app/src/state/opstrace-config/hooks/useOpstraceConfig.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useSelector, State } from "state/provider";
+
+export const getOpstraceConfig = (state: State) => state.opstrace;
+
+export default function useOpstraceConfig() {
+  const opstraceConfig = useSelector(getOpstraceConfig);
+
+  // todo: dispatch a call to load the config if it's not here.
+  // it's static so don't need a subscription
+  // const dispatch = useDispatch();
+
+  // useEffect(() => {
+  //   const subId = getSubscriptionID();
+  //   dispatch(subscribeToCortexConfig(subId));
+  //   return () => {
+  //     dispatch(unsubscribeFromCortexConfig(subId));
+  //   };
+  // }, [dispatch]);
+
+  return opstraceConfig;
+}

--- a/packages/app/src/state/opstrace-config/reducer.ts
+++ b/packages/app/src/state/opstrace-config/reducer.ts
@@ -14,33 +14,22 @@
  * limitations under the License.
  */
 
-import env from "server/env";
-import { NextFunction, Request, Response } from "express";
+import { createReducer, ActionType } from "typesafe-actions";
 
-import { BUILD_INFO } from "@opstrace/utils";
+import { OpstraceConfig } from "./types";
+import * as actions from "./actions";
 
-export const AUTH0_CONFIG = {
-  auth0_client_id: env.AUTH0_CLIENT_ID,
-  auth0_domain: env.AUTH0_DOMAIN
+type OpstraceConfigActions = ActionType<typeof actions>;
+
+const OpstraceConfigInitialState: OpstraceConfig = {
+  buildInfo: undefined
 };
 
-export { BUILD_INFO };
-
-export function pubUiCfgHandler(
-  req: Request,
-  res: Response,
-  next: NextFunction
-) {
-  res.status(200).json(AUTH0_CONFIG);
-  return;
-}
-
-// require authentication?
-export function buildInfoHandler(
-  req: Request,
-  res: Response,
-  next: NextFunction
-) {
-  res.status(200).json(BUILD_INFO);
-  return;
-}
+export const reducer = createReducer<OpstraceConfig, OpstraceConfigActions>(
+  OpstraceConfigInitialState
+).handleAction(
+  actions.updateOpstraceBuildInfo,
+  (state, action): OpstraceConfig => ({
+    buildInfo: action.payload.buildInfo
+  })
+);

--- a/packages/app/src/state/opstrace-config/types.ts
+++ b/packages/app/src/state/opstrace-config/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type OpstraceConfig = {
+  buildInfo?: OpstraceBuildInfo;
+};
+
+export type OpstraceBuildInfo = {
+  branch: string;
+  version: string;
+  commit: string;
+  buildTime: string;
+  buildHostname: string;
+};

--- a/packages/app/src/state/reducer.ts
+++ b/packages/app/src/state/reducer.ts
@@ -19,6 +19,7 @@ import { reducer as userReducer } from "./user/reducer";
 import { reducer as tenantReducer } from "./tenant/reducer";
 import { reducer as integrationReducer } from "./integration/reducer";
 import { reducer as cortexConfigReducer } from "./cortex-config/reducer";
+import { reducer as opstraceConfigReducer } from "./opstrace-config/reducer";
 import { reducer as formReducer } from "./form/reducer";
 
 export const mainReducers = {
@@ -26,7 +27,8 @@ export const mainReducers = {
   tenants: tenantReducer,
   integrations: integrationReducer,
   form: formReducer,
-  cortex: cortexConfigReducer
+  cortex: cortexConfigReducer,
+  opstrace: opstraceConfigReducer
 };
 
 export const mainReducer = combineReducers(mainReducers);


### PR DESCRIPTION
important: depends on https://github.com/opstrace/opstrace/pull/1115 being merged first

I've added a second tab to the Cluster Admin -> Configuration section called Opstrace that shows the static Build Info. I envision this section growing over time and some future addions being user adjusted.

![image](https://user-images.githubusercontent.com/17045/127077625-f5e1bd5b-7cac-4500-9d34-ed1d078679e7.png)
