### PR TITLE
fix(RingTable): error handling

### DIFF
--- a/packages/app/src/client/views/ring-health/RingHealth.test.tsx
+++ b/packages/app/src/client/views/ring-health/RingHealth.test.tsx
@@ -183,6 +183,34 @@ test("handles request errors", async () => {
 
   const errorMessage = "Something bad happened"
 
+  nock("http://localhost").get(tab.endpoint).replyWithError({
+    message: errorMessage,
+    code: 'SOMETHING_VERY_BAD_HAPPENED',
+  })
+
+  const container = renderComponent(
+    <RingHealth title="some title" tabs={[tab]} />
+  );
+
+  jest.runOnlyPendingTimers();
+
+  expect(
+    await container.findByText("Could not load table")
+  ).toBeInTheDocument();
+  expect(
+    await container.findByText(errorMessage)
+  ).toBeInTheDocument();
+});
+
+test("handles response errors", async () => {
+  const tab = {
+    title: "Tab",
+    path: `/tab`,
+    endpoint: "/tab-endpoint"
+  };
+
+  const errorMessage = "Something bad happened"
+
   nock("http://localhost").get(tab.endpoint).reply(500, errorMessage);
 
   const container = renderComponent(

--- a/packages/app/src/client/views/ring-health/RingTable.tsx
+++ b/packages/app/src/client/views/ring-health/RingTable.tsx
@@ -140,7 +140,7 @@ const RingTable = ({ ringEndpoint, baseUrl }: Props) => {
       const response = await axios.get<Payload>(ringEndpoint);
       setShards(response.data.shards);
     } catch (e) {
-      notifyError("Could not load table", e.response.data ?? e.message);
+      notifyError("Could not load table", e.response?.data ?? e.message);
       setKeepPolling(false);
     }
   };


### PR DESCRIPTION
Fixing this [error reported by sentry](https://sentry.io/organizations/opstrace/issues/2535043152/?environment=production&project=5529515&query=is%3Aunresolved):

<img width="1227" alt="Screenshot 2021-08-02 at 09 41 34" src="https://user-images.githubusercontent.com/64152453/127822690-eb845663-b2ce-49c7-8274-964b3b255db6.png">

The underlying problem was that while we handle errors in the response, we did not handle errors on the request level (e.g. no network connection). 
I believe this might be an issue we could potentially run into many places where we do requests.

# Have you...

* [x] Added an explanation of what your changes do?
* [x] Written new tests for your changes?
* [x] Thought about which docs need updating?
