### PR TITLE
Commit message prefix consolidation / simplification

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -35,7 +35,6 @@ module.exports = {
         "docs", // any documentation change
         "feat", // user-facing feature addition. Makes most sense in a semver world which we are not yet in.
         "fix", // fix for user-facing issue in the opstrace system (fix user-facing bug). Makes most sense in a semver world which we are not yet in.
-        "installer", // change in installer (cluster creation)
         "looker", // change to looker project
         "loki", // change to loki (config change for example)
         "makefile", // change in main Makefile
@@ -44,7 +43,6 @@ module.exports = {
         "systemlogs", // change in opstrace system log arch/implementation
         "test-remote", // change in test-remote project
         "test-upgrade", // change in test-remote project
-        "uninstaller", // change in uninstaller (cluster destruction/teardown)
         "website", // change in the website code or content
         "wip" // work in progress, later to be edited/squashed ("i don't want to think about choosing the right prefix now!")
       ]

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,7 +22,7 @@ module.exports = {
       2,
       "always",
       [
-        "ui", // any changes relating to the app (UI) package
+        "ui", // use `ui: ` for changes to client, and `ui: app:` for changes to server
         "bump", // third-party lib/component bump (can be big, including Cortex, ...)
         "chore", // small routine tasks, very localized refactors
         "ci", // change to automated CI pipeline
@@ -40,7 +40,6 @@ module.exports = {
         "systemlogs", // change in opstrace system log arch/implementation
         "test-browser", // any change for the test-browser test suite
         "test-remote", // change in test-remote project
-        "website", // change in the website code or content
         "wip" // work in progress, later to be edited/squashed ("i don't want to think about choosing the right prefix now!")
       ]
     ]

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -27,7 +27,6 @@ module.exports = {
         "chore", // small routine tasks, very localized refactors
         "ci", // change to automated CI pipeline
         "cli", // change to the cluster management CLI (create, destroy, ..., )
-        "config", // change to config api project
         "cortex", // change to cortex (config change for example)
         "go", // change to golang modules/projects (unit test setup, makefile, etc)
         "ddapi", // change to dd api project

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,7 +22,6 @@ module.exports = {
       2,
       "always",
       [
-        "stdlib", // any changes to stdlib
         "ui", // any changes relating to the app (UI) package
         "bump", // third-party lib/component bump (can be big, including Cortex, ...)
         "chore", // small routine tasks, very localized refactors

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -40,7 +40,6 @@ module.exports = {
         "systemlogs", // change in opstrace system log arch/implementation
         "test-browser", // any change for the test-browser test suite
         "test-remote", // change in test-remote project
-        "test-upgrade", // change in test-remote project
         "website", // change in the website code or content
         "wip" // work in progress, later to be edited/squashed ("i don't want to think about choosing the right prefix now!")
       ]

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -38,6 +38,7 @@ module.exports = {
         "makefile", // change in main Makefile
         "revert", // specifically for a git revert commit
         "systemlogs", // change in opstrace system log arch/implementation
+        "test-browser", // any change for the test-browser test suite
         "test-remote", // change in test-remote project
         "test-upgrade", // change in test-remote project
         "website", // change in the website code or content

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -33,8 +33,6 @@ module.exports = {
         "controller", // change in the k8s controller CLI
         "dashboards", // change to Grafana dashboards
         "docs", // any documentation change
-        "feat", // user-facing feature addition. Makes most sense in a semver world which we are not yet in.
-        "fix", // fix for user-facing issue in the opstrace system (fix user-facing bug). Makes most sense in a semver world which we are not yet in.
         "looker", // change to looker project
         "loki", // change to loki (config change for example)
         "makefile", // change in main Makefile

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -36,7 +36,6 @@ module.exports = {
         "looker", // change to looker project
         "loki", // change to loki (config change for example)
         "makefile", // change in main Makefile
-        "perf", // user-facing performance tweak. Makes most sense in a semver world which we are not yet in.
         "revert", // specifically for a git revert commit
         "systemlogs", // change in opstrace system log arch/implementation
         "test-remote", // change in test-remote project


### PR DESCRIPTION
Towards writing release notes, commit message prefixes should become more reliable.

This
* adds the `test-browser` prefix because it has become a real thing; CC @terrcin please use that :-).
* removes prefixes we have not used at all or not really used.
* removes prefixes we have mainly used 'wrongly' (such as 'fix').
* tries to sharpen the meaning of various component-based prefixes.

As always this state is evolving... I just wanted to have a little bit of an improvement now that we're in the release notes game.