### PR TITLE
bump: cortex to a4bf103

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -4,7 +4,7 @@
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.2.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
   "configApi": "opstrace/config-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
-  "cortex": "cortexproject/cortex:master-fde0a62",
+  "cortex": "cortexproject/cortex:master-a4bf103",
   "cortexOperator": "opstrace/cortex-operator:3318f7bf9-ci",
   "cortexApiProxy": "opstrace/cortex-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
   "ddApi": "opstrace/ddapi:f88f81513f6268e74641c4a7c899f46a9e5ca33f",


### PR DESCRIPTION
https://github.com/cortexproject/cortex/compare/fde0a62...a4bf103
91 commits, since May 20.

This will btw be pretty much the 1.10.0 release.