### PR TITLE
test-remote: Check that alerts configs exist before sending delete requests

### DIFF
--- a/test/test-remote/test_alerts.ts
+++ b/test/test-remote/test_alerts.ts
@@ -288,7 +288,7 @@ async function deleteE2EAlertsConfig(
     logHTTPResponse(alertmanagerDeleteResponse);
     assert(
       alertmanagerDeleteResponse.statusCode == 202 ||
-      alertmanagerDeleteResponse.statusCode == 200
+        alertmanagerDeleteResponse.statusCode == 200
     );
     deletesOccurred = true;
   }
@@ -505,14 +505,8 @@ suite("End-to-end alert tests", function () {
 
     // Clean up both tenants
     log.info("Deleting E2E alerts webhooks");
-    await deleteE2EAlertsConfig(
-      TENANT_DEFAULT_API_TOKEN_FILEPATH,
-      "default"
-    );
-    await deleteE2EAlertsConfig(
-      TENANT_SYSTEM_API_TOKEN_FILEPATH,
-      "system"
-    );
+    await deleteE2EAlertsConfig(TENANT_DEFAULT_API_TOKEN_FILEPATH, "default");
+    await deleteE2EAlertsConfig(TENANT_SYSTEM_API_TOKEN_FILEPATH, "system");
     // Don't worry about sleep()ing here since we aren't going to set a new config right away.
 
     log.info("Deleting E2E alerting resources");

--- a/test/test-remote/test_alerts.ts
+++ b/test/test-remote/test_alerts.ts
@@ -349,7 +349,7 @@ async function getE2EAlertCountMetric(
   const value = resultArray[0]["value"][1];
 
   // debug-log for 0 to reduce verbosity
-  if (value === 0) {
+  if (value == 0) {
     log.debug(`Got alert count value: ${value}`);
   } else {
     log.info(`Got alert count value: ${value}`);
@@ -453,7 +453,7 @@ suite("End-to-end alert tests", function () {
     // Before deploying anything, delete any existing alertmanager/rulegroup configuration.
     // This avoids an old alert config writing to the newly deployed webhook, making its hit count 1 when we expect 0
     // This should only be a problem when running the same test repeatedly against a cluster.
-    log.info(`Deleting any preexisting E2E alerts webhooks`);
+    log.info("Deleting any preexisting E2E alerts webhooks");
     const deletedDefault = await deleteE2EAlertsConfig(
       TENANT_DEFAULT_API_TOKEN_FILEPATH,
       "default"
@@ -467,7 +467,7 @@ suite("End-to-end alert tests", function () {
     // See also: https://github.com/opstrace/opstrace/issues/1130
     if (deletedDefault || deletedSystem) {
       log.info("Waiting 15s after configs were deleted");
-      sleep(15.0);
+      await sleep(15.0);
     } else {
       log.info("Continuing immediately after no configs needed to be deleted");
     }


### PR DESCRIPTION
MIGHT be a workaround for #1130, where there may be a race condition between deleting an alerts config followed immediately by setting it.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
