### PR TITLE
ui: when uninstalling an i9n always deletes the grafana folder, don't need to do it in callback

### DIFF
--- a/packages/app/src/client/integrations/k8sLogs/Show/UninstallInstructions.tsx
+++ b/packages/app/src/client/integrations/k8sLogs/Show/UninstallInstructions.tsx
@@ -82,15 +82,6 @@ export const UninstallInstructions = ({
     saveAs(configBlob, configFilename);
   };
 
-  const uninstallIntegrationHandler = async () => {
-    try {
-      // Dashboard folder might not exist
-      await grafana.deleteFolder({ integration, tenant });
-    } catch (err) {
-      console.log(err);
-    }
-  };
-
   return (
     <Box width="100%" height="100%" p={1}>
       <Card>
@@ -159,7 +150,6 @@ export const UninstallInstructions = ({
                     integration={integration}
                     tenant={tenant}
                     disabled={false}
-                    uninstallCallback={uninstallIntegrationHandler}
                   />
                 </Box>
               </TimelineContent>

--- a/packages/app/src/client/integrations/k8sLogs/Show/UninstallInstructions.tsx
+++ b/packages/app/src/client/integrations/k8sLogs/Show/UninstallInstructions.tsx
@@ -21,8 +21,6 @@ import { Integration } from "state/integration/types";
 
 import * as commands from "./templates/commands";
 
-import * as grafana from "client/utils/grafana";
-
 import { CopyToClipboardIcon } from "client/components/CopyToClipboard";
 
 import { ViewConfigDialogBtn } from "client/integrations/common/ViewConfigDialogBtn";

--- a/packages/app/src/client/integrations/k8sMetrics/Show/UninstallInstructions.tsx
+++ b/packages/app/src/client/integrations/k8sMetrics/Show/UninstallInstructions.tsx
@@ -19,8 +19,6 @@ import { saveAs } from "file-saver";
 
 import * as commands from "./templates/commands";
 
-import * as grafana from "client/utils/grafana";
-
 import { CopyToClipboardIcon } from "client/components/CopyToClipboard";
 import { ViewConfigDialogBtn } from "client/integrations/common/ViewConfigDialogBtn";
 import { UninstallBtn } from "client/integrations/common/UninstallIntegrationBtn";

--- a/packages/app/src/client/integrations/k8sMetrics/Show/UninstallInstructions.tsx
+++ b/packages/app/src/client/integrations/k8sMetrics/Show/UninstallInstructions.tsx
@@ -79,15 +79,6 @@ export const UninstallInstructions = ({
     saveAs(configBlob, configFilename);
   };
 
-  const uninstallIntegrationHandler = async () => {
-    try {
-      // Dashboard folder might not exist
-      await grafana.deleteFolder({ integration, tenant });
-    } catch (err) {
-      console.log(err);
-    }
-  };
-
   return (
     <Box width="100%" height="100%" p={1}>
       <Card>
@@ -156,7 +147,6 @@ export const UninstallInstructions = ({
                     integration={integration}
                     tenant={tenant}
                     disabled={false}
-                    uninstallCallback={uninstallIntegrationHandler}
                   />
                 </Box>
               </TimelineContent>


### PR DESCRIPTION
possibly related: https://github.com/opstrace/opstrace/issues/1098