### PR TITLE
ui: do not load Sentry when running on localhost 

### DIFF
--- a/packages/app/.env.client.development.example
+++ b/packages/app/.env.client.development.example
@@ -9,3 +9,6 @@ BROWSER=none
 
 # enabled early preview features when set
 EARLY_PREVIEW=true
+
+# by default when running on local dev machines exceptions won't be sent to sentry, use this to override that behaviour
+ENABLE_SENTRY_FOR_LOCALHOST=false

--- a/packages/app/.env.server.development.example
+++ b/packages/app/.env.server.development.example
@@ -12,3 +12,5 @@ UI_DOMAIN=http://localhost:3000
 COOKIE_SECRET=aef23610b381f01bf2325f012324a42c2e3e85b12ac37492e07fa98df00cdd20
 REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=myredispassword
+# by default when running on local dev machines exceptions won't be sent to sentry, use this to override that behaviour
+ENABLE_SENTRY_FOR_LOCALHOST=false

--- a/packages/app/config/env.js
+++ b/packages/app/config/env.js
@@ -84,6 +84,7 @@ function getClientEnvironment(publicUrl) {
             ? undefined
             : process.env.EARLY_PREVIEW,
         BUILDKITE: process.env.BUILDKITE,
+        ENABLE_SENTRY_FOR_LOCALHOST: process.env.ENABLE_SENTRY_FOR_LOCALHOST,
         // Always set this to null in the client
         HASURA_GRAPHQL_ADMIN_SECRET: null,
         // Useful for determining whether we’re running in production mode.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,6 +22,7 @@
     "@schemastore/package": "^0.0.6",
     "@sentry/react": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
+    "@sentry/node": "^6.2.5",
     "@types/axios": "^0.14.0",
     "@types/compression": "^1.7.0",
     "@types/cookie-parser": "^1.4.2",

--- a/packages/app/src/client/index.tsx
+++ b/packages/app/src/client/index.tsx
@@ -23,7 +23,7 @@ import { Integrations } from "@sentry/tracing";
 import { isLocalhost } from "./serviceWorker";
 import App from "./app";
 
-if (!isLocalhost) {
+if (!isLocalhost || process.env.OPSTRACE_OVERRIDE_ENABLE_SENTRY === "true") {
   Sentry.init({
     dsn: "https://28a6d713adde403aaaab7c7cc36f0383@o476375.ingest.sentry.io/5529515",
     integrations: [new Integrations.BrowserTracing()]

--- a/packages/app/src/client/index.tsx
+++ b/packages/app/src/client/index.tsx
@@ -20,13 +20,15 @@ import { BrowserRouter } from "react-router-dom";
 import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";
 // import * as serviceWorker from "./serviceWorker";
+import { isLocalhost } from "./serviceWorker";
 import App from "./app";
 
-Sentry.init({
-  dsn:
-    "https://28a6d713adde403aaaab7c7cc36f0383@o476375.ingest.sentry.io/5529515",
-  integrations: [new Integrations.BrowserTracing()]
-});
+if (!isLocalhost) {
+  Sentry.init({
+    dsn: "https://28a6d713adde403aaaab7c7cc36f0383@o476375.ingest.sentry.io/5529515",
+    integrations: [new Integrations.BrowserTracing()]
+  });
+}
 
 const root = document.getElementById("root");
 

--- a/packages/app/src/client/index.tsx
+++ b/packages/app/src/client/index.tsx
@@ -23,12 +23,14 @@ import { Integrations } from "@sentry/tracing";
 import { isLocalhost } from "./serviceWorker";
 import App from "./app";
 
-if (!isLocalhost || process.env.OPSTRACE_OVERRIDE_ENABLE_SENTRY === "true") {
+if (!isLocalhost || process.env.ENABLE_SENTRY_FOR_LOCALHOST === "true") {
   Sentry.init({
     // todo: this should be passed in as an ENV VAR
     dsn: "https://28a6d713adde403aaaab7c7cc36f0383@o476375.ingest.sentry.io/5529515",
     integrations: [new Integrations.BrowserTracing()]
   });
+} else {
+  console.log("Sentry not enabled as running on Localhost");
 }
 
 const root = document.getElementById("root");

--- a/packages/app/src/client/index.tsx
+++ b/packages/app/src/client/index.tsx
@@ -25,6 +25,7 @@ import App from "./app";
 
 if (!isLocalhost || process.env.OPSTRACE_OVERRIDE_ENABLE_SENTRY === "true") {
   Sentry.init({
+    // todo: this should be passed in as an ENV VAR
     dsn: "https://28a6d713adde403aaaab7c7cc36f0383@o476375.ingest.sentry.io/5529515",
     integrations: [new Integrations.BrowserTracing()]
   });

--- a/packages/app/src/client/serviceWorker.ts
+++ b/packages/app/src/client/serviceWorker.ts
@@ -26,7 +26,7 @@
 // To learn more about the benefits of this model and instructions on how to
 // opt-in, read https://bit.ly/CRA-PWA
 
-const isLocalhost = Boolean(
+export const isLocalhost = Boolean(
   window.location.hostname === "localhost" ||
     // [::1] is the IPv6 localhost address.
     window.location.hostname === "[::1]" ||

--- a/packages/app/src/server/env.ts
+++ b/packages/app/src/server/env.ts
@@ -60,6 +60,12 @@ const REDIS_PASSWORD = isDevEnvironment
   ? parseEnv("REDIS_PASSWORD", String, undefined)
   : parseRequiredEnv("REDIS_PASSWORD", String);
 
+const ENABLE_SENTRY_FOR_LOCALHOST = parseEnv(
+  "ENABLE_SENTRY_FOR_LOCALHOST",
+  String,
+  "false"
+);
+
 const envars = {
   PORT,
   REDIS_HOST,
@@ -71,7 +77,8 @@ const envars = {
   COOKIE_SECRET,
   GRAPHQL_ENDPOINT_HOST,
   GRAPHQL_ENDPOINT_PORT,
-  HASURA_GRAPHQL_ADMIN_SECRET
+  HASURA_GRAPHQL_ADMIN_SECRET,
+  ENABLE_SENTRY_FOR_LOCALHOST
 };
 
 export default envars;

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -26,7 +26,8 @@ import authRequired from "server/middleware/auth";
 
 import graphqlClient from "state/clients/graphqlClient";
 
-import { AUTH0_CONFIG, BUILD_INFO } from "./uicfg";
+import { AUTH0_CONFIG } from "./uicfg";
+import { BUILD_INFO } from "@opstrace/utils";
 
 import * as jwkshelpers from "./jwks";
 

--- a/packages/app/src/server/routes/api/uicfg.ts
+++ b/packages/app/src/server/routes/api/uicfg.ts
@@ -24,8 +24,6 @@ export const AUTH0_CONFIG = {
   auth0_domain: env.AUTH0_DOMAIN
 };
 
-export { BUILD_INFO };
-
 export function pubUiCfgHandler(
   req: Request,
   res: Response,

--- a/packages/app/src/server/server.ts
+++ b/packages/app/src/server/server.ts
@@ -66,10 +66,7 @@ const shutdownDelay: number = isDevEnvironment ? 0 : 30000;
 function createServer() {
   const app = express();
 
-  if (
-    !isDevEnvironment ||
-    process.env.OPSTRACE_OVERRIDE_ENABLE_SENTRY === "true"
-  ) {
+  if (!isDevEnvironment || env.ENABLE_SENTRY_FOR_LOCALHOST === "true") {
     Sentry.init({
       // todo: this should be passed in as an env var, also considere being a different project/dsn to the react client
       dsn: "https://28a6d713adde403aaaab7c7cc36f0383@o476375.ingest.sentry.io/5529515",
@@ -86,6 +83,8 @@ function createServer() {
 
     // The request handler must be the first middleware on the app
     app.use(Sentry.Handlers.requestHandler());
+  } else {
+    log.info("Sentry not enabled as running on Localhost");
   }
 
   app.use(helmet());
@@ -137,6 +136,9 @@ function createServer() {
   //     return;
   //   }
   // });
+
+  // The error handler must be before any other error middleware and after all controllers
+  app.use(Sentry.Handlers.errorHandler());
 
   // apply post api middleware
   app.use(catchErrorsMiddleware);

--- a/packages/app/src/state/opstrace-config/reducer.ts
+++ b/packages/app/src/state/opstrace-config/reducer.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as Sentry from "@sentry/react";
+
 import { createReducer, ActionType } from "typesafe-actions";
 
 import { OpstraceConfig } from "./types";
@@ -29,7 +31,17 @@ export const reducer = createReducer<OpstraceConfig, OpstraceConfigActions>(
   OpstraceConfigInitialState
 ).handleAction(
   actions.updateOpstraceBuildInfo,
-  (state, action): OpstraceConfig => ({
-    buildInfo: action.payload.buildInfo
-  })
+  (state, action): OpstraceConfig => {
+    const { buildInfo } = action.payload;
+
+    Sentry.setTag("opstrace.branch", buildInfo.branch);
+    Sentry.setTag("opstrace.version", buildInfo.version);
+    Sentry.setTag("opstrace.commit", buildInfo.commit);
+    Sentry.setTag("opstrace.build-time", buildInfo.buildTime);
+    Sentry.setTag("opstrace.build-hostname", buildInfo.buildHostname);
+
+    return {
+      buildInfo
+    };
+  }
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3478,6 +3478,17 @@
     "@sentry/utils" "6.2.5"
     tslib "^1.9.3"
 
+"@sentry/core@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.11.0.tgz#40e94043afcf6407a109be26655c77832c64e740"
+  integrity sha512-09TB+f3pqEq8LFahFWHO6I/4DxHo+NcS52OkbWMDqEi6oNZRD7PhPn3i14LfjsYVv3u3AESU8oxSEGbFrr2UjQ==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
 "@sentry/core@6.2.5":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.2.5.tgz#e75093f8598becc0a4a0be927f32f7ac49e8588f"
@@ -3489,6 +3500,15 @@
     "@sentry/utils" "6.2.5"
     tslib "^1.9.3"
 
+"@sentry/hub@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.11.0.tgz#ddf9ddb0577d1c8290dc02c0242d274fe84d6c16"
+  integrity sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==
+  dependencies:
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
 "@sentry/hub@6.2.5":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.2.5.tgz#324cae0c90d736cd1032e94104bf3f18becec4d6"
@@ -3498,6 +3518,15 @@
     "@sentry/utils" "6.2.5"
     tslib "^1.9.3"
 
+"@sentry/minimal@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.11.0.tgz#806d5512658370e40827b3e3663061db708fff33"
+  integrity sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/types" "6.11.0"
+    tslib "^1.9.3"
+
 "@sentry/minimal@6.2.5":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.2.5.tgz#3e963e868bfa68e97581403521fd4e09a8965b02"
@@ -3505,6 +3534,21 @@
   dependencies:
     "@sentry/hub" "6.2.5"
     "@sentry/types" "6.2.5"
+    tslib "^1.9.3"
+
+"@sentry/node@^6.2.5":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.11.0.tgz#62614c18af779373a12311f2fb57a8dde278425a"
+  integrity sha512-vbk+V/n7ZIFD8rHPYy03t/gIG5V7LGdjU4qJxVDgNZzticfWPnd2sLgle/r+l60XF6SKW/epG4rnxnBcgPdWaw==
+  dependencies:
+    "@sentry/core" "6.11.0"
+    "@sentry/hub" "6.11.0"
+    "@sentry/tracing" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
     tslib "^1.9.3"
 
 "@sentry/react@^6.2.5":
@@ -3519,6 +3563,17 @@
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
+"@sentry/tracing@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.11.0.tgz#9bd9287addea1ebc12c75b226f71c7713c0fac4f"
+  integrity sha512-9VA1/SY++WeoMQI4K6n/sYgIdRtCu9NLWqmGqu/5kbOtESYFgAt1DqSyqGCr00ZjQiC2s7tkDkTNZb38K6KytQ==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
 "@sentry/tracing@^6.2.5":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.2.5.tgz#3f5dadfdccdb5c1fb2eef68458c7c34329b0a34a"
@@ -3530,10 +3585,23 @@
     "@sentry/utils" "6.2.5"
     tslib "^1.9.3"
 
+"@sentry/types@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
+  integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
+
 "@sentry/types@6.2.5":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.5.tgz#34b75285b149e0b9bc5fd54fcc2c445d978c7f2e"
   integrity sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w==
+
+"@sentry/utils@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.11.0.tgz#d1dee4faf4d9c42c54bba88d5a66fb96b902a14c"
+  integrity sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==
+  dependencies:
+    "@sentry/types" "6.11.0"
+    tslib "^1.9.3"
 
 "@sentry/utils@6.2.5":
   version "6.2.5"
@@ -15647,6 +15715,11 @@ lru-queue@^0.1.0:
   integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
   dependencies:
     es5-ext "~0.10.2"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 lz-string@^1.4.4:
   version "1.4.4"


### PR DESCRIPTION
Now by default exceptions won't be sent to Sentry from the React app, this can be overriden with an env var. Additionally I've added Sentry exception tracking to the Express server and include BUILD_INFO data in the metadata tags sent from both server and client.