### PR TITLE
github issue labels: update codetree-related labels, add `area: system-monitoring`

### DIFF
--- a/ci/github-issue-labels.yaml
+++ b/ci/github-issue-labels.yaml
@@ -72,34 +72,42 @@
   color: "d4c5f9"
   aliases: ["area: ui"]
   description: ""
+
 - name: "area: cli"
   color: "d4c5f9"
   aliases: []
   description: ""
-- name: "area: test-remote"
+
+- name: "area: test suites"
   color: "d4c5f9"
-  aliases: []
-  description: ""
+  aliases: ["area: test-remote", "area: test-browser"]
+  description: "test-remote, test-browser, looker, etc"
+
 - name: "area: installer"
   color: "d4c5f9"
   aliases: []
   description: ""
+
 - name: "area: uninstaller"
   color: "d4c5f9"
   aliases: []
   description: ""
+
 - name: "area: controller"
   color: "d4c5f9"
   aliases: []
   description: ""
+
 - name: "area: dns-service"
   color: "d4c5f9"
   aliases: []
   description: "task/issue related to our DNS service, but also DNS service client in CLI"
+
 - name: "area: ci"
   color: "d4c5f9"
   aliases: []
   description: ""
+
 - name: "area: docs"
   color: "d4c5f9"
   aliases: []

--- a/ci/github-issue-labels.yaml
+++ b/ci/github-issue-labels.yaml
@@ -133,16 +133,17 @@
   aliases: []
   description: "a specific question (from inside or outside)"
 
-# grey for state dddddd
-# Will need to see how/if we manage state in this repo (with codetree?)
+# grey for state/status (dddddd)
+# Includes labels 'backlog', 'in progress' and 'codetree-epic' 
+# for use by Codetree.
 
 - name: "backlog"
   color: "dddddd"
-  aliases: ["state: backlog"]
+  aliases: []
   description: "state (used by codetree)"
 - name: "in progress"
   color: "dddddd"
-  aliases: ["state: in-progress"]
+  aliases: []
   description: "state (used by codetree)"
 - name: "codetree-epic"
   color: "dddddd"

--- a/ci/github-issue-labels.yaml
+++ b/ci/github-issue-labels.yaml
@@ -73,6 +73,11 @@
   aliases: ["area: ui"]
   description: ""
 
+- name: "area: system-monitoring"
+  color: "d4c5f9"
+  aliases: []
+  description: "task/issue related to system monitoring including alerts and dashboards"
+
 - name: "area: cli"
   color: "d4c5f9"
   aliases: []

--- a/ci/github-issue-labels.yaml
+++ b/ci/github-issue-labels.yaml
@@ -144,7 +144,10 @@
   color: "dddddd"
   aliases: ["state: in-progress"]
   description: "state (used by codetree)"
-
+- name: "codetree-epic"
+  color: "dddddd"
+  aliases: []
+  description: ""
 - name: "state: wontdo"
   color: "dddddd"
   aliases: []


### PR DESCRIPTION
Trying to help with https://github.com/opstrace/opstrace/pull/1300.

See individual commit messages.

Instead of "add a labels area for alerts" I propose to add one for system monitoring so that this also includes dashboards etc.