### PR TITLE
cortex: use current head of master

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -4,7 +4,7 @@
   "certManagerCAInjector": "quay.io/jetstack/cert-manager-cainjector:v1.2.0",
   "certManagerController": "quay.io/jetstack/cert-manager-controller:v1.2.0",
   "configApi": "opstrace/config-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
-  "cortex": "cortexproject/cortex:master-a4bf103",
+  "cortex": "cortexproject/cortex:master-e658571",
   "cortexOperator": "opstrace/cortex-operator:3318f7bf9-ci",
   "cortexApiProxy": "opstrace/cortex-api:f88f81513f6268e74641c4a7c899f46a9e5ca33f",
   "ddApi": "opstrace/ddapi:f88f81513f6268e74641c4a7c899f46a9e5ca33f",


### PR DESCRIPTION
Bump Cortex by 11 commits., a little beyond the 1.10.0 release.

Two commits with payload:
https://github.com/cortexproject/cortex/commit/4405f9c339779b5861f5755bd867ee7bac4f4fa9
https://github.com/cortexproject/cortex/commit/7133f01763e892430b97f3b440e0df11e88c16dc