### PR TITLE
cli(destroy): handle gcp global address tear down

### DIFF
--- a/ci/test-upgrade/run.sh
+++ b/ci/test-upgrade/run.sh
@@ -60,10 +60,16 @@ teardown() {
     source ci/create-cluster-artifacts.sh
 
     make testupgrade-teardown
+    EXITCODE_DESTROY=$?
 
     # Copy CLI log files "again" to artifact collection dir (for `destroy` log).
     # do not exit when this fails (rely on +e before).
     cp -vn opstrace_cli_*log ${OPSTRACE_ARTIFACT_DIR} || true
+
+    if [ "${EXITCODE_DESTROY}" -ne 0 ]; then
+        echo "teardown() not yet finished, destroy failed. Exit with exitcode of destroy"
+        exit "${EXITCODE_DESTROY}"
+    fi
 
     exit ${LAST_EXITCODE_BEFORE_TEARDOWN}
 }

--- a/ci/test-upgrade/teardown.sh
+++ b/ci/test-upgrade/teardown.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eou pipefail
+set -ou pipefail
 
 case ${OPSTRACE_CLOUD_PROVIDER} in
     aws)


### PR DESCRIPTION
Workaround for #976. I think this is some undocumented behavior where a second request to [delete the global address](https://cloud.google.com/compute/docs/reference/rest/v1/addresses/delete) returns a 400.

The log output of a successful destroy operation shows the global desired state is reached immediately after the delete. 

```
[2021-08-24T00:53:20Z] 2021-08-24T00:53:20.930Z [32minfo[39m: Ensure Address deletion
[2021-08-24T00:53:21Z] 2021-08-24T00:53:21.124Z [32minfo[39m: Global Address is RESERVED
[2021-08-24T00:53:23Z] 2021-08-24T00:53:23.753Z [32minfo[39m: Global Address teardown: desired state reached
```

A failed run shows it tried to issue a delete twice.

```
[2021-08-23T19:04:24Z] 2021-08-23T19:04:24.724Z info: Global Address is RESERVED
[2021-08-23T19:04:27Z] 2021-08-23T19:04:27.761Z info: Global Address is RESERVED
[2021-08-23T19:04:28Z] 2021-08-23T19:04:28.185Z error: error during cluster teardown (attempt 1):
[2021-08-23T19:04:28Z] GaxiosError: The resource 'projects/ci-shard-bbb/global/addresses/google-managed-services-schedul-bk-2936-3b3-ug' is not ready
```

This was not caught earlier in the upgrade tests because the teardown script was swallowing the error. This is also fixed in this PR. 