### PR TITLE
chore: remove shard-eee based (see #293)

### DIFF
--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -68,8 +68,8 @@ source secrets/opstrace_dockerhub_creds.sh
 # https://github.com/opstrace/opstrace/pull/128#issuecomment-742519078 and
 # https://stackoverflow.com/q/5189913/145400.
 #OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
-# remove eee and fff for now, see issue #293
-OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc ci-shard-eee)
+# remove ddd, eee and fff for now, see issue #293
+OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
 echo "--- random choice for GCP project ID: ${OPSTRACE_GCP_PROJECT_ID}"
 export GOOGLE_APPLICATION_CREDENTIALS=./secrets/gcp-svc-acc-${OPSTRACE_GCP_PROJECT_ID}.json
 


### PR DESCRIPTION
The GCP project `ci-shard-eee` has been exhibiting #293 more frequently than the other projects.  Let's remove it from rotation for now.