### PR TITLE
cli(destroy): correctly delete gcp dns managed zone

### DIFF
--- a/lib/dns/src/index.ts
+++ b/lib/dns/src/index.ts
@@ -19,6 +19,7 @@ import { CreateZoneResponse, DNS } from "@google-cloud/dns";
 import { Route53 } from "aws-sdk";
 import { DNSZone, DNSRecord, Provider } from "./types";
 import { getSubdomain } from "./util";
+export { getSubdomain } from "./util";
 import { DNSClient } from "./opstrace";
 
 import * as GCP from "./gcp";


### PR DESCRIPTION
The DNS zone name was missing a dot '.' at the end. The uninstaller now uses the same code as the installer to generate the DNS zone name.

Close #1195 