### PR TITLE
ci: upgrade tests: fix cluster name length (broken scheduled build on `main`)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,16 +81,16 @@ steps:
       # Use the Opstrace CLI artifact built from the PR branch to upgrade the
       # cluster.
       OPSTRACE_CLI_VERSION_TO: ${OPSTRACE_PREBUILD_DIR}/build/bin/opstrace
-      OPSTRACE_CLUSTER_NAME: "${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-upgr-g"
-      OPSTRACE_BUILD_DIR: "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-upgr-g"
-      OPSTRACE_ARTIFACT_DIR: "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-upgr-g/bk-artifacts"
+      OPSTRACE_CLUSTER_NAME: "${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug"
+      OPSTRACE_BUILD_DIR: "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug"
+      OPSTRACE_ARTIFACT_DIR: "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug/bk-artifacts"
       OPSTRACE_CLOUD_PROVIDER: "gcp"
       GCLOUD_CLI_REGION: "us-west2"
       GCLOUD_CLI_ZONE: "us-west2-a"
     command:
       - bash ci/check-if-docs-pr.sh || make ci-test-upgrade-run-sh
     artifact_paths:
-      - "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-upgr-g/bk-artifacts/**/*"
+      - "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug/bk-artifacts/**/*"
   - label: "🔨 cleanup /tmp"
     key: "cleanup-tmp"
     depends_on:


### PR DESCRIPTION
```
[2021-08-12T15:08:09Z] 2021-08-12T15:08:09.517Z error: cluster name must not be longer than 23 characters (is: 26)
[2021-08-12T15:08:09Z] 2021-08-12T15:08:09.517Z debug: shut down logger, then exit with code 1
```
https://buildkite.com/opstrace/scheduled-main-builds/builds/2843#0b430bbb-4380-4fd1-b036-90d671f4b570

This did not happen on the PR because the pipeline slug is longer for the scheduled builds.
