### PR TITLE
ui: Add radio option for log format to K8s log integration

### DIFF
--- a/packages/app/src/client/components/Form/SelectInput.tsx
+++ b/packages/app/src/client/components/Form/SelectInput.tsx
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { Controller } from "react-hook-form";
+import { HelpCircle } from "react-feather";
+
+import {
+  FormLabel,
+  FormHelperText,
+  Radio,
+  RadioProps,
+  RadioGroup,
+  RadioGroupProps
+} from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+import { Typography } from "client/components/Typography";
+import { CondRender } from "client/utils/rendering";
+import { Box } from "client/components/Box";
+
+type SelectInputProps = {
+  name: `${string}` | `${string}.${string}` | `${string}.${number}`;
+  label?: string;
+  helperText?: string | React.ReactNode | (() => React.ReactNode);
+  inputProps?: RadioGroupProps;
+  optionsProps?: RadioProps[];
+  control: any;
+  labelClass?: string;
+  controlClass?: string;
+};
+
+const useStyles = makeStyles(theme => ({
+  helperText: {
+    display: "flex",
+    alignItems: "center",
+    flexWrap: "wrap"
+  },
+  helperIcon: {
+    marginRight: 5
+  }
+}));
+
+export const SelectInput = ({
+  name,
+  label,
+  inputProps = {},
+  optionsProps = [],
+  helperText,
+  control,
+  labelClass,
+  controlClass
+}: SelectInputProps) => {
+  const classes = useStyles();
+
+  return (
+    <Controller
+      render={({ field }) => (
+        <Box>
+          <CondRender unless={label === undefined}>
+            <div className={labelClass}>
+              <FormLabel>
+                <Typography variant="h6" color="textSecondary">
+                  {label}
+                </Typography>
+              </FormLabel>
+            </div>
+          </CondRender>
+          <div className={controlClass}>
+            <RadioGroup {...field} {...inputProps}>
+            {optionsProps.map(optionProps => (
+              <Radio {...optionProps} />
+            ))}
+            </RadioGroup>
+            <CondRender
+              unless={helperText === undefined}
+              render={() => (
+                <FormHelperText>
+                  <Typography variant="caption" className={classes.helperText}>
+                    <HelpCircle
+                      width={12}
+                      height={12}
+                      className={classes.helperIcon}
+                    />
+                    <span>{helperText}</span>
+                  </Typography>
+                </FormHelperText>
+              )}
+            />
+          </div>
+        </Box>
+      )}
+      control={control}
+      name={name}
+    />
+  );
+};

--- a/packages/app/src/client/components/Form/SelectInput.tsx
+++ b/packages/app/src/client/components/Form/SelectInput.tsx
@@ -19,12 +19,11 @@ import { Controller } from "react-hook-form";
 import { HelpCircle } from "react-feather";
 
 import {
+  FormControlLabel,
   FormLabel,
   FormHelperText,
   Radio,
-  RadioProps,
   RadioGroup,
-  RadioGroupProps
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 
@@ -32,12 +31,16 @@ import { Typography } from "client/components/Typography";
 import { CondRender } from "client/utils/rendering";
 import { Box } from "client/components/Box";
 
+type SelectInputOptionProps = {
+  label: string;
+  value: string;
+};
+
 type SelectInputProps = {
   name: `${string}` | `${string}.${string}` | `${string}.${number}`;
   label?: string;
   helperText?: string | React.ReactNode | (() => React.ReactNode);
-  inputProps?: RadioGroupProps;
-  optionsProps?: RadioProps[];
+  optionsProps?: SelectInputOptionProps[];
   control: any;
   labelClass?: string;
   controlClass?: string;
@@ -57,7 +60,6 @@ const useStyles = makeStyles(theme => ({
 export const SelectInput = ({
   name,
   label,
-  inputProps = {},
   optionsProps = [],
   helperText,
   control,
@@ -80,9 +82,9 @@ export const SelectInput = ({
             </div>
           </CondRender>
           <div className={controlClass}>
-            <RadioGroup {...field} {...inputProps}>
+          <RadioGroup {...field}>
             {optionsProps.map(optionProps => (
-              <Radio {...optionProps} />
+              <FormControlLabel control={<Radio />} {...optionProps} />
             ))}
             </RadioGroup>
             <CondRender

--- a/packages/app/src/client/components/Form/SelectInput.tsx
+++ b/packages/app/src/client/components/Form/SelectInput.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from "react";
-import { Controller } from "react-hook-form";
+import { Controller, Control, FieldPath } from "react-hook-form";
 import { HelpCircle } from "react-feather";
 
 import {
@@ -32,16 +32,16 @@ import { CondRender } from "client/utils/rendering";
 import { Box } from "client/components/Box";
 
 type SelectInputOptionProps = {
-  label: string;
+  label: React.ReactNode;
   value: string;
 };
 
-type SelectInputProps = {
-  name: `${string}` | `${string}.${string}` | `${string}.${number}`;
-  label?: string;
+type SelectInputProps<TFieldValues> = {
+  name: FieldPath<TFieldValues>;
+  label?: React.ReactNode;
   helperText?: string | React.ReactNode | (() => React.ReactNode);
   optionsProps?: SelectInputOptionProps[];
-  control: any;
+  control: Control<TFieldValues>;
   labelClass?: string;
   controlClass?: string;
 };
@@ -57,7 +57,7 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-export const SelectInput = ({
+export const SelectInput = <TFieldValues,>({
   name,
   label,
   optionsProps = [],
@@ -65,7 +65,7 @@ export const SelectInput = ({
   control,
   labelClass,
   controlClass
-}: SelectInputProps) => {
+}: SelectInputProps<TFieldValues>) => {
   const classes = useStyles();
 
   return (

--- a/packages/app/src/client/integrations/k8sLogs/Form.tsx
+++ b/packages/app/src/client/integrations/k8sLogs/Form.tsx
@@ -106,11 +106,13 @@ export const K8sLogsForm = ({ handleCreate }: Props) => {
                     {label:"dockerd", value:"docker"}
                   ]}
                   label="Container Runtime"
-                  helperText="The log format produced by the cluster depends on the runtime"
+                  helperText="The cluster container runtime affects the log format."
                 />
-                <Typography color="textSecondary" variant="subtitle1">Check the runtime using this command:</Typography>
-                <Typography color="textSecondary" variant="subtitle1">{"kubectl get nodes -o jsonpath='{.items[].status.nodeInfo.containerRuntimeVersion}'"}</Typography>
-      <Typography color="textSecondary" variant="subtitle1">The output should start with e.g. 'containerd://' (pick 'CRI/containerd') or 'docker://' (pick 'dockerd').</Typography>
+                <Typography color="textSecondary" variant="caption">
+                  To find this, check for either <code>containerd://</code> or <code>docker://</code> from this command:<br />
+                  &nbsp; &nbsp;<code>$ kubectl get nodes \<br />
+                  &nbsp; &nbsp; -o jsonpath={"'{.items[].status.nodeInfo.containerRuntimeVersion}'"}</code>
+                </Typography>
               </Box>
               <Box mb={3}>
                 <ControlledInput

--- a/packages/app/src/client/integrations/k8sLogs/Form.tsx
+++ b/packages/app/src/client/integrations/k8sLogs/Form.tsx
@@ -27,6 +27,7 @@ import { SelectInput } from "client/components/Form/SelectInput";
 import { Card, CardContent, CardHeader } from "client/components/Card";
 import { Box } from "client/components/Box";
 import { Button } from "client/components/Button";
+import { Typography } from "client/components/Typography";
 
 type Values = {
   name: string;
@@ -43,7 +44,7 @@ const Schema = yup.object().shape({
 const defaultValues: Values = {
   name: "",
   deployNamespace: "opstrace",
-  format: ""
+  format: "cri"
 };
 
 type Props = {
@@ -100,11 +101,16 @@ export const K8sLogsForm = ({ handleCreate }: Props) => {
                 <SelectInput
                   name="format"
                   control={control}
-                  inputProps={{ defaultValue: "foo" }}
-                  optionsProps={[{id:"foo", name:"Foo", checked:true}, {id:"bar", name:"Bar"}]}
-                  label="Cluster Runtime"
-                  helperText="Runtime used by the cluster, can check by running <code>kubectl get nodes -o jsonpath='{.items[].status.nodeInfo.containerRuntimeVersion}'</code>"
+                  optionsProps={[
+                    {label:"CRI/containerd", value:"cri"},
+                    {label:"dockerd", value:"docker"}
+                  ]}
+                  label="Container Runtime"
+                  helperText="The log format produced by the cluster depends on the runtime"
                 />
+                <Typography color="textSecondary" variant="subtitle1">Check the runtime using this command:</Typography>
+                <Typography color="textSecondary" variant="subtitle1">{"kubectl get nodes -o jsonpath='{.items[].status.nodeInfo.containerRuntimeVersion}'"}</Typography>
+      <Typography color="textSecondary" variant="subtitle1">The output should start with e.g. 'containerd://' (pick 'CRI/containerd') or 'docker://' (pick 'dockerd').</Typography>
               </Box>
               <Box mb={3}>
                 <ControlledInput

--- a/packages/app/src/client/integrations/k8sLogs/Form.tsx
+++ b/packages/app/src/client/integrations/k8sLogs/Form.tsx
@@ -22,6 +22,7 @@ import * as yup from "yup";
 import { k8sLogsIntegration as integrationDef } from "./index";
 
 import { ControlledInput } from "client/components/Form/ControlledInput";
+import { SelectInput } from "client/components/Form/SelectInput";
 
 import { Card, CardContent, CardHeader } from "client/components/Card";
 import { Box } from "client/components/Box";
@@ -30,16 +31,19 @@ import { Button } from "client/components/Button";
 type Values = {
   name: string;
   deployNamespace: string;
+  format: string;
 };
 
 const Schema = yup.object().shape({
   name: yup.string().required(),
-  deployNamespace: yup.string().required()
+  deployNamespace: yup.string().required(),
+  format: yup.string().required()
 });
 
 const defaultValues: Values = {
   name: "",
-  deployNamespace: "opstrace"
+  deployNamespace: "opstrace",
+  format: ""
 };
 
 type Props = {
@@ -61,7 +65,7 @@ export const K8sLogsForm = ({ handleCreate }: Props) => {
   const onSubmit = (data: Values) => {
     handleCreate({
       name: data.name,
-      data: { deployNamespace: data.deployNamespace }
+      data: { deployNamespace: data.deployNamespace, format: data.format }
     });
   };
 
@@ -90,6 +94,16 @@ export const K8sLogsForm = ({ handleCreate }: Props) => {
                   inputProps={{ fullWidth: true, autoFocus: true }}
                   label="Integration Name"
                   helperText="An identifier for this integration"
+                />
+              </Box>
+              <Box mb={3}>
+                <SelectInput
+                  name="format"
+                  control={control}
+                  inputProps={{ defaultValue: "foo" }}
+                  optionsProps={[{id:"foo", name:"Foo", checked:true}, {id:"bar", name:"Bar"}]}
+                  label="Cluster Runtime"
+                  helperText="Runtime used by the cluster, can check by running <code>kubectl get nodes -o jsonpath='{.items[].status.nodeInfo.containerRuntimeVersion}'</code>"
                 />
               </Box>
               <Box mb={3}>

--- a/packages/app/src/client/integrations/k8sLogs/Form.tsx
+++ b/packages/app/src/client/integrations/k8sLogs/Form.tsx
@@ -29,17 +29,13 @@ import { Box } from "client/components/Box";
 import { Button } from "client/components/Button";
 import { Typography } from "client/components/Typography";
 
-type Values = {
-  name: string;
-  deployNamespace: string;
-  format: string;
-};
-
-const Schema = yup.object().shape({
+const Schema = yup.object({
   name: yup.string().required(),
   deployNamespace: yup.string().required(),
   format: yup.string().required()
 });
+
+type Values = yup.Asserts<typeof Schema>;
 
 const defaultValues: Values = {
   name: "",

--- a/packages/app/src/client/integrations/k8sLogs/Show/index.tsx
+++ b/packages/app/src/client/integrations/k8sLogs/Show/index.tsx
@@ -64,13 +64,13 @@ export const K8sLogsShow = () => {
 
   const config = useMemo(() => {
     if (integration?.id) {
+      const data = integration?.data;
       return promtailYaml({
         clusterHost: window.location.host,
         tenantName: tenant.name,
         integrationId: integration?.id,
-        deployNamespace: integration?.data.deployNamespace,
-        // TODO: allow user to select dockerd or cri/containerd (different log formats)
-        logFormat: PromtailLogFormat.CRI
+        deployNamespace: data.deployNamespace,
+        logFormat: data.format === "docker" ? PromtailLogFormat.Docker : PromtailLogFormat.CRI,
       });
     }
     return "";

--- a/packages/app/src/client/integrations/k8sLogs/Show/index.tsx
+++ b/packages/app/src/client/integrations/k8sLogs/Show/index.tsx
@@ -65,16 +65,24 @@ export const K8sLogsShow = () => {
   const config = useMemo(() => {
     if (integration?.id) {
       const data = integration?.data;
+      let logFormat;
+      if (data.format === "cri") {
+        logFormat = PromtailLogFormat.CRI;
+      } else if (data.format === "docker") {
+        logFormat = PromtailLogFormat.Docker;
+      } else {
+        throw new Error(`Unknown log format: ${data.format}`);
+      }
       return promtailYaml({
         clusterHost: window.location.host,
         tenantName: tenant.name,
         integrationId: integration?.id,
         deployNamespace: data.deployNamespace,
-        logFormat: data.format === "docker" ? PromtailLogFormat.Docker : PromtailLogFormat.CRI,
+        logFormat,
       });
     }
     return "";
-  }, [tenant.name, integration?.id, integration?.data.deployNamespace]);
+  }, [tenant.name, integration?.id, integration?.data]);
 
   if (!integration) {
     // TODO: add loading or NotFound here

--- a/packages/app/src/client/integrations/k8sLogs/Show/templates/config.ts
+++ b/packages/app/src/client/integrations/k8sLogs/Show/templates/config.ts
@@ -92,7 +92,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
 
-      # Whether the data is cri (tsv) or dockerd (json) format
+      # Specify whether the data is cri (tsv) or dockerd (json) format
       pipeline_stages:
       - ${logFormat}:
 


### PR DESCRIPTION
Adds an option for specifying whether the cluster is running CRI/containerd or dockerd. This is required by the underlying log scraper - depending on the runtime, the paths for the data are different and they have totally different formats. Previously, the code was hardcoded to CRI/containerd even though the underlying yaml template had an option for dockerd. There was just a TODO for exposing this as an option.

The result looks like this. Could probably be cleaned up a bit but I figured that this should be okay for now (baby's first react UI):
![k8slogs-radio-help](https://user-images.githubusercontent.com/35933/127616952-1d9d7b4c-dfa4-4758-ae32-805a62f92e6a.png)
