### PR TITLE
UI: retry login POST request to /_/auth/session

### DIFF
--- a/packages/app/src/client/components/withSession/index.tsx
+++ b/packages/app/src/client/components/withSession/index.tsx
@@ -262,7 +262,10 @@ const CreateSession = ({
         });
       } catch (err) {
         setLoginErrorString(`could not get access token: ${err.message}`);
-        return;
+        // This like is retryable, and the user is supposed to trigger that via
+        // the LoginError view. Let this blow up to show relevant detail in
+        // console and in Sentry.
+        throw err;
       }
 
       // Note(JP): this request exchanges the Auth0 access token into a session

--- a/packages/app/src/client/components/withSession/index.tsx
+++ b/packages/app/src/client/components/withSession/index.tsx
@@ -279,7 +279,6 @@ const CreateSession = ({
           // re-throw programming errors
           throw err;
         }
-
         if (err.response) {
           // non-2xx responses
           const r = err.response;
@@ -294,7 +293,7 @@ const CreateSession = ({
           // TODO: expose parts of the response body if structured err info is
           // present, in expected format.
           setLoginErrorString(
-            `POST to /_/auth/session got an unexpected response with status ${r.status}`
+            `POST to /_/auth/session got an unexpected response with status code ${r.status}`
           );
           return;
         }

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -158,6 +158,7 @@ function createAuthHandler(): express.Router {
   });
 
   auth.get("/status", (req, res) => {
+    // Note(JP): auth0 config and build info should not really be here.
     res.status(200).json({
       currentUserId: req.session?.userId,
       auth0Config: {
@@ -202,6 +203,8 @@ function createAuthHandler(): express.Router {
 }
 
 const loadUserInfo = async (accessToken: string) => {
+  // Note(JP): perform retrying. This is expected to return a 429 response,
+  // so ideally perform retrying while respecting the retry-after header.
   const { data } = await axios.get(`https://${env.AUTH0_DOMAIN}/userinfo`, {
     headers: {
       Authorization: `Bearer ${accessToken}`


### PR DESCRIPTION
This is to enhance robustness, allowing for auto-healing short transient issues. Also motivated by CI instability #1249.