### PR TITLE
loki: use 2.3.0 release

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -18,7 +18,7 @@
   "kubeRBACProxy": "quay.io/brancz/kube-rbac-proxy:v0.8.0",
   "kubeStateMetrics": "quay.io/coreos/kube-state-metrics:v1.7.2",
   "localVolumeProvisioner": "quay.io/external_storage/local-volume-provisioner:v2.2.0",
-  "loki": "grafana/loki:main-138ca71",
+  "loki": "grafana/loki:main-f5fd029",
   "lokiApiProxy": "opstrace/loki-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
   "memcached": "memcached:1.6.9-alpine",
   "memcachedExporter": "prom/memcached-exporter:v0.6.0",

--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -18,7 +18,7 @@
   "kubeRBACProxy": "quay.io/brancz/kube-rbac-proxy:v0.8.0",
   "kubeStateMetrics": "quay.io/coreos/kube-state-metrics:v1.7.2",
   "localVolumeProvisioner": "quay.io/external_storage/local-volume-provisioner:v2.2.0",
-  "loki": "grafana/loki:main-f5fd029",
+  "loki": "grafana/loki:main-b3d7740",
   "lokiApiProxy": "opstrace/loki-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
   "memcached": "memcached:1.6.9-alpine",
   "memcachedExporter": "prom/memcached-exporter:v0.6.0",


### PR DESCRIPTION
Bump Loki by six commits: https://github.com/grafana/loki/compare/138ca71...f5fd029


f5fd029 corresponds to the 2.3.0 release.