### PR TITLE
chore: revert tsc to 4.3 version

### DIFF
--- a/test/test-remote/looker/package.json
+++ b/test/test-remote/looker/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^14.14.7",
     "@types/tmp": "^0.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "^4.3.4"
+    "typescript": "~4.3"
   },
   "resolutions": {
     "boolean": "3.1.2"

--- a/test/test-remote/package.json
+++ b/test/test-remote/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^14.14.7",
     "@types/tmp": "^0.2.0",
     "ts-node": "^10.0.0",
-    "typescript": "^4.3.5",
+    "typescript": "~4.3",
     "ws": "^8.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
Main is currently broken because a new typescript version [is out](https://github.com/microsoft/TypeScript/releases). 

The bump to 4.4.2 happened because typescript version in the container images uses a caret ^ which:

> Allow changes that do not modify the first non-zero digit in the version, either the 3 in 3.1.4 or the 4 in 0.4.2.

https://classic.yarnpkg.com/en/docs/dependency-versions/#toc-caret-ranges

> Using ~ with a minor version specified allows patch changes. Using ~ with only major version specified will allow minor changes.

https://classic.yarnpkg.com/en/docs/dependency-versions/#toc-tilde-ranges
