### PR TITLE
ci: add a script to clean up gcp cloud dns zones

### DIFF
--- a/ci/scripts/cleanup-cloud-dns.sh
+++ b/ci/scripts/cleanup-cloud-dns.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#
+# Run this script when you need to clean up the cloud dns zones leftover by CI
+# builds. Note, it can take a while to run the clean up procedure because it's
+# deleting the record sets in a zone one by one.
+#
+
+set -eou pipefail
+
+SERVICE_ACCOUNT=$1
+PROJECT=$2
+
+if [ -z "${SERVICE_ACCOUNT}" ] ||  [ -z "${PROJECT}" ]; then
+    echo "usage: cleanup-cloud-dns.sh /path/to/gcp-svc-acc-ci-shard-xxx.json ci-shard-xxx"
+    exit 1
+fi
+
+# Set up gcloud auth.
+gcloud auth activate-service-account --key-file=${SERVICE_ACCOUNT}
+gcloud config set project ${PROJECT}
+
+# Get the list of managed zones created by CI in the project.
+MANAGED_ZONES=$(gcloud dns managed-zones list | grep bk | awk '{print $1}' )
+
+for ZONE in ${MANAGED_ZONES}
+do
+    echo "Clearing zone ${ZONE}"
+    # Get the list of record sets in the zone and delete them. Skip the NS and
+    # SOA records since those are there by default.
+    RECORD_SETS=$(gcloud dns record-sets list --zone ${ZONE} --page-size=200 | awk '(NR>1) {print $1, $2}')
+    while IF=' ' read -r NAME TYPE
+    do
+        if [ "${TYPE}" = "SOA" ] || [ "${TYPE}" = "NS" ]; then
+            echo "    Skipping ${NAME} with type ${TYPE}"
+        else
+            echo "Deleting record set ${NAME} ${TYPE}"
+            gcloud dns record-sets delete ${NAME} --type ${TYPE} --zone ${ZONE}
+        fi
+    done <<< ${RECORD_SETS}
+    echo "Deleting managed zone ${ZONE}"
+    gcloud dns managed-zones delete ${ZONE}
+done


### PR DESCRIPTION
Adds a script to clean up GCP Cloud DNS zones leftover by CI.

I'm currently running it locally to cleanup ci-shard-eee and this is an example output:

```
deleting record set dd.treetops792.upgrade-bk-1138-664-g.opstrace.io. TXT
Deleted [https://dns.googleapis.com/dns/v1/projects/ci-shard-eee/managedZones/upgrade-bk-1138-664-g-opstrace-io/rrsets/dd.treetops792.upgrade-bk-1138-664-g.opstrace.io./TXT].
deleting record set loki.treetops792.upgrade-bk-1138-664-g.opstrace.io. A
Deleted [https://dns.googleapis.com/dns/v1/projects/ci-shard-eee/managedZones/upgrade-bk-1138-664-g-opstrace-io/rrsets/loki.treetops792.upgrade-bk-1138-664-g.opstrace.io./A].
deleting record set loki.treetops792.upgrade-bk-1138-664-g.opstrace.io. TXT
Deleted [https://dns.googleapis.com/dns/v1/projects/ci-shard-eee/managedZones/upgrade-bk-1138-664-g-opstrace-io/rrsets/loki.treetops792.upgrade-bk-1138-664-g.opstrace.io./TXT].
deleting managed zone upgrade-bk-1138-664-g-opstrace-io
Deleted [https://dns.googleapis.com/dns/v1/projects/ci-shard-eee/managedZones/upgrade-bk-1138-664-g-opstrace-io].
clearing zone upgrade-bk-1139-8cd-g-opstrace-io
deleting record set upgrade-bk-1139-8cd-g.opstrace.io. A
Deleted [https://dns.googleapis.com/dns/v1/projects/ci-shard-eee/managedZones/upgrade-bk-1139-8cd-g-opstrace-io/rrsets/upgrade-bk-1139-8cd-g.opstrace.io./A].
    skipping upgrade-bk-1139-8cd-g.opstrace.io. with type NS
    skipping upgrade-bk-1139-8cd-g.opstrace.io. with type SOA
deleting record set upgrade-bk-1139-8cd-g.opstrace.io. TXT
Deleted [https://dns.googleapis.com/dns/v1/projects/ci-shard-eee/managedZones/upgrade-bk-1139-8cd-g-opstrace-io/rrsets/upgrade-bk-1139-8cd-g.opstrace.io./TXT].
deleting record set default.upgrade-bk-1139-8cd-g.opstrace.io. A
Deleted [https://dns.googleapis.com/dns/v1/projects/ci-shard-eee/managedZones/upgrade-bk-1139-8cd-g-opstrace-io/rrsets/default.upgrade-bk-1139-8cd-g.opstrace.io./A].
deleting record set default.upgrade-bk-1139-8cd-g.opstrace.io. TXT
Deleted [https://dns.googleapis.com/dns/v1/projects/ci-shard-eee/managedZones/upgrade-bk-1139-8cd-g-opstrace-io/rrsets/default.upgrade-bk-1139-8cd-g.opstrace.io./TXT].
deleting record set cortex.default.upgrade-bk-1139-8cd-g.opstrace.io. A
Deleted [https://dns.googleapis.com/dns/v1/projects/ci-shard-eee/managedZones/upgrade-bk-1139-8cd-g-opstrace-io/rrsets/cortex.default.upgrade-bk-1139-8cd-g.opstrace.io./A].
```
