### PR TITLE
go: proxy: replace X-Scope-OrgID header

### DIFF
--- a/go/pkg/middleware/proxy.go
+++ b/go/pkg/middleware/proxy.go
@@ -151,7 +151,7 @@ func (trp *TenantReverseProxy) HandleWithProxy(w http.ResponseWriter, r *http.Re
 	}
 
 	// Add the tenant in the request header and then forward the request to the backend.
-	r.Header.Add(trp.headerName, tenantName)
+	r.Header.Set(trp.headerName, tenantName)
 	trp.Revproxy.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
https://pkg.go.dev/net/http#Header.Add
https://pkg.go.dev/net/http#Header.Set

> Set sets the header entries associated with key to the single element value. It replaces any existing values associated with key.

We want to take full control in the proxy, and set the header based on the value provided by the authenticator. Any value set by the original HTTP client should be obliterated. Therefore, use `Set()`.

Exploiting this for cross-tenant data writing would still require valid authentication proof for a tenant.
