### PR TITLE
test-browser: migrate in the ring health test to help stabilise CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ packages/buildinfo/src/buildinfo.ts
 # playwright output
 test/test-remote/uishot-*
 test/browser/test-results
-test/browser/contextState.json
+test/browser/contextState-*.json
 
 packages/app/.env
 packages/app/.env.client.development

--- a/packages/app/src/client/views/ring-health/RingHealth.tsx
+++ b/packages/app/src/client/views/ring-health/RingHealth.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-type Tab = {
+export type Tab = {
   title: string;
   path: string;
   endpoint: string;
@@ -70,6 +70,7 @@ const RingHealth = ({ tabs, title }: Props) => {
                   label={tab.title}
                   component={Link}
                   to={tab.path}
+                  data-test={`ringHealth/tab/${tab.title}`}
                 />
               ))}
             </MuiTabs>

--- a/packages/app/src/client/views/ring-health/RingTable.tsx
+++ b/packages/app/src/client/views/ring-health/RingTable.tsx
@@ -225,9 +225,13 @@ const RingShard = ({
       </TableCell>
       <TableCell>{shard.state}</TableCell>
       <TableCell>
-        {formatDistanceToNow(new Date(shard.timestamp), {
-          addSuffix: true
-        })}
+        {
+          // dirty hack: the timestamp is not in a format recgonised recogised by FireFox or Safari
+          // more info here: https://stackoverflow.com/questions/16616950/date-function-returning-invalid-date-in-safari-and-firefox
+          formatDistanceToNow(new Date(shard.timestamp.replace(/-/g, "/")), {
+            addSuffix: true
+          })
+        }
       </TableCell>
       <TableCell>{shard.zone || "-"}</TableCell>
       <TableCell>{shard.address}</TableCell>

--- a/packages/app/src/client/views/ring-health/RingTable.tsx
+++ b/packages/app/src/client/views/ring-health/RingTable.tsx
@@ -30,7 +30,7 @@ import {
   Typography
 } from "@material-ui/core";
 import { Card } from "client/components/Card";
-import { formatDistanceToNow } from "date-fns";
+import { formatDistanceToNow, parseJSON } from "date-fns";
 import SkeletonTableBody from "./SkeletonTableBody";
 import { useSimpleNotification } from "client/services/Notification";
 import { Button } from "client/components/Button";
@@ -134,8 +134,9 @@ const RingTable = ({ ringEndpoint, baseUrl }: Props) => {
   const tokenShardIdToDisplay = useRouteMatch<{ shardId: string }>(
     `${baseUrl}/:shardId/token`
   )?.params.shardId;
-  const tokensToDisplay = shards?.find(s => s.id === tokenShardIdToDisplay)
-    ?.tokens;
+  const tokensToDisplay = shards?.find(
+    s => s.id === tokenShardIdToDisplay
+  )?.tokens;
 
   return (
     <>
@@ -225,13 +226,9 @@ const RingShard = ({
       </TableCell>
       <TableCell>{shard.state}</TableCell>
       <TableCell>
-        {
-          // dirty hack: the timestamp is not in a format recgonised recogised by FireFox or Safari, eg: "2021-08-04 05:16:17 +0000 UTC"
-          // more info here: https://stackoverflow.com/questions/16616950/date-function-returning-invalid-date-in-safari-and-firefox
-          formatDistanceToNow(new Date(shard.timestamp.replace(/-/g, "/")), {
-            addSuffix: true
-          })
-        }
+        {formatDistanceToNow(parseJSON(shard.timestamp), {
+          addSuffix: true
+        })}
       </TableCell>
       <TableCell>{shard.zone || "-"}</TableCell>
       <TableCell>{shard.address}</TableCell>

--- a/packages/app/src/client/views/ring-health/RingTable.tsx
+++ b/packages/app/src/client/views/ring-health/RingTable.tsx
@@ -159,7 +159,7 @@ const RingTable = ({ ringEndpoint, baseUrl }: Props) => {
             </TableRow>
           </TableHead>
           {shards && !isRefreshing ? (
-            <TableBody>
+            <TableBody data-test="ringTable/shards">
               {shards.map(shard => (
                 <RingShard
                   key={shard.id}
@@ -218,6 +218,7 @@ const RingShard = ({
       className={classNames({
         [classes.shardWarning]: shard.state !== "ACTIVE"
       })}
+      data-test={`ringTable/shards/row/${shard.state}`}
     >
       <TableCell component="th" scope="row">
         {shard.id}

--- a/packages/app/src/client/views/ring-health/RingTable.tsx
+++ b/packages/app/src/client/views/ring-health/RingTable.tsx
@@ -226,7 +226,7 @@ const RingShard = ({
       <TableCell>{shard.state}</TableCell>
       <TableCell>
         {
-          // dirty hack: the timestamp is not in a format recgonised recogised by FireFox or Safari
+          // dirty hack: the timestamp is not in a format recgonised recogised by FireFox or Safari, eg: "2021-08-04 05:16:17 +0000 UTC"
           // more info here: https://stackoverflow.com/questions/16616950/date-function-returning-invalid-date-in-safari-and-firefox
           formatDistanceToNow(new Date(shard.timestamp.replace(/-/g, "/")), {
             addSuffix: true

--- a/packages/app/src/client/views/ring-health/cortex/index.tsx
+++ b/packages/app/src/client/views/ring-health/cortex/index.tsx
@@ -16,8 +16,9 @@
 
 import React from "react";
 import RingHealth from "../RingHealth";
+import { Tab } from "../RingHealth";
 
-export const TABS = [
+export const TABS: Tab[] = [
   {
     title: "Ingester",
     path: `/ingester`,

--- a/packages/app/src/client/views/ring-health/testUtils.ts
+++ b/packages/app/src/client/views/ring-health/testUtils.ts
@@ -20,7 +20,7 @@ import { Shard } from "./RingTable";
 export const createMockShard = (id: string): Required<Shard> => ({
   id: `shard-id-${id}`,
   state: `shard-state-${id}`,
-  timestamp: "2021-05-31T13:02:47+00:00",
+  timestamp: "2021-08-04 05:16:17 +0000 UTC",
   zone: `shard-zone-${id}`,
   address: `shard-address-${id}`,
   tokens: [],

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -22,8 +22,8 @@
     "winston": "^3.3.3"
   },
   "scripts": {
-    "pw:localhost": "OPSTRACE_PLAYWRIGHT_SAVE_STATE=\"true\" OPSTRACE_INSTANCE_DNS_NAME=\"localhost:3000\" OPSTRACE_CLUSTER_INSECURE=true OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
-    "pw": "OPSTRACE_PLAYWRIGHT_SAVE_STATE=\"true\" OPSTRACE_CLUSTER_INSECURE=true OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
+    "pw:localhost": "OPSTRACE_PLAYWRIGHT_SAVE_STATE=\"true\" OPSTRACE_INSTANCE_DNS_NAME=\"localhost:3000\" OPSTRACE_CLUSTER_NAME=\"localhost\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
+    "pw": "OPSTRACE_PLAYWRIGHT_SAVE_STATE=\"true\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
     "lint": "eslint . --ext .ts --quiet"
   }
 }

--- a/test/browser/tests/clusterHealth.spec.ts
+++ b/test/browser/tests/clusterHealth.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@playwright/test";
+
+import useFixtures from "../fixtures";
+import { restoreLogin } from "../utils";
+
+const test = useFixtures("auth");
+
+test.describe("cluster health", () => {
+  test.beforeEach(restoreLogin);
+
+  test("all Cortext Ring Health tabs should render", async ({ page }) => {
+    await page.hover("[data-test='sidebar/clusterAdmin/Health']");
+    await page.click("[data-test='sidebar/clusterAdmin/Health']");
+    await page.click("[data-test='sidebar/clusterAdmin/Health/System']");
+    await page.click("[data-test='sidebar/clusterAdmin/Health/Metrics']");
+
+    for (const tabName of [
+      "Ingester",
+      "Ruler",
+      "Compactor",
+      "Store-gateway",
+      "Alertmanager"
+    ]) {
+      console.log("tabName:", tabName);
+      await page.click(`[data-test='ringHealth/tab/${tabName}']`);
+      await page.waitForSelector(`[data-test='ringTable/shards']`);
+      expect(
+        await page.waitForSelector(`[data-test='ringTable/shards/row/ACTIVE']`)
+      ).toBeTruthy();
+    }
+  });
+});

--- a/test/browser/tests/clusterHealth.spec.ts
+++ b/test/browser/tests/clusterHealth.spec.ts
@@ -37,7 +37,6 @@ test.describe("cluster health", () => {
       "Store-gateway",
       "Alertmanager"
     ]) {
-      console.log("tabName:", tabName);
       await page.click(`[data-test='ringHealth/tab/${tabName}']`);
       await page.waitForSelector(`[data-test='ringTable/shards']`);
       expect(

--- a/test/test-remote/test_ui_api.ts
+++ b/test/test-remote/test_ui_api.ts
@@ -583,33 +583,4 @@ suite("test_ui_api", function () {
       await sleep(10);
     }
   });
-
-  test("view_ring_health", async function () {
-    // Same consideration as above: this test is here in this module for now
-    // just because it's easy to use the authentication state after actual
-    // UI-based login.
-    assert(COOKIES_AFTER_LOGIN, "Auth cookies are present");
-    const page = await BROWSER.contexts()[0].newPage();
-    await page.goto(CLUSTER_BASE_URL);
-    await page.waitForNavigation();
-
-    await page.click("text=Health");
-    await page.click("text=Metrics");
-    assert(await page.isVisible("text=Cortex Ring Health"), "page loaded");
-
-    for (const tabName of [
-      "Ingester",
-      "Ruler",
-      "Compactor",
-      "Store-gateway",
-      "Alertmanager"
-    ]) {
-      await page.click(`text=${tabName}`);
-      page.waitForSelector(`css=tab >> text=${tabName} [aria-selected="true"]`);
-      assert(
-        await page.waitForSelector("text=less than a minute ago"),
-        `Loading ${tabName} table`
-      );
-    }
-  });
 });


### PR DESCRIPTION
White doing change I noticed that there was an `await` [missing](https://github.com/opstrace/opstrace/pull/1184/files#diff-0d2fcdddb14264ab274aba532f31800e276351ccf562e3e5ed4dcc72ac30fb73L608) from the original test-remote test which _may_ have been causing the problems on CI. The test should be under browser-test so I moved and corrected the problem.