### PR TITLE
browser-tests: debugging playwright cookie

### DIFF
--- a/packages/app/config/env.js
+++ b/packages/app/config/env.js
@@ -83,7 +83,6 @@ function getClientEnvironment(publicUrl) {
           process.env.NODE_ENV !== "development"
             ? undefined
             : process.env.EARLY_PREVIEW,
-        BUILDKITE: process.env.BUILDKITE,
         // Always set this to null in the client
         HASURA_GRAPHQL_ADMIN_SECRET: null,
         // Useful for determining whether we’re running in production mode.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -85,6 +85,7 @@
     "hotkeys-js": "^3.8.1",
     "husky": "^4.3.0",
     "identity-obj-proxy": "3.0.0",
+    "js-cookie": "^3.0.0",
     "js-yaml": "^4.0.0",
     "jwks-rsa": "^1.12.3",
     "lightship": "^6.1.0",

--- a/packages/app/src/client/components/withSession/pages/AccessDenied.tsx
+++ b/packages/app/src/client/components/withSession/pages/AccessDenied.tsx
@@ -16,6 +16,7 @@
 
 import React from "react";
 import { useAuth0 } from "@auth0/auth0-react";
+import Cookies from "js-cookie";
 
 import { loginUrl } from "client/components/withSession/paths";
 
@@ -32,6 +33,8 @@ export const AccessDeniedPage = ({ data }: { data: {} }) => {
   const message = user
     ? `Contact your administrator or log out and try again with a different account.`
     : "Contact your administrator or try again with a different account.";
+
+  const isPlaywright = Cookies.get("opstrace-playwright");
 
   return (
     <Page centered height="100vh" width="100vw">
@@ -62,7 +65,7 @@ export const AccessDeniedPage = ({ data }: { data: {} }) => {
         </Box>
       </ErrorView>
 
-      {process.env.BUILDKITE === "true" && (
+      {isPlaywright === "true" && (
         <ErrorView title="" subheader="" actions={null} maxWidth={800}>
           <Typography variant="h5">Error response</Typography>
           <pre>{JSON.stringify(data, null, 1)}</pre>

--- a/test/browser/fixtures/authenticated.ts
+++ b/test/browser/fixtures/authenticated.ts
@@ -30,7 +30,7 @@ export const addAuthFixture = (test: TestType) =>
           const context = await browser.newContext({ ignoreHTTPSErrors: true });
           const page = await context.newPage();
 
-          await performLogin({ page, cluster, user });
+          await performLogin({ page, context, cluster, user });
 
           const cookies = await page.context().cookies();
           await page.close();

--- a/test/browser/fixtures/config.ts
+++ b/test/browser/fixtures/config.ts
@@ -27,6 +27,7 @@ type SystemFixture = {
 
 type ClusterFixture = {
   name: string | undefined;
+  domain: string;
   baseUrl: string;
   cloudProvider: Record<string, boolean>;
 };
@@ -59,11 +60,11 @@ export const addConfigFixture = (test: TestType) =>
         const clusterName = process.env.OPSTRACE_CLUSTER_NAME;
         const dnsName = process.env.OPSTRACE_INSTANCE_DNS_NAME;
 
-        let baseUrl = undefined;
+        let domain;
         if (dnsName) {
-          baseUrl = dnsName;
+          domain = dnsName;
         } else if (clusterName) {
-          baseUrl = `${clusterName}.opstrace.io`;
+          domain = `${clusterName}.opstrace.io`;
         } else {
           log.error(
             "env variables OPSTRACE_INSTANCE_DNS_NAME or OPSTRACE_CLUSTER_NAME must be set"
@@ -71,10 +72,12 @@ export const addConfigFixture = (test: TestType) =>
           process.exit(1);
         }
 
-        baseUrl =
+        console.log("domain", domain);
+
+        const baseUrl =
           process.env.OPSTRACE_CLUSTER_INSECURE === "true"
-            ? `http://${baseUrl}`
-            : `https://${baseUrl}`;
+            ? `http://${domain}`
+            : `https://${domain}`;
 
         const cloudProvider = process.env.OPSTRACE_CLOUD_PROVIDER;
         if (CLOUD_PROVIDER_DEFAULTS[cloudProvider] !== false) {
@@ -86,6 +89,7 @@ export const addConfigFixture = (test: TestType) =>
 
         const cluster: ClusterFixture = {
           name: clusterName,
+          domain: domain,
           baseUrl: baseUrl,
           cloudProvider: CLOUD_PROVIDER_DEFAULTS
         };

--- a/test/browser/utils/authentication.ts
+++ b/test/browser/utils/authentication.ts
@@ -16,7 +16,17 @@
 
 import { expect, Page } from "@playwright/test";
 
-export const performLogin = async ({ page, cluster, user }) => {
+export const performLogin = async ({ page, context, cluster, user }) => {
+  await context.addCookies([
+    {
+      name: "opstrace-playwright",
+      value: "true",
+      domain: cluster.domain,
+      path: "/",
+      HttpOnly: false
+    }
+  ]);
+
   await page.goto(cluster.baseUrl);
 
   // <button class="MuiButtonBase-root Mui... MuiButton-sizeLarge" tabindex="0" type="button">
@@ -53,7 +63,7 @@ export const restoreLogin = async ({
     await page.goto(cluster.baseUrl);
     await page.waitForSelector("[data-test=getting-started]");
   } else {
-    await performLogin({ page, cluster, user });
+    await performLogin({ page, context, cluster, user });
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14524,6 +14524,11 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
+js-cookie@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.0.tgz#db1661d5459920ec95aaf186ccf74ceb4a495164"
+  integrity sha512-oUbbplKuH07/XX2YD2+Q+GMiPpnVXaRz8npE7suhBH9QEkJe2W7mQ6rwuMXHue3fpfcftQwzgyvGzIHyfCSngQ==
+
 js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"


### PR DESCRIPTION
Have the Playwright browser tests set a special `opstrace-playwright` cookie the react app can read. When set the `AccessDenied` page will show extra error info sent from the server which should be included in test failure screenshots.