### PR TITLE
gcp: destroy: try hard to deleteServiceConnect() before destroying VPC

### DIFF
--- a/lib/gcp/src/cloudSQL.ts
+++ b/lib/gcp/src/cloudSQL.ts
@@ -348,9 +348,13 @@ export function* ensureCloudSQLExists({
 
 export function* ensureCloudSQLDoesNotExist({
   opstraceClusterName,
+  networkName,
   addressName
 }: {
   opstraceClusterName: string;
+  // this is expected to be of the following shape:
+  // `projects/<gcpProjectID>/global/networks/<networkname >`
+  networkName: string;
   addressName: string;
 }): Generator<CallEffect, void, unknown> {
   const auth = new google.auth.GoogleAuth({
@@ -364,10 +368,8 @@ export function* ensureCloudSQLDoesNotExist({
   });
 
   google.options({ auth });
-  log.info(`Ensure SQLDatabase deletion`);
   yield call(ensureSQLDatabaseDoesNotExist, opstraceClusterName);
-  log.info(`Ensure SQLInstance deletion`);
   yield call(ensureSQLInstanceDoesNotExist, opstraceClusterName);
-  log.info(`Ensure Address deletion`);
+  yield call(deleteServiceConnectionsForNetwork, networkName);
   yield call(ensureAddressDoesNotExist, { addressName });
 }

--- a/lib/gcp/src/globalAddress.ts
+++ b/lib/gcp/src/globalAddress.ts
@@ -134,6 +134,8 @@ export function* ensureAddressDoesNotExist({
 }: {
   addressName: string;
 }): Generator<CallEffect, void, compute_v1.Schema$Address> {
+  log.info("global address teardown: start");
+
   let deleteIssued = false;
 
   while (true) {
@@ -142,18 +144,18 @@ export function* ensureAddressDoesNotExist({
     });
 
     if (!address) {
-      log.info("Global Address teardown: desired state reached");
+      log.info("global address teardown: desired state reached");
       return;
     }
 
-    log.info(`Global Address is ${address.status}`);
+    log.info(`global address status: ${address.status}`);
 
     try {
       // Workaround for https://github.com/opstrace/opstrace/issues/976.
       // Avoid issuing a second delete request for this resource otherwise we'll
       // get a 400 back.
       if (!deleteIssued) {
-        log.info(`Deleting Global Address`);
+        log.info("global address teardown: issue DELETE API call");
         yield call(deleteAddress, {
           name: addressName
         });
@@ -164,6 +166,6 @@ export function* ensureAddressDoesNotExist({
         throw e;
       }
     }
-    yield delay(2 * SECOND);
+    yield delay(5 * SECOND);
   }
 }

--- a/packages/uninstaller/src/gcp.ts
+++ b/packages/uninstaller/src/gcp.ts
@@ -108,9 +108,10 @@ export function* destroyGCPInfra(): Generator<
   log.info(`Ensure GKE deletion`);
   yield call(ensureGKEDoesNotExist, destroyConfig.clusterName);
 
-  log.info("Ensure CloudSQL deletion");
+  log.info("Delete CloudSQL stack");
   yield call(ensureCloudSQLDoesNotExist, {
     opstraceClusterName: destroyConfig.clusterName,
+    networkName: `projects/${destroyConfig.gcpProjectID}/global/networks/${destroyConfig.clusterName}`,
     addressName: `google-managed-services-${destroyConfig.clusterName}`
   });
 


### PR DESCRIPTION
https://github.com/opstrace/opstrace/issues/1312

GCP projects have an invisible quota for service connections. It's more of a GCP-internal sanity limit, not a user-facing quota.

Service connections may accumulate behind the scenes, even when deleting all referencing resources (namely, VPC networks, global addresses, and Cloud SQL instances).

This 'accumulation', as of GCP support, is for allowing to _quickly_ revive a service connection.

Now, the per-project hard limit of these dangling service connections seems to be 1024 (also as of GCP support).

Running into that limit resulted in the https://github.com/opstrace/opstrace/issues/1349 madness of the recent weeks which we accidentally tracked within #293 for a while.

This patch is to make it so that we try really hard to delete service connections associated with the VPC, before deleting the VPC.