### PR TITLE
UI: retry GET request to /_/auth/status, consolidate state management around that & collect browser console in test-remote

### DIFF
--- a/packages/app/src/client/components/withSession/index.tsx
+++ b/packages/app/src/client/components/withSession/index.tsx
@@ -98,7 +98,7 @@ type AppState = {
 // TODO: look to switching to using a "context" for passing things to children components
 
 type StatusData = {
-  currentUserId?: string;
+  currentUserId: string | null;
   auth0Config: { domain: string; clientId: string };
   buildInfo: OpstraceBuildInfo;
 };

--- a/packages/app/src/client/components/withSession/index.tsx
+++ b/packages/app/src/client/components/withSession/index.tsx
@@ -67,8 +67,6 @@ import { useDispatch } from "react-redux";
 import { Switch, Route, Redirect } from "react-router";
 import { Auth0Provider, useAuth0 } from "@auth0/auth0-react";
 
-import useAxios from "axios-hooks";
-
 import { setCurrentUser } from "state/user/actions";
 
 import { OpstraceBuildInfo } from "state/opstrace-config/types";
@@ -104,20 +102,44 @@ type StatusData = {
 };
 
 export const WithSession = ({ children }: { children: React.ReactNode }) => {
-  // TODO: need to double check that the UseAxios response doesn't expire and this status check isn't re-run after a while.
+  // Note(Nahum): need to double check that the UseAxios response doesn't expire and this status check isn't re-run after a while.
   // The reason for this is that "loadingStatus" would flip back to true and block the user for accessing the site while the
   // check is occuring. We only want to interrupt the user if their session with Auth0 actually expires - if the session
   // we create expires first it should silently be re-created without the user noticing
-  let [{ data, loading: loadingStatus, error: statusError }] = useAxios({
-    url: "/_/auth/status",
-    method: "GET",
-    withCredentials: true
-  });
-  // terrcin: ugh, don't know how to cast this in the above useAxios with typescript
-  data = data as StatusData;
 
-  // Note(JP): `data` may be undefined, e.g. when receiving a 504 response.
-  // That's not considered by the code below.
+  const [getAuthStateErrorString, setGetAuthStateErrorString] = useState<
+    string | null
+  >(null);
+  const [authState, setAuthState] = useState<StatusData | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const [data, errmsg] = await authStatusRequestWithRetry();
+
+      if (errmsg !== undefined) {
+        setGetAuthStateErrorString(errmsg);
+        return;
+      }
+      // The following check is like an assertion: that has to be a guarantee
+      // provided by `authStatusRequestWithRetry()`. The TS return type of
+      // `authStatusRequestWithRetry()` can probably be tuned to make this
+      // unnecessary.
+      if (data !== undefined) {
+        setAuthState(data);
+        return;
+      }
+
+      throw new Error("authStatusRequestWithRetry() returned [undef, undef]");
+    })();
+  }, [setGetAuthStateErrorString, setAuthState]);
+
+  // let [{ data, loading: loadingStatus, error: statusError }] = useAxios({
+  //   url: "/_/auth/status",
+  //   method: "GET",
+  //   withCredentials: true
+  // });
+  // // terrcin: ugh, don't know how to cast this in the above useAxios with typescript
+  //data = data as StatusData;
 
   const appStateRef = useRef<AppState>({ returnTo: window.location.pathname });
   const dispatch = useDispatch();
@@ -142,33 +164,47 @@ export const WithSession = ({ children }: { children: React.ReactNode }) => {
   );
 
   useEffect(() => {
-    if (data?.currentUserId) {
-      handleUserLoadedSuccess(data.currentUserId);
+    if (authState?.currentUserId) {
+      handleUserLoadedSuccess(authState.currentUserId);
     }
-  }, [handleUserLoadedSuccess, data?.currentUserId]);
+  }, [handleUserLoadedSuccess, authState?.currentUserId]);
 
   useEffect(() => {
-    if (data?.buildInfo) {
-      dispatch(updateOpstraceBuildInfo({ buildInfo: data.buildInfo }));
+    if (authState?.buildInfo) {
+      dispatch(updateOpstraceBuildInfo({ buildInfo: authState.buildInfo }));
     }
-  }, [data?.buildInfo, dispatch]);
+  }, [authState?.buildInfo, dispatch]);
 
   const reloadAppState = (appState: AppState = {}) => {
     appStateRef.current = appState;
   };
-
-  // Note(JP): when `statusError` is truthy then the idea of the axios-hooks
-  // authors is to respond to that error in the UI, not just log to console.
-  if (statusError) console.log("WithSession#statusError:", statusError);
 
   // Note(JP): when `loadingStatus` is truthy then it means that the UI should
   // show that things are currently loading. It does not mean that the request
   // succeeded. In fact, when the request fails with a 504 response then
   // `data.auth0Config` is `undefined` and the Auth0 initializtion below blows
   // up.
-  if (loadingStatus) {
+  if (authState === null && getAuthStateErrorString === null) {
+    // operation iss till in progress
     return <LoadingPage stage="status-check" />;
-  } else if (data?.currentUserId) {
+  }
+
+  if (getAuthStateErrorString !== null) {
+    // Loading current authentication status failed. For now, show the 'login
+    // error' view, offering a 'try again' for login.
+    return <LoginFailedPage errorString={getAuthStateErrorString} />;
+  }
+
+  // Being here means that `authState` is populated (with expected structure).
+  if (authState === null) {
+    // should not not happen, but that's not reflected by types.
+    throw new Error(
+      "programming err: getAuthStateErrorString and authState are both null"
+    );
+  }
+
+  // Handle: authentication state is: user is logged in.
+  if (authState.currentUserId !== null) {
     return (
       <Switch>
         <Route
@@ -177,8 +213,8 @@ export const WithSession = ({ children }: { children: React.ReactNode }) => {
           path="/logout"
           component={() => (
             <Auth0Provider
-              domain={data.auth0Config.domain}
-              clientId={data.auth0Config.clientId}
+              domain={authState.auth0Config.domain}
+              clientId={authState.auth0Config.clientId}
               audience={AUTH0_AUDIENCE}
               redirectUri={loginUrl()}
             >
@@ -190,31 +226,33 @@ export const WithSession = ({ children }: { children: React.ReactNode }) => {
         <Route key="app" path="*" component={() => <>{children}</>} />
       </Switch>
     );
-  } else {
-    return (
-      <Switch>
-        <Route
-          key="/login"
-          path="/login"
-          component={() => (
-            <Auth0Provider
-              domain={data.auth0Config.domain}
-              clientId={data.auth0Config.clientId}
-              audience={AUTH0_AUDIENCE}
-              redirectUri={loginUrl()}
-              onRedirectCallback={reloadAppState}
-            >
-              <DetectUser
-                userLoadedSuccess={handleUserLoadedSuccess}
-                appState={appStateRef.current}
-              />
-            </Auth0Provider>
-          )}
-        />
-        <Redirect from="*" to="/login" />
-      </Switch>
-    );
   }
+
+  // Handle: authentication state is: user is not logged in
+  // (authState.currentUserId is null)
+  return (
+    <Switch>
+      <Route
+        key="/login"
+        path="/login"
+        component={() => (
+          <Auth0Provider
+            domain={authState.auth0Config.domain}
+            clientId={authState.auth0Config.clientId}
+            audience={AUTH0_AUDIENCE}
+            redirectUri={loginUrl()}
+            onRedirectCallback={reloadAppState}
+          >
+            <DetectUser
+              userLoadedSuccess={handleUserLoadedSuccess}
+              appState={appStateRef.current}
+            />
+          </Auth0Provider>
+        )}
+      />
+      <Redirect from="*" to="/login" />
+    </Switch>
+  );
 };
 
 const DetectUser = ({
@@ -340,6 +378,127 @@ const CreateSession = ({
   return <LoadingPage stage="create-session" />;
 };
 
+/**
+ * Perform GET request to /_/auth/status to get current authentication (and
+ * configuration?) state. Perform a little bit of retrying for what appear to
+ * be transient issues. Goal is to quickly heal short network hiccups but to
+ * still fail reasonably fast if those retries didn't help.
+ *
+ * @returns 2-tuple
+ *  [data, errmsg]
+ *    `data` is either undefined or validated to be of type `StatusData`;
+ *    `errmsg` is a string if `data` is `undefined`, otherwise it is `undefined`
+ * @throws: not expected to throw an error
+ */
+async function authStatusRequestWithRetry(): Promise<
+  [StatusData, undefined] | [undefined, string]
+> {
+  // Use a custom retrying config. Do that by creating a local Axios instance
+  // and  then attach the rax logic to it. The outcome is that axios is _not_
+  // affected globally.
+  //
+  // `timeout`: in Axios, `timeout` controls the entire HTTP request (no more
+  // fine-grained control available). Expect the HTTP request handler in web
+  // app to be reasonably fast; it may however need a tiny bit of time for JWKS
+  // (re)fetching. After ~10 seconds we can and should retry.
+  //
+  //`retry`: retry count for requests that return a response.
+  // `noResponseRetries` is for scenarios where request not sent, response not
+  // received.
+  //
+  // Use default for `statusCodesToRetry`: 100-199, 429, 500-599
+  // Retry for POST, which is the only method used here.
+  const httpclient = axios.create({
+    timeout: 5000
+  });
+  httpclient.defaults.raxConfig = {
+    instance: httpclient,
+    retry: 3,
+    noResponseRetries: 3,
+    backoffType: "static",
+    retryDelay: 2000,
+    httpMethodsToRetry: ["GET"],
+    onRetryAttempt: err => {
+      const cfg = rax.getConfig(err);
+      console.log(
+        `GET to /_/auth/status: retry attempt #${
+          cfg!.currentRetryAttempt
+        } after: ${err.message}`
+      );
+    }
+  };
+  rax.attach(httpclient);
+
+  let resp: AxiosResponse<any>;
+  try {
+    resp = await httpclient.request({
+      method: "GET",
+      url: "/_/auth/status",
+      // really required? is that a cross-site request? goal is to send cookies for current context
+      withCredentials: true
+    });
+  } catch (err) {
+    if (!axios.isAxiosError(err)) {
+      // re-throw programming errors
+      throw err;
+    }
+    if (err.response) {
+      // non-2xx responses
+      const r = err.response;
+      return [
+        undefined,
+        `GET /_/auth/status failed: got an unexpected response with status code ${r.status}`
+      ];
+
+      // TODO: expose parts of the response body if structured err info is
+      // present, in expected format.
+    }
+
+    // timeout errors, transient errors etc. maybe even body deserialization
+    // errors when resp headers and body mismatch
+    return [undefined, `GET /_/auth/status failed: ${err.message}`];
+  }
+
+  // When we are here, `resp` should not be `undefined` (rely on axios error
+  // handling to ensure that). Axios does the JSON deserialization for us.
+  // Validate the structure briefly (schema-based validation would be more
+  // rigorous).
+  if (resp.data === undefined) {
+    return [undefined, `GET /_/auth/status failed: response body missing`];
+  }
+
+  // type StatusData = {
+  //   currentUserId?: string;
+  //   auth0Config: { domain: string; clientId: string };
+  //   buildInfo: OpstraceBuildInfo;
+  // };
+  const d = resp.data;
+  for (const p of ["currentUserId", "auth0Config", "buildInfo"]) {
+    if (!(p in d)) {
+      return [
+        undefined,
+        `GET /_/auth/status failed: property '${p}' missing in response structure`
+      ];
+    }
+  }
+  // Data object in response looks good.
+  return [d, undefined];
+}
+
+/**
+ * Perform POST request to /_/auth/session to exchange Auth0 access token into
+ * session secret. Perform a little bit of retrying for what appear to be
+ * transient issues. Goal is to quickly heal short network hiccups but to still
+ * fail reasonably fast if those retries didn't help.
+ *
+ * @param auth0AccessToken
+ * @returns
+ *    axios response upon 2xx HTTP response, no validation on response body
+ * @throws
+ *  - axios errors:
+ *       - when response is available (err response)
+ *       - when no response is available (if retrying didn't heal)
+ */
 async function loginRequestWithRetry(
   auth0AccessToken: string
 ): Promise<AxiosResponse<any>> {

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -164,7 +164,18 @@ function createAuthHandler(): express.Router {
     let uid: string | null;
     uid = null;
     if (req.session !== undefined) {
-      uid = req.session.userId;
+      // may look like this:
+      // session: {
+      //   "cookie": {
+      //     "originalMaxAge": null,
+      //     "expires": null,
+      //     "httpOnly": true,
+      //     "path": "/"
+      //   }
+      // }
+      if (req.session.userId !== undefined) {
+        uid = req.session.userId;
+      }
     }
 
     res.status(200).json({

--- a/packages/app/src/server/routes/api/authentication.ts
+++ b/packages/app/src/server/routes/api/authentication.ts
@@ -158,9 +158,18 @@ function createAuthHandler(): express.Router {
   });
 
   auth.get("/status", (req, res) => {
-    // Note(JP): auth0 config and build info should not really be here.
+    // currentUserId being `null` is the contract for the client to know that
+    // there is no valid authentication state.
+
+    let uid: string | null;
+    uid = null;
+    if (req.session !== undefined) {
+      uid = req.session.userId;
+    }
+
     res.status(200).json({
-      currentUserId: req.session?.userId,
+      currentUserId: uid,
+      // Note(JP): auth0 config and build info should not really be here, hmm...
       auth0Config: {
         domain: AUTH0_CONFIG.auth0_domain,
         clientId: AUTH0_CONFIG.auth0_client_id

--- a/test/browser/Dockerfile
+++ b/test/browser/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.13.0-focal
+FROM mcr.microsoft.com/playwright:v1.13.1-focal
 
 RUN mkdir -p /build/test/browser/test-results
 WORKDIR /build/test/browser

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@playwright/test": "1.13.0",
+    "@playwright/test": "1.13.1",
     "@types/node": "^14.14.7",
     "@types/ramda": "^0.27.38",
     "ramda": "^0.27.1",

--- a/test/test-remote/package.json
+++ b/test/test-remote/package.json
@@ -42,6 +42,7 @@
     "mathjs": "^8.0.1",
     "mocha": "^8.2.1",
     "mustache": "^4.0.0",
+    "playwright": "^1.13.1",
     "prom-client": "^12.0.0",
     "protobufjs": "^6.10.1",
     "snappy": "^6.3.5",

--- a/test/test-remote/test_ui_api.ts
+++ b/test/test-remote/test_ui_api.ts
@@ -250,6 +250,11 @@ async function performLoginFlowWithRetry(browsercontext: BrowserContext) {
       log.info(`wrote browser console content to to ${fp}`);
     }
 
+    const consoleText = consoleLines.join("\n");
+    const fp = artipath(`browser-console-after-login-success.log`);
+    fs.writeFileSync(fp, consoleText, { encoding: "utf-8" });
+    log.info(`wrote browser console content to to ${fp}`);
+
     log.info("try again in 10 s");
     await sleep(20);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3252,10 +3252,10 @@
   resolved "https://registry.yarnpkg.com/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"
   integrity sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==
 
-"@playwright/test@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.13.0.tgz#d22fa9f02c17758f7cb6178be3e22462c4357582"
-  integrity sha512-pT9GTQ1eaxdxycnGg4ZANxGZsu4bzN6M8eRzcDxTprJUWZDBqZknGImOFKMRkHB+YhS8UJRuJ6YpPfZaNL2RLw==
+"@playwright/test@1.13.1":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.13.1.tgz#a040020d81227cf33fbe71b918578ed3b6e5bc8c"
+  integrity sha512-i8se6FK65hdbTzGMWnvPEaFoCh7DQ0XLKmaf2rWnh+ufhn4Ad/1jhdK8c6s4Mo87veTfd6N60fKCAWjyhbHyCg==
   dependencies:
     "@babel/code-frame" "^7.12.13"
     "@babel/core" "^7.14.0"
@@ -17687,6 +17687,26 @@ pkg@^5.3.1:
     resolve "^1.20.0"
     stream-meter "^1.0.4"
     tslib "2.1.0"
+
+playwright@^1.13.1:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.14.0.tgz#18301b11f5278a446d36b5cf96f67db36ce2cd20"
+  integrity sha512-aR5oZ1iVsjQkGfYCjgYAmyMAVu0MQ0i8MgdnfdqDu9EVLfbnpuuFmTv/Rb7/Yjno1kOrDUP9+RyNC+zfG3wozA==
+  dependencies:
+    commander "^6.1.0"
+    debug "^4.1.1"
+    extract-zip "^2.0.1"
+    https-proxy-agent "^5.0.0"
+    jpeg-js "^0.4.2"
+    mime "^2.4.6"
+    pngjs "^5.0.0"
+    progress "^2.0.3"
+    proper-lockfile "^4.1.1"
+    proxy-from-env "^1.1.0"
+    rimraf "^3.0.2"
+    stack-utils "^2.0.3"
+    ws "^7.4.6"
+    yazl "^2.5.1"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
See commit messages and code comments (also those code comments that are being removed).

I tested the retrying logic locally by injecting failures here and there.