### PR TITLE
looker: log series with synthetic time source coupled to wall time (part 2)

### DIFF
--- a/ci/invoke-looker.sh
+++ b/ci/invoke-looker.sh
@@ -45,6 +45,7 @@ docker run ${COMMON_ARGS} looker \
     --n-chars-per-msg 100 \
     --stream-write-n-fragments 15 \
     --n-cycles 3 \
+    --log-start-time="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     > looker-${TSTRING}.log 2>&1
 cat looker-${TSTRING}.log | tail -n 10
 
@@ -60,6 +61,7 @@ docker run ${COMMON_ARGS} looker \
     --stream-write-n-seconds 10 \
     --n-cycles 5 \
     --change-streams-every-n-cycles 3 \
+    --log-start-time="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     > looker-${TSTRING}.log 2>&1
 cat looker-${TSTRING}.log | tail -n 10
 
@@ -74,6 +76,7 @@ docker run ${COMMON_ARGS} looker \
     --n-chars-per-msg 100 \
     --stream-write-n-fragments 10 \
     --max-concurrent-writes 2  \
+    --log-start-time="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     > looker-${TSTRING}.log 2>&1
 cat looker-${TSTRING}.log | tail -n 10
 
@@ -88,6 +91,7 @@ docker run ${COMMON_ARGS} looker \
     --n-chars-per-msg 100 \
     --stream-write-n-seconds 10 \
     --stream-write-n-seconds-jitter 5 \
+    --log-start-time="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     > looker-${TSTRING}.log 2>&1
 cat looker-${TSTRING}.log | tail -n 10
 
@@ -103,6 +107,7 @@ docker run ${COMMON_ARGS} looker \
     --n-fragments-per-push-message 2 \
     --n-chars-per-msg 100 \
     --max-concurrent-reads 2 \
+    --log-start-time="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     --stream-write-n-seconds 10 \
     > looker-${TSTRING}.log 2>&1
 cat looker-${TSTRING}.log | tail -n 10

--- a/test/test-remote/README.md
+++ b/test/test-remote/README.md
@@ -30,6 +30,8 @@ For example, a change to `test/test-remote/package.json` must be followed by reb
 
 This section explains how to run the (modified) test code directly on your machine within an uncontainerized NodeJS runtime (this is how I started building the test runner and this is how I make bigger changes to it).
 
+Note: prepare your shell environment via the `Environment setup` section below.
+
 Enter the `test-remote` NPM package directory:
 
 ```bash
@@ -67,6 +69,40 @@ yarn run mocha --grep 'short'
 Also see [Mocha command line interface docs](https://mochajs.org/#command-line-usage).
 
 For 'proper' auto-formatting of code, use VSCode with the ESLint extension and use the default settings, in particular `eslint.codeActionsOnSave.mode` set to `all`.
+
+### Environment setup
+
+Enter Opstrace repo root dir, e.g.:
+
+
+```text
+cd ~/dev/opstrace
+```
+
+Then do
+
+```text
+make set-build-info-constants
+export OPSTRACE_BUILDINFO_PATH="$(pwd)/buildinfo.json"
+```
+
+Then set details of Opstrace instance to test against:
+
+```text
+export OPSTRACE_CLUSTER_NAME=<opstrace-instance-name>
+export OPSTRACE_CLOUD_PROVIDER=<aws or gcp>
+export TENANT_DEFAULT_API_TOKEN_FILEPATH=<p>
+export TENANT_SYSTEM_API_TOKEN_FILEPATH=<p>
+```
+
+Generate kubectl config:
+
+```text
+make kconfig
+```
+
+Now `cd test/test-remote` and follow the commands above.
+
 
 ## Notes
 

--- a/test/test-remote/looker/package.json
+++ b/test/test-remote/looker/package.json
@@ -24,6 +24,7 @@
     "@js-joda/core": "^3.1.0",
     "argparse": "^2.0.1",
     "await-semaphore": "^0.1.3",
+    "denque": "^2.0.0",
     "express": "^4.17.1",
     "get-port": "^5.1.1",
     "got": "11.8.2",

--- a/test/test-remote/looker/package.json
+++ b/test/test-remote/looker/package.json
@@ -6,7 +6,7 @@
   "author": "Dr. Jan-Philip Gehrcke / Opstrace Inc",
   "license": "",
   "devDependencies": {
-    "@types/argparse": "^2.0.5",
+    "@types/argparse": "^2.0.10",
     "@types/express": "^4.17.6",
     "@types/http-terminator": "^2.0.0",
     "@types/jsonwebtoken": "^8.5.0",

--- a/test/test-remote/looker/src/args.ts
+++ b/test/test-remote/looker/src/args.ts
@@ -20,15 +20,11 @@ import { strict as assert } from "assert";
 import { ArgumentParser } from "argparse";
 import { ZonedDateTime } from "@js-joda/core";
 
-import { rndstring, timestampToRFC3339Nano } from "./util";
+import { rndstring } from "./util";
 
 import { log, buildLogger, setLogger } from "./log";
 
-import {
-  DEFAULT_LOG_LEVEL_STDERR,
-  START_TIME_JODA
-  //WALLTIME_COUPLING_PARAMS
-} from "./index";
+import { DEFAULT_LOG_LEVEL_STDERR } from "./index";
 
 interface CfgInterface {
   n_concurrent_streams: number;
@@ -185,7 +181,8 @@ export function parseCmdlineArgs(): void {
       "ISO 8601 / RFC3339Nano (tz-aware) notation, example: " +
       "2020-02-20T17:46:37.27000000Z. Note that across cycles the same " +
       "start time is used",
-    type: "str"
+    type: "str",
+    default: ""
   });
 
   parser.add_argument("--log-time-increment-ns", {
@@ -393,16 +390,11 @@ export function parseCmdlineArgs(): void {
     CFG.invocation_id = uniqueInvocationId;
   }
 
-  if (CFG.log_start_time) {
+  if (CFG.log_start_time !== "") {
     // validate input, let this blow up for now if input is invalid
     ZonedDateTime.parse(CFG.log_start_time);
     // In metrics mode, don't support this feature
     assert(!CFG.metrics_mode);
-  } else {
-    // Set default for log stream starttime: program invocation time.
-    // Note: in metrics mode, this is never used; alway use the current
-    // wall time upon DummyStream object initialization.
-    CFG.log_start_time = timestampToRFC3339Nano(START_TIME_JODA);
   }
 
   if (CFG.stream_write_n_seconds !== 0) {

--- a/test/test-remote/looker/src/args.ts
+++ b/test/test-remote/looker/src/args.ts
@@ -383,9 +383,8 @@ export function parseCmdlineArgs(): void {
   );
 
   if (CFG.invocation_id === "") {
-    // common case: the id was not specified manually, so generate one
-    // ensure it has a good amount of randomness to ensure reads are unique (if enabled)
-    // const uniqueInvocationId = `looker-${START_TIME_EPOCH}-${rndstring(10)}`;
+    // Generate invocation ID. For long-running test scenarios where individual
+    // lookers are started at high rate this should not create collisions.
     const uniqueInvocationId = `looker-${rndstring(10)}`;
     CFG.invocation_id = uniqueInvocationId;
   }

--- a/test/test-remote/looker/src/args.ts
+++ b/test/test-remote/looker/src/args.ts
@@ -178,8 +178,8 @@ export function parseCmdlineArgs(): void {
       "log streams. Does not apply in metrics mode. Is useful when " +
       "writing to Loki that is configured to allow ingesting log samples " +
       "far from the past or future. Must be provided in " +
-      "ISO 8601 / RFC3339Nano (tz-aware) notation, example: " +
-      "2020-02-20T17:46:37.27000000Z. Note that across cycles the same " +
+      "RFC3339 notation. Use for example " +
+      'date -u +"%Y-%m-%dT%H:%M:%SZ". Note that across cycles the same ' +
       "start time is used",
     type: "str",
     default: ""

--- a/test/test-remote/looker/src/args.ts
+++ b/test/test-remote/looker/src/args.ts
@@ -178,8 +178,7 @@ export function parseCmdlineArgs(): void {
       "log streams. Does not apply in metrics mode. Is useful when " +
       "writing to Loki that is configured to allow ingesting log samples " +
       "far from the past or future. Must be provided in " +
-      "RFC3339 notation. Use for example " +
-      `date -u +"%Y-%m-%dT%H:%M:%SZ". Note that across cycles the same ` +
+      "RFC3339 notation. Note that across cycles the same " +
       "start time is used",
     type: "str",
     default: ""

--- a/test/test-remote/looker/src/args.ts
+++ b/test/test-remote/looker/src/args.ts
@@ -129,11 +129,14 @@ export function parseCmdlineArgs(): void {
   // mode w.r.t. walltime coupling.
   parser.add_argument("--log-start-time", {
     help:
-      "Timestamp of the first sample for all synthetic " +
-      "log streams." +
-      "ISO 8601 / RFC3339Nano (tz-aware), example: 2020-02-20T17:46:37.27000000Z. " +
-      "Default: invocation time. Does not apply in metrics mode " +
-      "(which is always guided by the current wall time)",
+      "This disables the loose coupling of synthetic time to wall time " +
+      "and defines the timestamp of the first sample for all synthetic " +
+      "log streams. Does not apply in metrics mode. Is useful when " +
+      "writing to Loki that is configured to allow ingesting log samples " +
+      "far from the past or future. Must be provided in " +
+      "ISO 8601 / RFC3339Nano (tz-aware) notation, example: " +
+      "2020-02-20T17:46:37.27000000Z. Note that across cycles the same " +
+      "start time is used",
     type: "str"
   });
 

--- a/test/test-remote/looker/src/args.ts
+++ b/test/test-remote/looker/src/args.ts
@@ -17,7 +17,7 @@
 import fs from "fs";
 import { strict as assert } from "assert";
 
-import argparse from "argparse";
+import { ArgumentParser } from "argparse";
 import { ZonedDateTime } from "@js-joda/core";
 
 import { rndstring, timestampToRFC3339Nano } from "./util";
@@ -66,9 +66,57 @@ interface CfgInterface {
 export let CFG: CfgInterface;
 export let BEARER_TOKEN: undefined | string;
 
+// Formatter with support of `\n` in Help texts.
+// class HelpFormatter extends RawDescriptionHelpFormatter {
+//   // executes parent _split_lines for each line of the help, then flattens the result
+//   _split_lines(text: string, width: number) {
+//     return [].concat(
+//       ...text.split("\n").map(line => super._split_lines(line, width))
+//     );
+//   }
+// }
+
 export function parseCmdlineArgs(): void {
-  const parser = new argparse.ArgumentParser({
-    description: "Looker test runner"
+  const parser = new ArgumentParser({
+    //formatter_class: HelpFormatter,
+    description: `Looker is a Loki / Cortex testing and benchmarking tool.
+
+    Looker originated as a black-box storage testing program for Loki with
+    strict and deep read validation. Since then, it has evolved quite a bit.
+
+    Looker tries to be CPU-bound which also implies that it wants to
+    generate log/metric samples as quickly as it can.
+
+    The timestamps associated with log/metric samples are synthetically
+    generated (which allows for strict/deep read validation).
+
+    By default, synthetic time series start time is chosen randomly from an
+    interval in the past compared to current wall time. Specifically, from the
+    interval [now-maxLagSeconds, now-minLagSeconds). The meaning of
+    'maxLagSeconds' and 'minLagSeconds' is explained below.
+
+    By default, the synthetic time source used for time series generation is
+    guided by wall time through a loose coupling mechanism. When synthetic
+    time passes faster than wall time that mechanism
+    throttles sample generation when getting too close to 'now', as defined
+    by 'minLagSeconds'. That is, this mechanism guarantees that each
+    generated sample has a timestamp at least as old as now-minLagSeconds
+    (with 'now' approximately being the sample generation time).
+
+    When the synthetic time source passes slower than wall time then the
+    coupling mechanism compensates for that by a forward-leap method:
+    if the last generated sample is older than now-maxLagSeconds then the
+    next generated sample will have a timestamp very close to
+    now-minLagSeconds.
+
+    This loose coupling between wall time and synthetic time allows for
+    pushing data to an ingest system which does not accept data to
+    that is either too old or too new, compared to is own perspective on wall
+    time.
+    `
+    // .replace("\n\n", "FOO")
+    // .replace("\n", " ")
+    // .replace("FOO", "\n")
   });
 
   parser.add_argument("apibaseurl", {

--- a/test/test-remote/looker/src/args.ts
+++ b/test/test-remote/looker/src/args.ts
@@ -179,7 +179,7 @@ export function parseCmdlineArgs(): void {
       "writing to Loki that is configured to allow ingesting log samples " +
       "far from the past or future. Must be provided in " +
       "RFC3339 notation. Use for example " +
-      'date -u +"%Y-%m-%dT%H:%M:%SZ". Note that across cycles the same ' +
+      `date -u +"%Y-%m-%dT%H:%M:%SZ". Note that across cycles the same ` +
       "start time is used",
     type: "str",
     default: ""

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -243,7 +243,7 @@ async function createNewSeries(
         includeTimeInMsg: true,
         labelset: labelset,
         compressability: CFG.compressability,
-        wtopts: undefined // explititly disable for now during dev
+        wtopts: WALLTIME_COUPLING_PARAMS
       });
     }
 

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -921,12 +921,12 @@ async function _postFragments(
   // it's confirmed (above) that this array is not empty.
   const firstseries = fragments[0].parent as LogSeries | MetricSeries;
 
-  if (fragments.length === 1) {
+  const fcount = fragments.length;
+
+  if (fcount === 1) {
     name = `actor ${actorIndex}: prProducerPOSTer(${firstseries.promQueryString()})`;
   } else {
-    name = `actor ${actorIndex}: prProducerPOSTer(nstreams=${
-      fragments.length
-    }, first=${firstseries.promQueryString()})`;
+    name = `actor ${actorIndex}: prProducerPOSTer(nstreams=${fcount}, first=${firstseries.promQueryString()})`;
   }
 
   if (
@@ -939,7 +939,7 @@ async function _postFragments(
       `${name}: generated pushrequest msg in ${genduration.toFixed(
         2
       )} s with ` +
-        `${pr.fragments.length} series ` +
+        `${fcount} series ` +
         `(first: ${
           firstFragment.parent?.uniqueName
         }, index ${firstFragment.indexString(3)} -- ` +
@@ -967,13 +967,11 @@ async function _postFragments(
   pm.hist_duration_post_with_retry_seconds.observe(postDurationSeconds);
 
   COUNTER_STREAM_FRAGMENTS_PUSHED =
-    COUNTER_STREAM_FRAGMENTS_PUSHED + BigInt(CFG.n_fragments_per_push_message);
+    COUNTER_STREAM_FRAGMENTS_PUSHED + BigInt(fcount);
 
-  pm.counter_fragments_pushed.inc(CFG.n_fragments_per_push_message);
+  pm.counter_fragments_pushed.inc(fcount);
 
-  pm.counter_log_entries_pushed.inc(
-    CFG.n_samples_per_series_fragment * CFG.n_fragments_per_push_message
-  );
+  pm.counter_log_entries_pushed.inc(CFG.n_samples_per_series_fragment * fcount);
 
   // NOTE: payloadByteCount() includes timestamps. For logs, the timestamp
   // payload data (12 bytes per entry) might be small compared to the log

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -81,7 +81,7 @@ export const DEFAULT_LOG_LEVEL_STDERR = "info";
 
 // only expose via CLI args if a good use case arises.
 export const WALLTIME_COUPLING_PARAMS: WalltimeCouplingOptions = {
-  maxLagSeconds: 15 * 60,
+  maxLagSeconds: 10 * 60,
   minLagSeconds: 1 * 60
 };
 

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -309,7 +309,7 @@ async function createNewSeries(
 
     const logEveryN = util.logEveryNcalc(CFG.n_concurrent_streams);
     if (i % logEveryN == 0) {
-      log.info(msg + ` (${logEveryN - 1} msgs like this hidden)`);
+      log.info(msg + ` (${logEveryN - 1} msgs like this are/will be hidden)`);
       // Allow for more or less snappy SIGINTing this initialization step.
       await sleep(0.0001);
     } else {
@@ -673,7 +673,7 @@ export async function generateAndPostFragments(
   const seriespool = new Denque([...series]);
   //const seriespool = new Denque(series);
 
-  log.info(`seriespool.length: ${seriespool.length}`);
+  log.debug(`seriespool.length: ${seriespool.length}`);
 
   const actorCount = CFG.max_concurrent_writes;
   for (let i = 1; i <= actorCount; i++) {
@@ -738,7 +738,7 @@ async function tryToGetNFragmentsFromSeriesPool(
 
     if (s === undefined) {
       log.info(
-        `actor ${actorIndex}: series pool is empty. got ${fragments.length} (desired: ${nf})`
+        `actor ${actorIndex}: series pool is empty. generated ${fragments.length} fragments (desired: ${nf})`
       );
       // Break from the loop. At this point, the `fragments` array may
       // be of length between 0 or nf-1.
@@ -828,8 +828,8 @@ async function tryToGetNFragmentsFromSeriesPool(
     PER_STREAM_FRAGMENTS_CONSUMED_IN_CURRENT_CYCLE[s.uniqueName] += 1;
 
     if (fragments.length === nf) {
-      log.info(`seriespool.length: ${seriespool.length}`);
-      log.info(`actor ${actorIndex}: collected ${nf} fragments`);
+      log.debug(`seriespool.length: ${seriespool.length}`);
+      log.debug(`actor ${actorIndex}: collected ${nf} fragments`);
       return fragments;
     }
   }

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -80,10 +80,9 @@ interface ReadStats {
 export const DEFAULT_LOG_LEVEL_STDERR = "info";
 
 // only expose via CLI args if a good use case arises.
-export const WALLTIME_COUPLING_PARAMS = {
+export const WALLTIME_COUPLING_PARAMS: WalltimeCouplingOptions = {
   maxLagSeconds: 15 * 60,
-  minLagSeconds: 2 * 60,
-  leapForwardNSeconds: 2 * 60
+  minLagSeconds: 1 * 60
 };
 
 // let STATS_WRITE: WriteStats;

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -881,7 +881,7 @@ async function produceAndPOSTpushrequestsUntilCycleStopCriterion(
     for (const f of fragments) {
       const s = f.parent!;
       if (
-        PER_STREAM_FRAGMENTS_CONSUMED_IN_CURRENT_CYCLE[s.uniqueName] <=
+        PER_STREAM_FRAGMENTS_CONSUMED_IN_CURRENT_CYCLE[s.uniqueName] <
         CFG.stream_write_n_fragments
       ) {
         // Put back into work pool (left-hand side). All other actors might

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -216,14 +216,16 @@ async function createNewSeries(
         counterForwardLeap: pm.counter_forward_leap
       });
     } else {
+      // disable wall time coupling when --log-start-time has been set.
       let wtopts: WalltimeCouplingOptions | undefined =
         WALLTIME_COUPLING_PARAMS;
       let logstarttime: ZonedDateTime | undefined = starttime;
-      if (CFG.log_start_time) {
+      if (CFG.log_start_time !== "") {
         log.info("wall time coupling disabled as of --log-start-time");
         wtopts = undefined;
         logstarttime = ZonedDateTime.parse(CFG.log_start_time);
       }
+
       stream = new LogSeries({
         n_samples_per_series_fragment: CFG.n_samples_per_series_fragment,
         n_chars_per_msg: CFG.n_chars_per_msg,

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -115,7 +115,7 @@ async function main() {
 
   WALLTIME_COUPLING_PARAMS = calcWalltimeCouplingOptions();
 
-  for (let cyclenum = 1; cyclenum <= CFG.n_cycles + 1; cyclenum++) {
+  for (let cyclenum = 1; cyclenum <= CFG.n_cycles; cyclenum++) {
     setUptimeGauge();
 
     // The idea is that `CFG.invocation_id` is unique among those looker

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -669,7 +669,8 @@ async function _produceAndPOSTpushrequest(
             1
           )} minutes. Sample generation is too fast. Delay generating ` +
             "and pushing the next fragment. This may take up to " +
-            `${(s.fragmentTimeLeapSeconds / 60.0).toFixed(1)} minutes.`
+            `${(s.fragmentTimeLeapSeconds / 60.0).toFixed(1)} minutes ` +
+            "(the time width of a stream fragment)."
         );
 
         // We want to monitor the artificial throttling

--- a/test/test-remote/looker/src/index.ts
+++ b/test/test-remote/looker/src/index.ts
@@ -707,7 +707,7 @@ async function produceAndPOSTpushrequestsUntilCycleStopCriterion(
       log.info(
         `actor ${actorIndex}: series pool is empty. got ${fragments.length} (desired: ${nfppm})`
       );
-      break;
+      return;
     }
 
     let fragment: MetricSeriesFragment | LogSeriesFragment | undefined =

--- a/test/test-remote/looker/src/logs/dummystream.ts
+++ b/test/test-remote/looker/src/logs/dummystream.ts
@@ -289,14 +289,11 @@ export class LogSeries extends TimeseriesBase<LogSeriesFragment> {
     }
   }
 
-  protected leapForward(): void {
+  protected leapForward(n: number): void {
     // invariant: this must not be called when `this.walltimeCouplingOptions`
     // is undefined.
     assert(this.walltimeCouplingOptions);
-
-    this.currentSeconds += Number(
-      this.walltimeCouplingOptions.leapForwardNSeconds
-    );
+    this.currentSeconds += n;
   }
 
   public currentTime(): ZonedDateTime {

--- a/test/test-remote/looker/src/metrics/dummyseries.ts
+++ b/test/test-remote/looker/src/metrics/dummyseries.ts
@@ -91,8 +91,7 @@ export class MetricSeries extends TimeseriesBase<MetricSeriesFragment> {
       );
       this.walltimeCouplingOptions = {
         maxLagSeconds: 30 * 60,
-        minLagSeconds: 2 * 60,
-        leapForwardNSeconds: 3 * 60
+        minLagSeconds: 2 * 60
       };
 
       // Use validation logic in base class to confirm that these parameters

--- a/test/test-remote/looker/src/metrics/dummyseries.ts
+++ b/test/test-remote/looker/src/metrics/dummyseries.ts
@@ -275,14 +275,12 @@ export class MetricSeries extends TimeseriesBase<MetricSeriesFragment> {
     return this.millisSinceEpochOfLastGeneratedSample.divide(1000).toNumber();
   }
 
-  protected leapForward(): void {
+  protected leapForward(n: number): void {
     // invariant: this must not be called when `this.walltimeCouplingOptions`
     // is undefined.
     assert(this.walltimeCouplingOptions);
     this.millisSinceEpochOfLastGeneratedSample =
-      this.millisSinceEpochOfLastGeneratedSample.add(
-        Number(this.walltimeCouplingOptions.leapForwardNSeconds) * 1000
-      );
+      this.millisSinceEpochOfLastGeneratedSample.add(n * 1000);
   }
 
   protected generateNextFragment(): MetricSeriesFragment {

--- a/test/test-remote/looker/src/prommetrics.ts
+++ b/test/test-remote/looker/src/prommetrics.ts
@@ -103,6 +103,12 @@ export const counter_forward_leap = new promclient.Counter({
     "to not fall behind walltime too much"
 });
 
+export const hist_lag_compared_to_wall_time = new promclient.Histogram({
+  name: "hist_lag_compared_to_wall_time",
+  help: "Current lag of individual time series compared to wall time, in seconds",
+  buckets: [5, 60, 180, 300, 420, 540, 660, 1000, 1500, 10000]
+});
+
 export const gauge_last_http_request_body_size_bytes = new promclient.Gauge({
   name: "gauge_last_http_request_body_size_bytes",
   help: "size of last successfully POSTed HTTP request body (snappy-compressed protobuf message: a serialized log stream fragments)"

--- a/test/test-remote/looker/src/series.ts
+++ b/test/test-remote/looker/src/series.ts
@@ -290,10 +290,11 @@ export abstract class TimeseriesBase<FragmentType> {
   protected abstract lastSampleSecondsSinceEpoch(): number;
 
   /**
-   * Leap forward by N seconds, according to walltimeCouplingOptions. Must only
-   * be called after just having completed a fragment (right?).
+   * Leap forward by N seconds.
+   *
+   * Must only be called after just having completed a fragment (right?).
    */
-  protected abstract leapForward(): void;
+  protected abstract leapForward(n: number): void;
 
   abstract fetchAndValidate(
     opts: MetricSeriesFetchAndValidateOpts | LogSeriesFetchAndValidateOpts

--- a/test/test-remote/looker/src/series.ts
+++ b/test/test-remote/looker/src/series.ts
@@ -43,7 +43,6 @@ export interface LabelSet {
 export interface WalltimeCouplingOptions {
   maxLagSeconds: number;
   minLagSeconds: number;
-  leapForwardNSeconds: number;
 }
 
 export interface FragmentStatsBase {
@@ -316,7 +315,6 @@ export abstract class TimeseriesBase<FragmentType> {
     // I was unable to do this with a for loop based on a static set of
     // strings or using `for (const key in obj)` -- always a type error.
     // Huh.
-    assert(Number.isInteger(o["leapForwardNSeconds"]));
     assert(Number.isInteger(o["minLagSeconds"]));
     assert(Number.isInteger(o["maxLagSeconds"]));
 

--- a/test/test-remote/looker/src/series.ts
+++ b/test/test-remote/looker/src/series.ts
@@ -478,7 +478,13 @@ export abstract class TimeseriesBase<FragmentType> {
       shiftIntoPastSeconds - this.fragmentTimeLeapSeconds >
       this.walltimeCouplingOptions.minLagSeconds
     ) {
-      return [shiftIntoPastSeconds, this.generateNextFragment()];
+      // When generating a new fragment then the current shift into the past
+      // (the 'lag') is not the value we just got, but we've advanced by a
+      // known amount: the fragmentTimeLeapSeconds -- add that.
+      return [
+        shiftIntoPastSeconds + this.fragmentTimeLeapSeconds,
+        this.generateNextFragment()
+      ];
     }
 
     // Behind wall time, but too close to wall time. Do not generate a new

--- a/test/test-remote/looker/src/util.ts
+++ b/test/test-remote/looker/src/util.ts
@@ -37,8 +37,12 @@ export const httpTimeoutSettings = {
   request: 60000
 };
 
-export function rndFloatFromInterval(min: number, max: number) {
-  // half-closed: [min, max)
+/**
+ * Generate a floating point number from [min, max) with uniform distribution.
+ */
+export function rndFloatFromInterval(min: number, max: number): number {
+  // Note that Math.random() returns [0,1) (not including 1). So this picks
+  // from the half-closed interval [min, max), excluding max.
   return Math.random() * (max - min) + min;
 }
 

--- a/test/test-remote/test_prom_remote_write.ts
+++ b/test/test-remote/test_prom_remote_write.ts
@@ -93,7 +93,12 @@ suite("Prometheus remote_write (push to opstrace cluster) tests", function () {
       //starttime: ZonedDateTime.parse("2020-02-20T17:40:40.000000000Z"),
       uniqueName: uniquevalue,
       sample_time_increment_ns: 1000000,
-      labelset: undefined
+      labelset: undefined,
+      wtopts: {
+        // our current cortex config does not allow for data older than 60 mins
+        maxLagSeconds: 55 * 60,
+        minLagSeconds: 1 * 60
+      }
     });
     log.info("Dummy timeseries: %s", series);
     const burl = TENANT_DEFAULT_CORTEX_API_BASE_URL;
@@ -141,7 +146,12 @@ suite("Prometheus remote_write (push to opstrace cluster) tests", function () {
       //starttime: ZonedDateTime.parse("2020-02-20T17:40:40.000000000Z"),
       uniqueName: uniquevalue,
       sample_time_increment_ns: 1000000,
-      labelset: undefined
+      labelset: undefined,
+      wtopts: {
+        // our current cortex config does not allow for data older than 60 mins
+        maxLagSeconds: 55 * 60,
+        minLagSeconds: 1 * 60
+      }
     });
     log.info("Dummy timeseries: %s", series);
     const burl = TENANT_DEFAULT_CORTEX_API_BASE_URL;
@@ -165,7 +175,12 @@ suite("Prometheus remote_write (push to opstrace cluster) tests", function () {
       //starttime: ZonedDateTime.parse("2020-02-20T17:40:40.000000000Z"),
       uniqueName: uniquevalue,
       sample_time_increment_ns: 1000,
-      labelset: undefined
+      labelset: undefined,
+      wtopts: {
+        // our current cortex config does not allow for data older than 60 mins
+        maxLagSeconds: 55 * 60,
+        minLagSeconds: 1 * 60
+      }
     });
     log.info("Dummy timeseries: %s", series);
     const burl = TENANT_DEFAULT_CORTEX_API_BASE_URL;
@@ -189,7 +204,12 @@ suite("Prometheus remote_write (push to opstrace cluster) tests", function () {
       //starttime: ZonedDateTime.parse("2020-02-20T17:40:40.000000000Z"),
       uniqueName: uniquevalue,
       sample_time_increment_ns: 1000,
-      labelset: undefined
+      labelset: undefined,
+      wtopts: {
+        // our current cortex config does not allow for data older than 60 mins
+        maxLagSeconds: 55 * 60,
+        minLagSeconds: 1 * 60
+      }
     });
     log.info("Dummy timeseries: %s", series);
     const burl = TENANT_DEFAULT_CORTEX_API_BASE_URL;

--- a/test/test-remote/testutils/logs.ts
+++ b/test/test-remote/testutils/logs.ts
@@ -60,9 +60,9 @@ async function queryLoki(
     ...additionalHeaders
   };
 
-  // Expect to be wrapped by polling loop.
-  // expect 'snappy' response generation.
+  // Expect to be wrapped by polling loop. Expect 'snappy' response generation.
   const options = {
+    retry: 0,
     throwHttpErrors: false,
     searchParams: queryParams,
     timeout: {


### PR DESCRIPTION
This was part 1: https://github.com/opstrace/opstrace/pull/1310

This PR continues implementing the coupling mechanism for Looker's 'log mode' but also brings along a number of significant behavioral changes that also affect the coupling in 'metric mode'.