### PR TITLE
ui(NotificationService): simpler interface

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,11 +6,23 @@
       "routes": [
         {
           "title": "Opstrace Introduction",
-          "path": "/docs/README.md"
+          "path": "/docs/README.md",
+          "readingTime": {
+            "text": "2 min",
+            "minutes": 1.945,
+            "time": 116700,
+            "words": 389
+          }
         },
         {
           "title": "Opstrace Quick Start",
-          "path": "/docs/quickstart.md"
+          "path": "/docs/quickstart.md",
+          "readingTime": {
+            "text": "8 min",
+            "minutes": 7.085,
+            "time": 425100,
+            "words": 1417
+          }
         },
         {
           "heading": true,
@@ -18,23 +30,53 @@
           "routes": [
             {
               "title": "Configuring Alertmanager",
-              "path": "/docs/guides/user/configuring-alerts.md"
+              "path": "/docs/guides/user/configuring-alerts.md",
+              "readingTime": {
+                "text": "6 min",
+                "minutes": 5.82,
+                "time": 349200,
+                "words": 1164
+              }
             },
             {
               "title": "Sending Metrics with Prometheus",
-              "path": "/docs/guides/user/sending-metrics-with-prometheus.md"
+              "path": "/docs/guides/user/sending-metrics-with-prometheus.md",
+              "readingTime": {
+                "text": "2 min",
+                "minutes": 1.615,
+                "time": 96900,
+                "words": 323
+              }
             },
             {
               "title": "Sending Logs with FluentD",
-              "path": "/docs/guides/user/sending-logs-with-fluentd.md"
+              "path": "/docs/guides/user/sending-logs-with-fluentd.md",
+              "readingTime": {
+                "text": "3 min",
+                "minutes": 2.37,
+                "time": 142200,
+                "words": 474
+              }
             },
             {
               "title": "Sending Logs with Promtail",
-              "path": "/docs/guides/user/sending-logs-with-promtail.md"
+              "path": "/docs/guides/user/sending-logs-with-promtail.md",
+              "readingTime": {
+                "text": "2 min",
+                "minutes": 1.385,
+                "time": 83100,
+                "words": 277
+              }
             },
             {
               "title": "Instrumenting a K8s Cluster",
-              "path": "/docs/guides/user/instrumenting-a-k8s-cluster.md"
+              "path": "/docs/guides/user/instrumenting-a-k8s-cluster.md",
+              "readingTime": {
+                "text": "6 min",
+                "minutes": 5.76,
+                "time": 345600,
+                "words": 1152
+              }
             }
           ]
         },
@@ -44,23 +86,53 @@
           "routes": [
             {
               "title": "Managing Tenants",
-              "path": "/docs/guides/administrator/managing-tenants.md"
+              "path": "/docs/guides/administrator/managing-tenants.md",
+              "readingTime": {
+                "text": "5 min",
+                "minutes": 4.745,
+                "time": 284700,
+                "words": 949
+              }
             },
             {
               "title": "Managing Users",
-              "path": "/docs/guides/administrator/managing-users.md"
+              "path": "/docs/guides/administrator/managing-users.md",
+              "readingTime": {
+                "text": "1 min",
+                "minutes": 0.515,
+                "time": 30900,
+                "words": 103
+              }
             },
             {
               "title": "Hands-on Troubleshooting",
-              "path": "/docs/guides/administrator/troubleshooting.md"
+              "path": "/docs/guides/administrator/troubleshooting.md",
+              "readingTime": {
+                "text": "2 min",
+                "minutes": 1.295,
+                "time": 77700,
+                "words": 259
+              }
             },
             {
               "title": "Upgrading",
-              "path": "/docs/guides/administrator/upgrading.md"
+              "path": "/docs/guides/administrator/upgrading.md",
+              "readingTime": {
+                "text": "2 min",
+                "minutes": 1.845,
+                "time": 110700,
+                "words": 369
+              }
             },
             {
               "title": "GCP project setup",
-              "path": "/docs/guides/administrator/gcp-setup.md"
+              "path": "/docs/guides/administrator/gcp-setup.md",
+              "readingTime": {
+                "text": "4 min",
+                "minutes": 3.855,
+                "time": 231300,
+                "words": 771
+              }
             }
           ]
         },
@@ -70,19 +142,43 @@
           "routes": [
             {
               "title": "Development Environment",
-              "path": "/docs/guides/contributor/setting-up-your-dev-env.md"
+              "path": "/docs/guides/contributor/setting-up-your-dev-env.md",
+              "readingTime": {
+                "text": "2 min",
+                "minutes": 1.69,
+                "time": 101400,
+                "words": 338
+              }
             },
             {
               "title": "Running and Writing Tests",
-              "path": "/docs/guides/contributor/test-remote.md"
+              "path": "/docs/guides/contributor/test-remote.md",
+              "readingTime": {
+                "text": "3 min",
+                "minutes": 2.745,
+                "time": 164700,
+                "words": 549
+              }
             },
             {
               "title": "Developer Workflows",
-              "path": "/docs/guides/contributor/workflows.md"
+              "path": "/docs/guides/contributor/workflows.md",
+              "readingTime": {
+                "text": "5 min",
+                "minutes": 4.16,
+                "time": 249600,
+                "words": 832
+              }
             },
             {
               "title": "Writing Docs",
-              "path": "/docs/guides/contributor/writing-docs.md"
+              "path": "/docs/guides/contributor/writing-docs.md",
+              "readingTime": {
+                "text": "5 min",
+                "minutes": 4.245,
+                "time": 254700,
+                "words": 849
+              }
             }
           ]
         }
@@ -94,31 +190,73 @@
       "routes": [
         {
           "title": "Frequently Asked Questions",
-          "path": "/docs/references/faq.md"
+          "path": "/docs/references/faq.md",
+          "readingTime": {
+            "text": "2 min",
+            "minutes": 1.68,
+            "time": 100800,
+            "words": 336
+          }
         },
         {
           "title": "Roadmap",
-          "path": "/docs/references/roadmap.md"
+          "path": "/docs/references/roadmap.md",
+          "readingTime": {
+            "text": "2 min",
+            "minutes": 1.35,
+            "time": 81000,
+            "words": 270
+          }
         },
         {
           "title": "Configuration",
-          "path": "/docs/references/configuration.md"
+          "path": "/docs/references/configuration.md",
+          "readingTime": {
+            "text": "6 min",
+            "minutes": 5.465,
+            "time": 327900,
+            "words": 1093
+          }
         },
         {
           "title": "Command Line Interface (CLI)",
-          "path": "/docs/references/cli.md"
+          "path": "/docs/references/cli.md",
+          "readingTime": {
+            "text": "8 min",
+            "minutes": 7.35,
+            "time": 441000,
+            "words": 1470
+          }
         },
         {
           "title": "Key Concepts",
-          "path": "/docs/references/concepts.md"
+          "path": "/docs/references/concepts.md",
+          "readingTime": {
+            "text": "3 min",
+            "minutes": 2.99,
+            "time": 179400,
+            "words": 598
+          }
         },
         {
           "title": "AWS configuration",
-          "path": "/docs/references/aws.md"
+          "path": "/docs/references/aws.md",
+          "readingTime": {
+            "text": "2 min",
+            "minutes": 1.015,
+            "time": 60900,
+            "words": 203
+          }
         },
         {
           "title": "GCP configuration",
-          "path": "/docs/references/gcp.md"
+          "path": "/docs/references/gcp.md",
+          "readingTime": {
+            "text": "1 min",
+            "minutes": 0.96,
+            "time": 57600,
+            "words": 192
+          }
         }
       ]
     }

--- a/packages/app/src/client/integrations/common/UninstallIntegrationBtn.tsx
+++ b/packages/app/src/client/integrations/common/UninstallIntegrationBtn.tsx
@@ -30,8 +30,7 @@ import graphqlClient from "state/clients/graphqlClient";
 import { deleteFolder } from "client/utils/grafana";
 
 import { Button } from "client/components/Button";
-import { useNotificationService } from "client/services/Notification";
-import { random } from "lodash";
+import { useSimpleNotification } from "client/services/Notification";
 
 export const UninstallBtn = ({
   integration,
@@ -46,10 +45,7 @@ export const UninstallBtn = ({
 }) => {
   const dispatch = useDispatch();
   const history = useHistory();
-  const {
-    registerNotification,
-    unregisterNotification
-  } = useNotificationService();
+  const { registerNotification } = useSimpleNotification();
 
   const handleUninstall = async () => {
     if (uninstallCallback !== undefined) await uninstallCallback();
@@ -62,38 +58,20 @@ export const UninstallBtn = ({
       try {
         await deleteFolder({ integration, tenant });
       } catch (error) {
-        const messageId = random(0, 9999).toString();
-        const newNotification = {
-          id: messageId,
+        registerNotification({
           state: "error" as const,
           title: "Could not delete grafana folder",
-          information: error.response.data.message ?? error.message,
-          handleClose: () =>
-            unregisterNotification({
-              id: messageId,
-              title: "",
-              information: ""
-            })
-        };
-        registerNotification(newNotification);
+          information: error.response.data.message ?? error.message
+        });
       }
       dispatch(deleteIntegration({ tenantId: tenant.id, id: integration.id }));
       history.push(installedIntegrationsPath({ tenant }));
     } catch (error) {
-      const messageId = random(0, 9999).toString();
-      const newNotification = {
-        id: messageId,
+      registerNotification({
         state: "error" as const,
         title: "Could not uninstall integration",
-        information: error.response.errors?.[0].message ?? error.message,
-        handleClose: () =>
-          unregisterNotification({
-            id: messageId,
-            title: "",
-            information: ""
-          })
-      };
-      registerNotification(newNotification);
+        information: error.response.errors?.[0].message ?? error.message
+      });
     }
   };
 

--- a/packages/app/src/client/integrations/k8sLogs/Show/InstallInstructions.tsx
+++ b/packages/app/src/client/integrations/k8sLogs/Show/InstallInstructions.tsx
@@ -23,7 +23,7 @@ import { Integration } from "state/integration/types";
 import * as commands from "./templates/commands";
 import { makePromtailDashboardRequests } from "./dashboards";
 
-import { useNotificationService } from "client/services/Notification";
+import { useSimpleNotification } from "client/services/Notification";
 import * as grafana from "client/utils/grafana";
 
 import { updateGrafanaStateForIntegration } from "state/integration/actions";
@@ -89,29 +89,17 @@ export const InstallInstructions = ({
     saveAs(configBlob, configFilename);
   };
 
-  const {
-    registerNotification,
-    unregisterNotification
-  } = useNotificationService();
+  const { registerNotification } = useSimpleNotification();
 
   const notifyError = useCallback(
     (title: string, message: string) => {
-      const messageId = Math.floor(Math.random() * Math.floor(100000)).toString();
-      const newNotification = {
-        id: messageId,
+      registerNotification({
         state: "error" as const,
         title,
-        information: message,
-        handleClose: () =>
-          unregisterNotification({
-            id: messageId,
-            title: "",
-            information: ""
-          })
-      };
-      registerNotification(newNotification);
+        information: message
+      });
     },
-    [registerNotification, unregisterNotification]
+    [registerNotification]
   );
 
   const dashboardHandler = async () => {

--- a/packages/app/src/client/services/Notification/NotificationService.test.tsx
+++ b/packages/app/src/client/services/Notification/NotificationService.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import {
+  useSimpleNotification,
+  NotificationService
+} from "client/services/Notification";
+import light from "client/themes/light";
+import ThemeProvider from "client/themes/Provider";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { render } from "@testing-library/react";
+
+test("useNotificationService", async () => {
+  const title = "my-title";
+  const information = "my-information";
+  const state = "error";
+  const TestComponent = () => {
+    const { registerNotification } = useSimpleNotification();
+    return (
+      <button
+        onClick={() =>
+          registerNotification({
+            title,
+            information,
+            state
+          })
+        }
+      />
+    );
+  };
+
+  const container = renderComponent(<TestComponent />);
+
+  userEvent.click(container.getByRole("button"));
+
+  expect(await container.findByText(title)).toBeInTheDocument();
+  expect(await container.findByText(information)).toBeInTheDocument();
+});
+
+const renderComponent = (children: React.ReactNode) => {
+  return render(
+    <ThemeProvider theme={light}>
+      <NotificationService>{children}</NotificationService>
+    </ThemeProvider>
+  );
+};

--- a/packages/app/src/client/services/Notification/NotificationService.tsx
+++ b/packages/app/src/client/services/Notification/NotificationService.tsx
@@ -24,6 +24,7 @@ import type {
 import { actions, notificationServiceReducer, initialState } from "./reducer";
 import { useTypesafeReducer } from "../../hooks/useTypesafeReducer";
 import NotificationsList from "../../components/NotificationsList/NotificationsList";
+import { random } from "lodash";
 
 const notificationServiceContext = React.createContext<NotificationServiceApi | null>(
   null
@@ -99,6 +100,36 @@ export function useNotificationService(
     unregisterNotification: notificationService.unregister,
     unregisterAllNotifications: notificationService.unregisterAll,
     changeNotificationVisibility: notificationService.changeVisibility
+  };
+}
+
+export function useSimpleNotification() {
+  const {
+    registerNotification,
+    unregisterNotification
+  } = useNotificationService();
+
+  return {
+    registerNotification: ({
+      title,
+      information,
+      state
+    }: Pick<Notification, "title" | "information" | "state">) => {
+      const messageId = random(0, 9999).toString();
+      const newNotification = {
+        id: messageId,
+        state,
+        title,
+        information,
+        handleClose: () =>
+          unregisterNotification({
+            id: messageId,
+            title: "",
+            information: ""
+          })
+      };
+      registerNotification(newNotification);
+    }
   };
 }
 

--- a/packages/app/src/client/views/ring-health/RingTable.tsx
+++ b/packages/app/src/client/views/ring-health/RingTable.tsx
@@ -32,7 +32,7 @@ import {
 import { Card } from "client/components/Card";
 import { formatDistanceToNow } from "date-fns";
 import SkeletonTableBody from "./SkeletonTableBody";
-import { useNotificationService } from "client/services/Notification";
+import { useSimpleNotification } from "client/services/Notification";
 import { Button } from "client/components/Button";
 import { Box } from "client/components/Box";
 import TokenDialog from "./TokenDialog";
@@ -68,17 +68,10 @@ type Props = {
   baseUrl: string;
 };
 
-function getRandomInt() {
-  return Math.floor(Math.random() * Math.floor(100000));
-}
-
 const RingTable = ({ ringEndpoint, baseUrl }: Props) => {
   const history = useHistory();
 
-  const {
-    registerNotification,
-    unregisterNotification
-  } = useNotificationService();
+  const { registerNotification } = useSimpleNotification();
   const [keepPolling, setKeepPolling] = useState(true);
   const [shards, setShards] = useState<Array<Shard>>();
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -86,22 +79,13 @@ const RingTable = ({ ringEndpoint, baseUrl }: Props) => {
 
   const notifyError = useCallback(
     (title: string, message: string) => {
-      const messageId = `${getRandomInt()}`;
-      const newNotification = {
-        id: messageId,
+      registerNotification({
         state: "error" as const,
         title,
-        information: message,
-        handleClose: () =>
-          unregisterNotification({
-            id: messageId,
-            title: "",
-            information: ""
-          })
-      };
-      registerNotification(newNotification);
+        information: message
+      });
     },
-    [registerNotification, unregisterNotification]
+    [registerNotification]
   );
 
   const forgetShard = useCallback(


### PR DESCRIPTION
The current notification hook has a [quiet verbose interface and is not straightforward to use](https://github.com/opstrace/opstrace/blob/b04440718010e7e13c7f4856bdbb995b5588bc61/packages/app/src/client/integrations/common/UninstallIntegrationBtn.tsx#L66-L78). 

So far most use cases have been very similar without the need of having a super configurable notification system. 
Here I am adding a small wrapper called `useSimpleNotification` that turns this:
```typescript
const id = generateId();
registerNotification({
  id,
  state: "error" as const,
  title: "Could not delete grafana folder",
  information: error.message,
  handleClose: () =>
    unregisterNotification({
      id: messageId,
      title: "",
      information: ""
    })
});
```
into this
```typescript
registerNotification({
  state: "error" as const,
  title: "Could not delete grafana folder",
  information: error.message
});
```

and should be completely sufficient for most current use cases. 

# Have you...

* [x] Added an explanation of what your changes do?
* [x] Written new tests for your changes?
* [x] Thought about which docs need updating?
