### PR TITLE
cli(upgrade): exit early if buildinfo matches

### DIFF
--- a/packages/upgrader/src/index.ts
+++ b/packages/upgrader/src/index.ts
@@ -287,6 +287,8 @@ function* rootTaskUpgrade(): Generator<any, any, any> {
     log.warning(
       `Opstrace instance is already running the desired version, skipping upgrade`
     );
+    // Cancel the forked informers so we can exit
+    yield cancel(informers);
     return;
   }
 

--- a/packages/upgrader/src/upgrade.ts
+++ b/packages/upgrader/src/upgrade.ts
@@ -75,7 +75,7 @@ export function* opstraceInstanceRequiresUpgrade(): Generator<
       .pop();
     if (lastCLIVersion !== installedControllerImageTag) {
       die(
-        `found Opstrace version mismatch, CLI version ${lastCLIVersion} does not match installed controller version ${installedControllerImageTag}`
+        `found Opstrace version mismatch, last CLI version ${lastCLIVersion} in controller configuration does not match installed controller version ${installedControllerImageTag}`
       );
     }
 


### PR DESCRIPTION
Close #1223

Move the buildinfo version check to as early as possible and checks if the `cliMetadata.allCLIVersions` image tag of the Opstrace controller deployment matches the one defined in the CLI buildinfo. Older Opstrace versions will have an empty cliMetadata field, for these, check the Opstrace controller deployment image and check it matches buildinfo.

