### PR TITLE
ci: use smaller instance type on GCP

### DIFF
--- a/ci/cluster-config-prs.yaml
+++ b/ci/cluster-config-prs.yaml
@@ -1,0 +1,12 @@
+# This configuration is used in the 'PRs' Buildkite pipeline.
+tenants:
+  - default
+env_label: opstrace-ci
+cert_issuer: letsencrypt-staging
+aws:
+  eks_admin_roles:
+    - AWSReservedSSO_AdministratorAccess_8488c3da2f880f06
+custom_auth0_client_id: 5MoCYfPXPuEzceBLRUr6T6SAklT2GDys
+gcp:
+  # Use a smaller instance type to reduce CI costs.
+  machine_type: e2-medium

--- a/ci/cluster-config.yaml
+++ b/ci/cluster-config.yaml
@@ -1,3 +1,4 @@
+# This configuration is used in the 'Scheduled main builds' Buildkite pipeline.
 tenants:
   - default
 env_label: opstrace-ci

--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -234,8 +234,14 @@ export OPSTRACE_INSTANCE_DNS_NAME="${OPSTRACE_CLUSTER_NAME}.opstrace.io"
 # Run opstrace installer locally. The installer will deploy the controller into
 # the cluster and wait until deployments are 'ready'.
 echo "--- create cluster "
+
+INSTANCE_CONFIG=ci/cluster-config.yaml
+if [ "${BUILDKITE_BRANCH}" != "main" ]; then
+    INSTANCE_CONFIG=ci/cluster-config-prs.yaml
+fi
+
 if [[ "${OPSTRACE_CLOUD_PROVIDER}" == "aws" ]]; then
-    cat ci/cluster-config.yaml | ./build/bin/opstrace create aws ${OPSTRACE_CLUSTER_NAME} \
+    cat ${INSTANCE_CONFIG} | ./build/bin/opstrace create aws ${OPSTRACE_CLUSTER_NAME} \
         --log-level=debug --yes \
         --write-kubeconfig-file "${OPSTRACE_CLI_WRITE_KUBECFG_FILEPATH}"
 

--- a/ci/test-upgrade/create-cluster.sh
+++ b/ci/test-upgrade/create-cluster.sh
@@ -15,7 +15,7 @@ fi
 
 echo "--- creating cluster"
 ./from/opstrace create ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} \
-    --instance-config ci/test-upgrade/initial-cluster-config.yaml \
+    --instance-config ${INSTANCE_CONFIG} \
     --write-kubeconfig-file "${OPSTRACE_CLI_WRITE_KUBECFG_FILEPATH}" \
     --log-level=debug \
     --yes

--- a/ci/test-upgrade/initial-cluster-config.yaml
+++ b/ci/test-upgrade/initial-cluster-config.yaml
@@ -1,7 +1,0 @@
-tenants:
-  - default
-env_label: opstrace-ci
-cert_issuer: letsencrypt-staging
-aws:
-  eks_admin_roles:
-    - AWSReservedSSO_AdministratorAccess_8488c3da2f880f06

--- a/ci/test-upgrade/run.sh
+++ b/ci/test-upgrade/run.sh
@@ -75,6 +75,10 @@ set -o xtrace
 # config into the test-remote container. This path is set on create-cluster.sh.
 export OPSTRACE_KUBECFG_FILEPATH_ONHOST="${OPSTRACE_BUILD_DIR}/kubeconfig.cfg"
 
+export INSTANCE_CONFIG=ci/cluster-config.yaml
+if [ "${BUILDKITE_BRANCH}" != "main" ]; then
+    export INSTANCE_CONFIG=ci/cluster-config-prs.yaml
+fi
 
 # For debugging potential issues. `gcloud` is a moving target in our CI and
 # if something fails around the gcloud CLI it's good to know exactly which

--- a/ci/test-upgrade/upgrade-cluster.sh
+++ b/ci/test-upgrade/upgrade-cluster.sh
@@ -19,7 +19,7 @@ esac
 echo "--- upgrading cluster"
 ./to/opstrace upgrade ${OPSTRACE_CLOUD_PROVIDER} ${OPSTRACE_CLUSTER_NAME} \
     --region=${REGION} \
-    --instance-config=ci/cluster-config.yaml \
+    --instance-config=${INSTANCE_CONFIG} \
     --log-level=debug \
     --yes
 


### PR DESCRIPTION
The scheduled main builds will use the default machine type so we
don't break anything.

PR builds will use a smaller instance type to reduce costs. These instance types are also faster to create so hopefully the upgrade test will finish a bit faster than the AWS one.