### PR TITLE
chore: add a label sync tools

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
-documentation:
+"area: docs":
 - any: ['docs/**/*']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.LABELER_TOKEN }}"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,25 +22,25 @@ module.exports = {
       2,
       "always",
       [
-        "ui", // use `ui: ` for changes to client, and `ui: app:` for changes to server
         "alerts", // use `alerts: ` for changes to alert rules, definitions, thresholds, etc.
         "bump", // third-party lib/component bump (can be big, including Cortex, ...)
         "chore", // small routine tasks, very localized refactors
         "ci", // change to automated CI pipeline
         "cli", // change to the cluster management CLI (create, destroy, ..., )
-        "cortex", // change to cortex (config change for example)
-        "go", // change to golang modules/projects (unit test setup, makefile, etc)
-        "ddapi", // change to dd api project
         "controller", // change in the k8s controller CLI
+        "cortex", // change to cortex (config change for example)
         "dashboards", // change to Grafana dashboards
+        "ddapi", // change to dd api project
         "docs", // any documentation change
-        "looker", // change to looker project
+        "go", // change to golang modules/projects (unit test setup, makefile, etc)
         "loki", // change to loki (config change for example)
+        "looker", // change to looker project
         "makefile", // change in main Makefile
         "revert", // specifically for a git revert commit
         "systemlogs", // change in opstrace system log arch/implementation
         "test-browser", // any change for the test-browser test suite
         "test-remote", // change in test-remote project
+        "ui", // use `ui: ` for changes to client, and `ui: app:` for changes to server
         "wip" // work in progress, later to be edited/squashed ("i don't want to think about choosing the right prefix now!")
       ]
     ]

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -23,6 +23,7 @@ module.exports = {
       "always",
       [
         "ui", // use `ui: ` for changes to client, and `ui: app:` for changes to server
+        "alerts", // use `alerts: ` for changes to alert rules, definitions, thresholds, etc.
         "bump", // third-party lib/component bump (can be big, including Cortex, ...)
         "chore", // small routine tasks, very localized refactors
         "ci", // change to automated CI pipeline

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@redux-saga/types": "^1.1.0",
+    "@types/js-yaml": "^3.12.5",
     "@types/node": "^16.6.1",
     "@types/source-map-support": "^0.5.4",
-    "@types/js-yaml": "^3.12.5",
     "@types/yup": "^0.28.3",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
@@ -50,6 +50,8 @@
     "wsrun": "^5.2.4"
   },
   "dependencies": {
+    "@types/js-yaml": "^3.12.5",
+    "github-label-sync": "^2.0.2",
     "typesafe-actions": "^5.1.0"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -28,14 +28,15 @@
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
     "babel-eslint": "^10.1.0",
-    "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-flowtype": "^5.9.0",
     "eslint-plugin-import": "^2.24.0",
     "eslint-plugin-jsx-a11y": "6.x",
-    "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "4.x",
+    "eslint-plugin-react": "^7.24.0",
+    "eslint": "^7.32.0",
+    "github-label-sync": "^2.0.2",
     "husky": "^4.3.0",
     "istanbul-reports": "^3.0.2",
     "lint-staged": "^10.5.3",
@@ -50,8 +51,6 @@
     "wsrun": "^5.2.4"
   },
   "dependencies": {
-    "@types/js-yaml": "^3.12.5",
-    "github-label-sync": "^2.0.2",
     "typesafe-actions": "^5.1.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,6 +2159,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@financial-times/origami-service-makefile@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@financial-times/origami-service-makefile/-/origami-service-makefile-7.0.3.tgz#96a9913a2e79d7fc4c02b1a6c359d20d94b46a37"
+  integrity sha512-aKe65sZ3XgZ/0Sm0MDLbGrcO3G4DRv/bVW4Gpmw68cRZV9IBE7h/pwfR3Rs7njNSZMFkjS4rPG/YySv9brQByA==
+
 "@google-cloud/common@^3.0.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-3.6.0.tgz#c2f6da5f79279a4a9ac7c71fc02d582beab98e8b"
@@ -6620,6 +6625,11 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+array-uniq@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.2.tgz#5fcc373920775723cfd64d65c64bef53bf9eba6d"
+  integrity sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0=
+
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
@@ -7523,7 +7533,7 @@ block-stream2@^2.0.0:
   dependencies:
     readable-stream "^3.4.0"
 
-bluebird@^3.3.5, bluebird@^3.5.1, bluebird@^3.5.5, bluebird@^3.7.2:
+bluebird@^3.3.5, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -8119,7 +8129,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.1:
+chalk@^4, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -8542,7 +8552,7 @@ commander@^5.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
-commander@^6.1.0, commander@^6.2.0:
+commander@^6.1.0, commander@^6.2.0, commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -11981,6 +11991,19 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
+github-label-sync@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/github-label-sync/-/github-label-sync-2.0.2.tgz#0e4ca68393fdbb682924b8f9294528e9b8ab73e6"
+  integrity sha512-xDxlGG6s9LVfMNQexatne0bMUrwyYyTma9cC04b82zbEMFoy8rxSlag4eUYYF++ThMxvJp577Wk+uAv0mjRsNg==
+  dependencies:
+    "@financial-times/origami-service-makefile" "^7.0.3"
+    chalk "^4"
+    commander "^6.2.1"
+    got "^11.8.2"
+    js-yaml "^3.14.1"
+    node.extend "^2.0.2"
+    octonode "^0.10.2"
+
 glamor@^2.20.40:
   version "2.20.40"
   resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.40.tgz#f606660357b7cf18dface731ad1a2cfa93817f05"
@@ -14714,7 +14737,7 @@ js-yaml@4.0.0, js-yaml@^4.0.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.12.1, js-yaml@^3.13.1, js-yaml@^3.14.0:
+js-yaml@^3.12.1, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -16723,6 +16746,14 @@ node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
 
+node.extend@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node.extend/-/node.extend-2.0.2.tgz#b4404525494acc99740f3703c496b7d5182cc6cc"
+  integrity sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==
+  dependencies:
+    has "^1.0.3"
+    is "^3.2.1"
+
 nodemon-webpack-plugin@^4.3.2:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/nodemon-webpack-plugin/-/nodemon-webpack-plugin-4.4.4.tgz#57d2fa517bd4bb3cd080cebdeec06ec0f5b2b69e"
@@ -17041,6 +17072,16 @@ obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+
+octonode@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/octonode/-/octonode-0.10.2.tgz#2b773866f44f03a2c544741d9b0df2d2c1b4f0cf"
+  integrity sha512-lxKJxAvrw3BuM0Wu3A/TRyFkYxMFWbMm8p7fDO3EoG9KDgOy53d91bjlGR1mmNk1EoF5LjGBx7BmIB+PfmMKLQ==
+  dependencies:
+    bluebird "^3.5.0"
+    deep-extend "^0.6.0"
+    randomstring "^1.1.5"
+    request "^2.72.0"
 
 oidc-token-hash@^5.0.1:
   version "5.0.1"
@@ -19011,6 +19052,11 @@ random-bytes@~1.0.0:
   resolved "https://registry.yarnpkg.com/random-bytes/-/random-bytes-1.0.0.tgz#4f68a1dc0ae58bd3fb95848c30324db75d64360b"
   integrity sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=
 
+randombytes@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.3.tgz#674c99760901c3c4112771a31e521dc349cc09ec"
+  integrity sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew=
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -19025,6 +19071,14 @@ randomfill@^1.0.3:
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
+
+randomstring@^1.1.5:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/randomstring/-/randomstring-1.2.1.tgz#71cd3cda24ad1b7e0b65286b3aa5c10853019349"
+  integrity sha512-eMnfell9XuU3jfCx3f4xCaFAt0YMFPZhx9R3PSStmLarDKg5j5vivqKhf/8pvG+VX/YkxsckHK/VPUrKa5V07A==
+  dependencies:
+    array-uniq "1.0.2"
+    randombytes "2.0.3"
 
 range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
@@ -20020,7 +20074,7 @@ request-promise-native@^1.0.5, request-promise-native@^1.0.8:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@2.88.2, request@^2.88.0, request@^2.88.2:
+request@2.88.2, request@^2.72.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
Following instructions from here:  https://github.com/opstrace/opstrace/blob/b00d2a20701f2455f1340bb1b23a5de9b85011ca/ci/github-issue-labels.md

* [x] A label config file change is proposed with a pull request and discussed among us
* [x] As part of the pull request we show the dry run output.
* [ ] After merge, we run the actual sync and update the PR with the output.

```
$ ./node_modules/.bin/github-label-sync  --dry-run --labels opstrace-labels.yaml opstrace/opstrace
zsh: no such file or directory: ./node_modules/.bin/github-label-sync

$ yarn add -W github-label-sync
...
success Saved lockfile.
success Saved 6 new dependencies.
info Direct dependencies
└─ github-label-sync@2.0.2
info All dependencies
├─ @financial-times/origami-service-makefile@7.0.3
├─ array-uniq@1.0.2
├─ github-label-sync@2.0.2
├─ node.extend@2.0.2
├─ octonode@0.10.2
└─ randomstring@1.2.1
Done in 29.64s.

$ ./node_modules/.bin/github-label-sync  --dry-run --labels opstrace-labels.yaml opstrace/opstrace
No labels were found in /home/ubuntu/opstrace/opstrace-labels.yaml

$ ./node_modules/.bin/github-label-sync  --dry-run --labels ci/github-issue-labels.yaml opstrace/opstrace
No labels were found in /home/ubuntu/opstrace/ci/github-issue-labels.yaml

$ wc -l /home/ubuntu/opstrace/ci/github-issue-labels.yaml
147 /home/ubuntu/opstrace/ci/github-issue-labels.yaml
```

¯\\_(ツ)_/¯ 