### PR TITLE
cli: add support for new ap-northeast-3 aws region

### DIFF
--- a/packages/cli/src/list.ts
+++ b/packages/cli/src/list.ts
@@ -87,11 +87,15 @@ export async function EKSgetOpstraceClustersAcrossManyRegions(): Promise<
   // the `opstrace list` operation. Parallelize/batch http requests. Is a bit
   // costly but still fine (especially given the UX win).
 
+  // Enumerate only AWS global regions; omit not local zones and cn-* regions.
+  //   https://aws.amazon.com/about-aws/global-infrastructure/localzones/
+  //   https://www.amazonaws.cn/en/about-aws/regional-product-services/
   const regions = [
     "af-south-1",
     "ap-east-1",
     "ap-northeast-1",
     "ap-northeast-2",
+    "ap-northeast-3",
     "ap-south-1",
     "ap-southeast-1",
     "ap-southeast-2",

--- a/packages/cli/src/list.ts
+++ b/packages/cli/src/list.ts
@@ -87,9 +87,12 @@ export async function EKSgetOpstraceClustersAcrossManyRegions(): Promise<
   // the `opstrace list` operation. Parallelize/batch http requests. Is a bit
   // costly but still fine (especially given the UX win).
 
-  // Enumerate only AWS global regions; omit not local zones and cn-* regions.
+  // Enumerate only AWS global regions; omit "local zones" and cn-* regions.
   //   https://aws.amazon.com/about-aws/global-infrastructure/localzones/
   //   https://www.amazonaws.cn/en/about-aws/regional-product-services/
+  //
+  // Discuss adding cn-* regions: https://github.com/opstrace/opstrace/issues/1202
+
   const regions = [
     "af-south-1",
     "ap-east-1",


### PR DESCRIPTION
Follow-on from #1193.

AWS announced the Osaka region on March 1, 2021.  Add this explicitly to our list of supported regions.

https://aws.amazon.com/blogs/aws/aws-asia-pacific-osaka-region-now-open-to-all-with-three-azs-more-services/