### PR TITLE
UI login: make JWKS fetching more robust

### DIFF
--- a/lib/utils/src/deadline.ts
+++ b/lib/utils/src/deadline.ts
@@ -34,14 +34,16 @@ export function mtime(): bigint {
   // nanoseconds.
   return process.hrtime.bigint();
 }
-
+/**
+ * Number of seconds passed since reference point in time (in the past). `ref`
+ * must be a value previously obtained from `mtime()`. Number() converts a
+ * BigInt to a regular Number type, allowing for translating from nanoseconds
+ * to seconds with a simple division, retaining sub-second resolution. This
+ * assumes that the measured time duration does not grow beyond 104 days.
+ * @param ref: reference time
+ * @returns number of seconds passed since reference time.
+ */
 export function mtimeDiffSeconds(ref: bigint): number {
-  // number of seconds passed since reference point in time (in the past).
-  // `ref` must be a value previously obtained from `mtime()`. Number()
-  // converts a BigInt to a regular Number type, allowing for translating from
-  // nanoseconds to seconds with a simple division, retaining sub-second
-  // resolution. This assumes that the measured time duration does not grow
-  // beyond 104 days.
   return Number(process.hrtime.bigint() - ref) / 10 ** 9;
 }
 

--- a/lib/utils/src/httpclient.ts
+++ b/lib/utils/src/httpclient.ts
@@ -16,11 +16,7 @@
 
 import { strict as assert } from "assert";
 
-import got, {
-  Got,
-  Response as GotResponse,
-  RetryObject as GotRetryObject
-} from "got";
+import got, { Got, RetryObject, Response as GotResponse } from "got";
 
 import { log } from "./log";
 //import { rndFloatFromInterval } from "./math";
@@ -41,13 +37,13 @@ const httpTimeoutSettings = {
   request: 30000
 };
 
-export function customGotRetryfunc(ro: GotRetryObject): number {
+export function customGotRetryfunc(ro: RetryObject): number {
   // log.debug("retry object: %s", JSON.stringify(ro, null, 2));
 
   // Non-obvious pieces of information:
   // (also see https://github.com/sindresorhus/got/issues/1143)
   //
-  // - The GotRetryObject contains the entire retry configuration, potentially
+  // - The Got RetryObject contains the entire retry configuration, potentially
   //   the _custom_ one if a custom one was set through the `retry` property on
   //   the got client object. See below for an example.
   //

--- a/lib/utils/src/httpclient.ts
+++ b/lib/utils/src/httpclient.ts
@@ -41,7 +41,7 @@ const httpTimeoutSettings = {
   request: 30000
 };
 
-function retryfunc(ro: GotRetryObject): number {
+export function customGotRetryfunc(ro: GotRetryObject): number {
   // log.debug("retry object: %s", JSON.stringify(ro, null, 2));
 
   // Non-obvious pieces of information:
@@ -182,7 +182,7 @@ export const httpcl: Got = got.extend({
   // ETIMEDOUT ECONNRESET EADDRINUSE ECONNREFUSED EPIPE ENOTFOUND ENETUNREACH EAI_AGAIN
   retry: {
     limit: 10,
-    calculateDelay: retryfunc,
+    calculateDelay: customGotRetryfunc,
     // remove 429 for now, for https://github.com/opstrace/opstrace/issues/30
     statusCodes: [408, 413, 500, 502, 503, 504, 521, 522, 524],
     // do not retry for longer than 5 minutes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,7 +76,7 @@
     "file-saver": "^2.0.5",
     "glamor": "^2.20.40",
     "glob": "^7.1.6",
-    "got": "11.1.4",
+    "got": "11.8.2",
     "graphql": "15.3.0",
     "graphql-request": "^3.0.0",
     "graphql-tag": "^2.10.3",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -86,7 +86,7 @@
     "husky": "^4.3.0",
     "identity-obj-proxy": "3.0.0",
     "js-yaml": "^4.0.0",
-    "jwks-rsa": "^1.12.3",
+    "jwks-rsa": "^2.0.4",
     "lightship": "^6.1.0",
     "lodash": "^4.17.21",
     "match-sorter": "^4.2.1",

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -32,9 +32,8 @@ import * as jwkshelpers from "./jwks";
 
 // Use something like this for testing error handling.
 //const JWKS_URL = `http://httpbin.org/delay/10`;
-const JWKS_URL = `http://httpbin.org/status/504`;
-
-// const JWKS_URL = `https://${env.AUTH0_DOMAIN}/.well-known/jwks.json`;
+// const JWKS_URL = `http://httpbin.org/status/504`;
+const JWKS_URL = `https://${env.AUTH0_DOMAIN}/.well-known/jwks.json`;
 
 // Middleware for verification of the Auth0-emitted access token that is sent
 // as _login_ credential.

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -36,7 +36,7 @@ const JWKS_URL = `https://${env.AUTH0_DOMAIN}/.well-known/jwks.json`;
 // as _login_ credential.+
 const checkAccessTokenForLogin = jwt({
   secret: jwksRsa.expressJwtSecret({
-    cache: false,
+    cache: true,
     rateLimit: true,
     jwksRequestsPerMinute: 5,
     jwksUri: JWKS_URL,

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -30,8 +30,11 @@ import { AUTH0_CONFIG, BUILD_INFO } from "./uicfg";
 
 import * as jwkshelpers from "./jwks";
 
+// Use something like this for testing error handling.
+//const JWKS_URL = `http://httpbin.org/delay/10`;
+const JWKS_URL = `http://httpbin.org/status/504`;
+
 // const JWKS_URL = `https://${env.AUTH0_DOMAIN}/.well-known/jwks.json`;
-const JWKS_URL = `http://httpbin.org/delay/10`;
 
 // Middleware for verification of the Auth0-emitted access token that is sent
 // as _login_ credential.
@@ -180,11 +183,6 @@ const loadUserInfo = async (accessToken: string) => {
   return { email: data.email, avatar: data.picture || "", username };
 };
 
-// during import time, trigger the JWKS prepopulation and swallow all errors.
-// try {
-//   await jwkshelpers.prepopulate(JWKS_URL);
-// } catch (err) {
-//   log.warning(`non-fatal: JWKS preopulation failed: ${err}`);
-// }
+jwkshelpers.prepopulateZombie(JWKS_URL);
 
 export default createAuthHandler;

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -30,10 +30,11 @@ import { AUTH0_CONFIG, BUILD_INFO } from "./uicfg";
 
 import * as jwkshelpers from "./jwks";
 
-const JWKS_URL = `https://${env.AUTH0_DOMAIN}/.well-known/jwks.json`;
+// const JWKS_URL = `https://${env.AUTH0_DOMAIN}/.well-known/jwks.json`;
+const JWKS_URL = `http://httpbin.org/delay/10`;
 
 // Middleware for verification of the Auth0-emitted access token that is sent
-// as _login_ credential.+
+// as _login_ credential.
 const checkAccessTokenForLogin = jwt({
   secret: jwksRsa.expressJwtSecret({
     cache: true,
@@ -43,7 +44,7 @@ const checkAccessTokenForLogin = jwt({
     // Override fetcher function, see
     // https://github.com/auth0/node-jwks-rsa/blob/cd52aa297756bc097e45f59a8ee216c69a2e1704/src/wrappers/request.js#L7
     //@ts-ignore: type not up to date
-    fetcher: jwkshelpers.fetcher
+    fetcher: jwkshelpers.fetch
   }),
 
   // Validate the audience and the issuer.
@@ -57,8 +58,6 @@ function createAuthHandler(): express.Router {
   // endpoint for creating a session so we don't have to
   // pass JWTs to every API request.
   auth.post("/session", checkAccessTokenForLogin, async (req, res, next) => {
-    log.info("HELLO FROM /SESSION");
-
     const { email, username, avatar } = await loadUserInfo(
       // @ts-ignore Object is possibly 'undefined'
       req.headers.authorization.split(" ")[1]

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -57,9 +57,12 @@ const checkAccessTokenForLogin = jwt({
 
 function createAuthHandler(): express.Router {
   const auth = express.Router();
-  // endpoint for creating a session so we don't have to
-  // pass JWTs to every API request.
+  // Note(JP): think of this as a _login_ endpoint, exchanging primary
+  // credential (here: Auth0-emitted access token) into a secondary credential
+  // (here: session identifier, wrapped in cookie)
   auth.post("/session", checkAccessTokenForLogin, async (req, res, next) => {
+    // Note(JP): TODO: clarify which errors this may throw, and for some of
+    // them maybe also emit a proper 401 response.
     const { email, username, avatar } = await loadUserInfo(
       // @ts-ignore Object is possibly 'undefined'
       req.headers.authorization.split(" ")[1]

--- a/packages/app/src/server/routes/api/jwks.ts
+++ b/packages/app/src/server/routes/api/jwks.ts
@@ -195,6 +195,11 @@ export async function fetch(url: string) {
     );
   }
 
+  // after retrying machinery we might still end up with e.g. a 504 response
+  // as last response, not yet explicitly treated by code although the
+  // JSON deser handler will catch that
+  // TODO if (resp.code !== 200) { ... getPotantiallyStaleJWKS() ... }
+
   let newKeySet: object | undefined;
   try {
     newKeySet = JSON.parse(resp.body);

--- a/packages/app/src/server/routes/api/jwks.ts
+++ b/packages/app/src/server/routes/api/jwks.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2021 Opstrace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { strict as assert } from "assert";
+import got, { Response as GotResponse } from "got";
+
+import { customGotRetryfunc, mtime, mtimeDiffSeconds } from "@opstrace/utils";
+
+import { log } from "@opstrace/utils/lib/log";
+
+// This bypasses the cache mechanism in jwks-rksa / adds to it using the
+// assumption that public keys are practically never rotated. I don't think
+// that the cache built into jwks-rksa has the following really important
+// functionality: if the cache is stale, instead of erroring out the operation
+// simply try to use the 'last known good key set', even if that's technically
+// 'outdated', based on the cache configuration. The probability for that
+// "stale" cache item to contain the correct public key is practically 100 %.
+// Another property that jwks-rsa does not provide is 'prepopulation' before
+// the first request, at least it's not clear how to do that.
+let LAST_JWKS_POTENTIALLY_STALE: object;
+let LAST_JWKS_SET_TIME: bigint;
+let FIRST_JWKS_FROM_PREPOPULATE_CALL: object | undefined;
+
+// JWKS request-adjusted timeout constants. Paradigm: fail fast to allow
+// for a quick retry to potentially heal what went wrong (L4 round-robin
+// load balancing for example might result in a different network path
+// between attempts, we want to make use of that).
+const GOT_JWKS_HTTP_TIMEOUT_SETTINGS = {
+  // Rely on this to be between data centers (not involving a
+  // consumer-grade Internet conn). If a TCP connect() takes longer then
+  // ~5 seconds then most certainly there is a networking issue. Use value
+  // slightly larger than 3 s, initial TCP retransmit timeout.
+  connect: 3400,
+  // After TCP-connect, this controls the max time the TLS handshake is
+  // allowed to take.
+  secureConnect: 2000,
+  // After TLS over TCP ist established, require the few request bytes to
+  // (just a GET w/o body) to be written real quick.
+  send: 2000,
+  // After having written the request, expect response _headers_ to
+  // arrive within that time (not the complete response).
+  response: 2000,
+  // global timeout, supposedly until final response byte arrived.
+  request: 10000
+};
+
+// From the jwks-rsa docs: "Even if caching is enabled the library will call
+// the JWKS endpoint if the kid is not available in the cache, because a key
+// rotation could have taken place."
+
+// Also: ideally, never fetch this in the hot path. Trigger a refresh every now
+// and then in the hot path, but don't wait for the result. That however
+// requires an override for the case where `kid` is not in the current JWKS
+// in that case we have to get a fresh key set, to see if rotation just took
+// place.
+
+// Note(JP): this may be done as part of processing an incoming HTTP request,
+// i.e. we should not retry for longer than ~1 minute. Ideally less than 30
+// seconds or so. Also note that retries are done automatically for a range of
+// transient issues: ETIMEDOUT ECONNRESET EADDRINUSE ECONNREFUSED EPIPE
+// ENOTFOUND ENETUNREACH EAI_AGAIN
+const GOT_JWKS_RETRY_OBJECT = {
+  limit: 3,
+  calculateDelay: customGotRetryfunc,
+  statusCodes: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
+  // do not retry for longer than 60 seconds
+  maxRetryAfter: 45 * 1000
+};
+
+const GOT_JWKS_OPTIONS = {
+  retry: GOT_JWKS_RETRY_OBJECT,
+  timeout: GOT_JWKS_HTTP_TIMEOUT_SETTINGS,
+  throwHttpErrors: false
+};
+
+// function serveFromCacheIfFresh(): null | object {
+//     if (LAST_JWKS_SET_TIME !== undefined) {
+//         // trigger a refreh once per hour.
+//         if (mtimeDiffSeconds(LAST_JWKS_SET_TIME) <  ) {
+
+//         }
+//     }
+// }
+
+/**
+ * Set newly fetched JWKS object. Rely on this being an atomic operation in the
+ * runtime. Return the same object for convenience.
+ */
+function rememberNewJWKS(j: object): object {
+  LAST_JWKS_POTENTIALLY_STALE = j;
+  LAST_JWKS_SET_TIME = mtime();
+  log.info(
+    "JWKS fetcher: got fresh key set, stored as LAST_JWKS_POTENTIALLY_STALE"
+  );
+  return j;
+}
+
+function getPotantiallyStaleJWKS() {
+  assert(LAST_JWKS_SET_TIME !== undefined);
+  log.info(
+    `JWKS fetcher: use potentially stale JWKS. Age: ${mtimeDiffSeconds(
+      LAST_JWKS_SET_TIME
+    ).toFixed(2)} `
+  );
+  return LAST_JWKS_POTENTIALLY_STALE;
+}
+
+export async function prepopulate(url: string) {
+  FIRST_JWKS_FROM_PREPOPULATE_CALL = await fetcher(url);
+  log.info("JWKS prepopulation: done (not as part of HTTP request)");
+}
+
+export async function fetcher(url: string) {
+  if (FIRST_JWKS_FROM_PREPOPULATE_CALL) {
+    log.info(
+      "JWKS fetcher: first call after prepopulate, return FIRST_JWKS_FROM_PREPOPULATE_CALL"
+    );
+    // Important: reset to `undefined` so that this really is only used in the
+    // _first_ call to jwksFetcher() that is _not_ from within prepopulate()
+    const s = FIRST_JWKS_FROM_PREPOPULATE_CALL;
+    FIRST_JWKS_FROM_PREPOPULATE_CALL = undefined;
+    return s;
+  }
+
+  // Perform HTTP request -- this uses retrying (and logging), see above for
+  // the corresponding parameters.
+  log.info("JWKS fetcher: start GET machinery with retrying");
+  let resp: GotResponse<string> | undefined;
+  try {
+    resp = await got(url, GOT_JWKS_OPTIONS);
+  } catch (err) {
+    log.warning(
+      `JWKS fetcher: giving up HTTP GET after retrying, last error: ${err}`
+    );
+  }
+
+  if (resp === undefined) {
+    if (LAST_JWKS_POTENTIALLY_STALE !== undefined) {
+      return getPotantiallyStaleJWKS();
+    }
+    throw new Error(
+      "JWKS fetcher: HTTP GET failed and LAST_JWKS_POTENTIALLY_STALE not set"
+    );
+  }
+
+  let newKeySet: object | undefined;
+  try {
+    newKeySet = JSON.parse(resp.body);
+  } catch (err) {
+    log.warning(`JWKS fetcher: JSON deserialization failed: ${err}`);
+  }
+
+  if (newKeySet !== undefined) {
+    return rememberNewJWKS(newKeySet);
+  }
+
+  if (LAST_JWKS_POTENTIALLY_STALE !== undefined) {
+    return getPotantiallyStaleJWKS();
+  }
+
+  throw new Error(
+    "JWKS fetcher: request succeeded, deserialization failed, LAST_JWKS_POTENTIALLY_STALE not set"
+  );
+}

--- a/packages/app/src/server/server.ts
+++ b/packages/app/src/server/server.ts
@@ -101,6 +101,18 @@ function createServer() {
   // all api routes will be prefixed with _/ which gets us around the service worker cache
   // we don't want these responses cached long term by the service worker
   app.use("/_", api());
+
+  //@ts-ignore: implicit any
+  // app.use(function (err, req, res: Response, next) {
+  //   if (err.name === "UnauthorizedError") {
+  //     log.info(
+  //       `${req.id}: seen UnauthorizedError, send opaque 401 resp. Err detail: ${err.message}`
+  //     );
+  //     res.status(401).send("no valid authentication token found");
+  //     return;
+  //   }
+  // });
+
   // apply post api middleware
   app.use(catchErrorsMiddleware);
   // return the app-shell for PWA

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,18 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES6",
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
     "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
     "jsx": "react",
     "baseUrl": "src",
     "paths": {
@@ -24,5 +17,8 @@
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["**/node_modules/*"],
-  "references": [{ "path": "../../lib/utils" }, { "path": "../../lib/kubernetes" }]
+  "references": [
+    { "path": "../../lib/utils" },
+    { "path": "../../lib/kubernetes" }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,11 +3548,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@sindresorhus/is@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-2.1.1.tgz#ceff6a28a5b4867c2dd4a1ba513de278ccbe8bb1"
-  integrity sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==
-
 "@sindresorhus/is@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.0.tgz#2ff674e9611b45b528896d820d3d7a812de2f0e4"
@@ -12183,24 +12178,6 @@ googleapis@83.0.0:
     google-auth-library "^7.0.2"
     googleapis-common "^5.0.2"
 
-got@11.1.4:
-  version "11.1.4"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.1.4.tgz#ecf0064aab26ae4b2989ab52aadd31a17e7bad63"
-  integrity sha512-z94KIXHhFSpJONuY6C6w1wC+igE7P1d0b5h3H2CvrOXn0/tum/OgFblIGUAxI5PBXukGLvKb9MJXVHW8vsYaBA==
-  dependencies:
-    "@sindresorhus/is" "^2.1.1"
-    "@szmarczak/http-timer" "^4.0.5"
-    "@types/cacheable-request" "^6.0.1"
-    "@types/responselike" "^1.0.0"
-    cacheable-lookup "^5.0.3"
-    cacheable-request "^7.0.1"
-    decompress-response "^6.0.0"
-    get-stream "^5.1.0"
-    http2-wrapper "^1.0.0-beta.4.5"
-    lowercase-keys "^2.0.0"
-    p-cancelable "^2.0.0"
-    responselike "^2.0.0"
-
 got@11.8.1, got@^11.8.0:
   version "11.8.1"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.1.tgz#df04adfaf2e782babb3daabc79139feec2f7e85d"
@@ -12934,7 +12911,7 @@ http-terminator@^2.0.3:
     delay "^4.3.0"
     roarr "^2.14.6"
 
-http2-wrapper@^1.0.0-beta.4.5, http2-wrapper@^1.0.0-beta.5.2:
+http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.0-beta.5.2"
   resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz#8b923deb90144aea65cf834b016a340fc98556f3"
   integrity sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9342,7 +9342,7 @@ debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.0:
+debug@^4.3.0, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -14545,6 +14545,13 @@ jose@^2.0.4:
   dependencies:
     "@panva/asn1.js" "^1.0.0"
 
+jose@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-2.0.5.tgz#29746a18d9fff7dcf9d5d2a6f62cb0c7cd27abd3"
+  integrity sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==
+  dependencies:
+    "@panva/asn1.js" "^1.0.0"
+
 jpeg-js@^0.4.2:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
@@ -15014,21 +15021,16 @@ jwa@^2.0.0:
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jwks-rsa@^1.12.3:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/jwks-rsa/-/jwks-rsa-1.12.3.tgz#40232f85d16734cb82837f38bb3e350a34435400"
-  integrity sha512-cFipFDeYYaO9FhhYJcZWX/IyZgc0+g316rcHnDpT2dNRNIE/lMOmWKKqp09TkJoYlNFzrEVODsR4GgXJMgWhnA==
+jwks-rsa@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/jwks-rsa/-/jwks-rsa-2.0.4.tgz#59d95e39f300783a8582ef8aa37d5ebbc6a8aa6f"
+  integrity sha512-iJqVCECYZZ+3oPmY1qXv3Fq+3ywDtuNEVBvG41pPlaR0zyGxa12nC0beAOBBUhETJmc05puS50mRQN4NkCGhmg==
   dependencies:
     "@types/express-jwt" "0.0.42"
-    axios "^0.21.1"
-    debug "^4.1.0"
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "^5.0.0"
-    jsonwebtoken "^8.5.1"
+    debug "^4.3.2"
+    jose "^2.0.5"
     limiter "^1.1.5"
-    lru-memoizer "^2.1.2"
-    ms "^2.1.2"
-    proxy-from-env "^1.1.0"
+    lru-memoizer "^2.1.4"
 
 jws@^3.2.2:
   version "3.2.2"
@@ -15631,7 +15633,7 @@ lru-cache@~4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-memoizer@^2.1.2:
+lru-memoizer@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-2.1.4.tgz#b864d92b557f00b1eeb322156a0409cb06dafac6"
   integrity sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==


### PR DESCRIPTION
This is to enhance login robustness by a great deal

This PR implements this:

> perform retrying around JWKS fetching requests. As a bonus, try to populate the JWKS cache upon app start, i.e. not as part of processing an HTTP request.

quote from https://github.com/opstrace/opstrace/issues/1156.

on top of the cache implemented in `jwksRsa.expressJwtSecret()` this adds:

*  A custom JWKS HTTP endpoint fetch function using the got() HTTP client with carefully chosen retrying parameters and logging.
* A use-stale-item-if-refresh-failed technique for making the cache more useful and robust.
* A prepopulate-upon-app-start technique to make the first login more robust and fast (minimize hot path impact).