### PR TITLE
bump: loki to 138ca71

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -18,7 +18,7 @@
   "kubeRBACProxy": "quay.io/brancz/kube-rbac-proxy:v0.8.0",
   "kubeStateMetrics": "quay.io/coreos/kube-state-metrics:v1.7.2",
   "localVolumeProvisioner": "quay.io/external_storage/local-volume-provisioner:v2.2.0",
-  "loki": "grafana/loki:main-1ed19f7",
+  "loki": "grafana/loki:main-138ca71",
   "lokiApiProxy": "opstrace/loki-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
   "memcached": "memcached:1.6.9-alpine",
   "memcachedExporter": "prom/memcached-exporter:v0.6.0",


### PR DESCRIPTION
https://github.com/grafana/loki/compare/1ed19f7...138ca71

