### PR TITLE
ci: push/pull CI container image.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
       - docker ps
       - bash ci/fetch-main.sh
       - echo "--- make rebuild-ci-container-image"
-      - make fetch-secrets && set-dockerhub-credentials && rebuild-ci-container-image && make push-ci-container-image
+      - make fetch-secrets && make set-dockerhub-credentials && rebuild-ci-container-image && make push-ci-container-image
       - make ci-preamble
     artifact_paths:
       - "${OPSTRACE_PREBUILD_DIR}/bk-artifacts/preamble/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
       - docker ps
       - bash ci/fetch-main.sh
       - echo "--- make rebuild-ci-container-image"
-      - make fetch-secrets && make set-dockerhub-credentials && make rebuild-ci-container-image
+      - make rebuild-ci-container-image
       - make ci-preamble
     artifact_paths:
       - "${OPSTRACE_PREBUILD_DIR}/bk-artifacts/preamble/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
       - docker ps
       - bash ci/fetch-main.sh
       - echo "--- make rebuild-ci-container-image"
-      - make rebuild-ci-container-image
+      - make rebuild-ci-container-image && make push-ci-container-image
       - make ci-preamble
     artifact_paths:
       - "${OPSTRACE_PREBUILD_DIR}/bk-artifacts/preamble/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
       - docker ps
       - bash ci/fetch-main.sh
       - echo "--- make rebuild-ci-container-image"
-      - make fetch-secrets && make set-dockerhub-credentials && make rebuild-ci-container-image && make push-ci-container-image
+      - make fetch-secrets && make set-dockerhub-credentials && make rebuild-ci-container-image
       - make ci-preamble
     artifact_paths:
       - "${OPSTRACE_PREBUILD_DIR}/bk-artifacts/preamble/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
       - docker ps
       - bash ci/fetch-main.sh
       - echo "--- make rebuild-ci-container-image"
-      - make rebuild-ci-container-image && make push-ci-container-image
+      - make fetch-secrets && set-dockerhub-credentials && rebuild-ci-container-image && make push-ci-container-image
       - make ci-preamble
     artifact_paths:
       - "${OPSTRACE_PREBUILD_DIR}/bk-artifacts/preamble/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
       - docker ps
       - bash ci/fetch-main.sh
       - echo "--- make rebuild-ci-container-image"
-      - make fetch-secrets && make set-dockerhub-credentials && rebuild-ci-container-image && make push-ci-container-image
+      - make fetch-secrets && make set-dockerhub-credentials && make rebuild-ci-container-image && make push-ci-container-image
       - make ci-preamble
     artifact_paths:
       - "${OPSTRACE_PREBUILD_DIR}/bk-artifacts/preamble/**/*"

--- a/ci/preamble.sh
+++ b/ci/preamble.sh
@@ -23,6 +23,11 @@ echo "--- current working directory: $(pwd)"
 make fetch-secrets
 make set-dockerhub-credentials
 
+# Note(JP): I wanted to do this before entering the CI container but
+# struggled with setting up Docker credentials.
+# See https://github.com/opstrace/opstrace/pull/1285#issuecomment-899727121
+make push-ci-container-image
+
 echo "--- lint docs: quick feedback"
 make lint-docs
 

--- a/ci/preamble.sh
+++ b/ci/preamble.sh
@@ -136,7 +136,7 @@ mv packages/app/package.json packages/app/package.json.deactivated
 mv test/test-remote/package.json test/test-remote/package.json.deactivated
 #mv test/test-remote/looker/package.json test/test-remote/looker/package.json.deactivated
 mv test/browser/package.json test/browser/package.json.deactivated
-mv packages/controller/package.json packages/controller/package.json.deactivated
+#mv packages/controller/package.json packages/controller/package.json.deactivated
 
 yarn --frozen-lockfile --ignore-optional &> preamble_yarn_install.outerr.log < /dev/null &
 YARN_PID="$!"

--- a/ci/preamble.sh
+++ b/ci/preamble.sh
@@ -23,6 +23,7 @@ echo "--- current working directory: $(pwd)"
 make fetch-secrets
 make set-dockerhub-credentials
 
+echo "--- make push-ci-container-image"
 # Note(JP): I wanted to do this before entering the CI container but
 # struggled with setting up Docker credentials.
 # See https://github.com/opstrace/opstrace/pull/1285#issuecomment-899727121
@@ -30,7 +31,6 @@ make push-ci-container-image
 
 echo "--- lint docs: quick feedback"
 make lint-docs
-
 
 # If this is a docs-only change: skip the rest of the preamble, move on to the
 # next build step in the BK pipeline which allows for a
@@ -132,10 +132,13 @@ echo "--- start in background: yarn --frozen-lockfile"
 # This is expected to cut 1.5 minutes from the preamble which is more than 20 %
 # of the preamble runtime when nothing in packages/app changed (i.e. when the
 # container image is not rebuilt).
-#mv packages/app/package.json packages/app/package.json.deactivated
-rm -rf packages/app
-yarn --frozen-lockfile --ignore-optional \
-    &> preamble_yarn_install.outerr.log < /dev/null &
+mv packages/app/package.json packages/app/package.json.deactivated
+mv test/test-remote/package.json test/test-remote/package.json.deactivated
+mv test/test-remote/looker/package.json test/test-remote/looker/package.json.deactivated
+mv test/browser/package.json test/browser/package.json.deactivated
+mv packages/controller/package.json packages/controller/package.json.deactivated
+
+yarn --frozen-lockfile --ignore-optional &> preamble_yarn_install.outerr.log < /dev/null &
 YARN_PID="$!"
 sleep 1 # so that the xtrace output is in this build log section
 
@@ -193,7 +196,6 @@ fi
 set -e
 
 
-
 echo "--- wait for background process: make lint-codebase"
 set +e
 wait $LINT_CODEBASE_PID
@@ -205,7 +207,6 @@ if [[ $LINT_CODEBASE_PID != "0" ]]; then
     echo "make lint-codebase failed, exit 1"
     exit 1
 fi
-
 
 
 echo "--- make cli-pkg (for linux and mac)"

--- a/ci/preamble.sh
+++ b/ci/preamble.sh
@@ -134,7 +134,7 @@ echo "--- start in background: yarn --frozen-lockfile"
 # container image is not rebuilt).
 mv packages/app/package.json packages/app/package.json.deactivated
 mv test/test-remote/package.json test/test-remote/package.json.deactivated
-mv test/test-remote/looker/package.json test/test-remote/looker/package.json.deactivated
+#mv test/test-remote/looker/package.json test/test-remote/looker/package.json.deactivated
 mv test/browser/package.json test/browser/package.json.deactivated
 mv packages/controller/package.json packages/controller/package.json.deactivated
 


### PR DESCRIPTION
So far the CI container image was never pushed to docker hub.

It was bound to the lifetime of the VM / disk.

Sometimes, a build finds empty / fresh state (fresh disk) and then the CI container image needs to be built from scratch. This takes a few minutes. Can reduce the duration of that process by pulling in some image layers stored on docker hub. (the last N layers need to be built and pushed for each build, and that's at the _con_ side of this change -- let's monitor the impact).
