### PR TITLE
[wip] test-browser: run single auth spec to save logged in state before executing the entire suite which reuses it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -686,8 +686,9 @@ test-browser:
 		-e OPSTRACE_CLUSTER_NAME \
 		-e OPSTRACE_CLOUD_PROVIDER \
 		-e OPSTRACE_INSTANCE_DNS_NAME \
+		-e OPSTRACE_PLAYWRIGHT_REUSE_STATE=true \
 		opstrace/test-browser:$(CHECKOUT_VERSION_STRING) \
- 			yarn playwright test --workers 1 --forbid-only --retries 3
+ 			yarn pw:save-state-for-reuse && yarn playwright test --workers 3 --forbid-only --retries 3
 
 
 # Used by CI:

--- a/Makefile
+++ b/Makefile
@@ -688,7 +688,7 @@ test-browser:
 		-e OPSTRACE_INSTANCE_DNS_NAME \
 		-e OPSTRACE_PLAYWRIGHT_REUSE_STATE=true \
 		opstrace/test-browser:$(CHECKOUT_VERSION_STRING) \
- 			yarn pw:save-state-for-reuse && yarn playwright test --workers 3 --forbid-only --retries 3
+ 			./run_on_ci.sh
 
 
 # Used by CI:

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -106,14 +106,14 @@ test.describe("after auth0 authentication", () => {
 });
 ```
 
-## Save state between test runs
+## Reuse state between test runs
 
 To speed up the development feedback loop the playwright context state can be reused between runs of Playwright, ie you can keep the CI user logged in and not have to re-login each time you run Playwright. If there is no save state already present the CI user will login as normal and then save the state reuse on subsequent runs.
 
 To manually set the following env var:
 
 ```bash
-export OPSTRACE_PLAYWRIGHT_SAVE_STATE=true
+export OPSTRACE_PLAYWRIGHT_REUSE_STATE=true
 
 ```
 

--- a/test/browser/fixtures/authenticated.ts
+++ b/test/browser/fixtures/authenticated.ts
@@ -28,11 +28,11 @@ export const addAuthFixture = (test: TestType) =>
     authCookies: [
       async ({ browser, system, cluster, user }, use) => {
         if (system.workerAuth) {
-          const SAVE_STATE =
-            process.env.OPSTRACE_PLAYWRIGHT_SAVE_STATE === "true";
+          const REUSE_STATE =
+            process.env.OPSTRACE_PLAYWRIGHT_REUSE_STATE === "true";
           const STATE_FILENAME = `contextState-${cluster.name}.json`;
 
-          const statePresent = SAVE_STATE && validStatePresent(STATE_FILENAME);
+          const statePresent = REUSE_STATE && validStatePresent(STATE_FILENAME);
 
           const context = await browser.newContext({
             ignoreHTTPSErrors: true,
@@ -42,7 +42,7 @@ export const addAuthFixture = (test: TestType) =>
 
           if (!statePresent) {
             await performLogin({ page, cluster, user });
-            if (SAVE_STATE)
+            if (REUSE_STATE)
               await context.storageState({ path: STATE_FILENAME });
           }
 

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "pw:localhost": "OPSTRACE_PLAYWRIGHT_REUSE_STATE=\"true\" OPSTRACE_INSTANCE_DNS_NAME=\"localhost:3000\" OPSTRACE_CLUSTER_NAME=\"localhost\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
     "pw": "OPSTRACE_PLAYWRIGHT_REUSE_STATE=\"true\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
-    "pw:save-state-for-reuse": "yarn playwright test --project=Chromium tests/authentication.spec.ts -g \"user should see homepage\" --workers 1 --forbid-only --retries 1",
+    "pw:save-state-for-reuse": "yarn playwright test --project=Chromium -g \"OPSTRACE_PLAYWRIGHT_REUSE_STATE\" --workers 1 --forbid-only --retries 1",
     "lint": "eslint . --ext .ts --quiet"
   }
 }

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -22,8 +22,9 @@
     "winston": "^3.3.3"
   },
   "scripts": {
-    "pw:localhost": "OPSTRACE_PLAYWRIGHT_SAVE_STATE=\"true\" OPSTRACE_INSTANCE_DNS_NAME=\"localhost:3000\" OPSTRACE_CLUSTER_NAME=\"localhost\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
-    "pw": "OPSTRACE_PLAYWRIGHT_SAVE_STATE=\"true\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
+    "pw:localhost": "OPSTRACE_PLAYWRIGHT_REUSE_STATE=\"true\" OPSTRACE_INSTANCE_DNS_NAME=\"localhost:3000\" OPSTRACE_CLUSTER_NAME=\"localhost\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
+    "pw": "OPSTRACE_PLAYWRIGHT_REUSE_STATE=\"true\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
+    "pw:save-state-for-reuse": "yarn playwright test --project=Chromium tests/authentication.spec.ts -g \"user should see homepage\" --workers 1 --forbid-only --retries 1",
     "lint": "eslint . --ext .ts --quiet"
   }
 }

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -25,6 +25,7 @@
     "pw:localhost": "OPSTRACE_PLAYWRIGHT_REUSE_STATE=\"true\" OPSTRACE_INSTANCE_DNS_NAME=\"localhost:3000\" OPSTRACE_CLUSTER_NAME=\"localhost\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
     "pw": "OPSTRACE_PLAYWRIGHT_REUSE_STATE=\"true\" OPSTRACE_CLOUD_PROVIDER=dev yarn playwright test --config playwright.dev.config.ts",
     "pw:save-state-for-reuse": "yarn playwright test --project=Chromium -g \"OPSTRACE_PLAYWRIGHT_REUSE_STATE\" --workers 1 --forbid-only --retries 1",
+    "pw:ci": "yarn playwright test --workers 3 --forbid-only --retries 3",
     "lint": "eslint . --ext .ts --quiet"
   }
 }

--- a/test/browser/run_on_ci.sh
+++ b/test/browser/run_on_ci.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+#  Copyright 2021 Opstrace, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+
+yarn pw:save-state-for-reuse
+
+yarn playwright test --workers 3 --forbid-only --retries 3

--- a/test/browser/tests/authentication.spec.ts
+++ b/test/browser/tests/authentication.spec.ts
@@ -24,7 +24,10 @@ const test = useFixtures("auth");
 test.describe("after auth0 authentication", () => {
   test.beforeEach(restoreLogin);
 
-  test("user should see homepage", async ({ page, cluster }) => {
+  test("user should see homepage, also OPSTRACE_PLAYWRIGHT_REUSE_STATE", async ({
+    page,
+    cluster
+  }) => {
     expect(await page.isVisible("[data-test=getting-started]")).toBeTruthy();
   });
 


### PR DESCRIPTION
This change updates how the playwright browser tests are executed on CI. the `OPSTRACE_PLAYWRIGHT_REUSE_STATE` env var is now set to `true` which means that the login fixtures and hooks will look for and use a previously logged in state (file on disk), if it's not there a normal login will occur and then the logged in state will be saved. 

On CI playwright is now run twice, once with a single worker running a single test that logs the user in resulting in the logged in state being saving to disk. The second and main run is now back to using multiple workers each reusing the logged in state rather than logging in. This means we can have any number of workers and only login once per test run.