### PR TITLE
chore: disable nodejs profiler

### DIFF
--- a/packages/controller-config/src/resources/controller.ts
+++ b/packages/controller-config/src/resources/controller.ts
@@ -107,7 +107,7 @@ export function ControllerResources({
                   name: "opstrace-controller",
                   image: `${controllerImage}`,
                   imagePullPolicy: "IfNotPresent",
-                  command: ["node", "--prof", "./cmd.js"],
+                  command: ["node", "./cmd.js"],
                   args: controllerCmdlineArgs,
                   resources: {
                     limits: {


### PR DESCRIPTION
This is creating a log file with several gigabytes which eventually triggers a pod eviction when the node where the opstrace controller pod is running reaches disk pressure.

Close #1152.
