### PR TITLE
ui(users): improve user creation hints

### DIFF
--- a/packages/app/src/client/views/users/AddUserDialog.test.tsx
+++ b/packages/app/src/client/views/users/AddUserDialog.test.tsx
@@ -121,7 +121,7 @@ test("reactivates users", async () => {
   userEvent.type(input, mockUser.email + "{enter}");
 });
 
-test("handles user creation error when no name is entered", async () => {
+test("handles when no name is entered", async () => {
   const username = "";
   renderComponent(
     <CommandServiceTrigger>
@@ -132,13 +132,10 @@ test("handles user creation error when no name is entered", async () => {
   const input = screen.getByRole("textbox", { name: "picker filter" });
   userEvent.type(input, username + "{enter}");
 
-  expect(await screen.findByText("Could not add user")).toBeInTheDocument();
-  expect(
-    await screen.findByText("Please enter a valid email address")
-  ).toBeInTheDocument();
+  expect(screen.getByText("Enter new user's email")).toBeInTheDocument();
 });
 
-test("handles user creation error when name is no email", async () => {
+test("handles when name is no email", async () => {
   const username = "not an email";
   renderComponent(
     <CommandServiceTrigger>
@@ -149,10 +146,7 @@ test("handles user creation error when name is no email", async () => {
   const input = screen.getByRole("textbox", { name: "picker filter" });
   userEvent.type(input, username + "{enter}");
 
-  expect(await screen.findByText("Could not add user")).toBeInTheDocument();
-  expect(
-    await screen.findByText(`${username} is not a valid email address`)
-  ).toBeInTheDocument();
+  expect(screen.getByText("It must be a valid email address")).toBeInTheDocument();
 });
 
 test.todo("handles user creation error");

--- a/packages/app/src/client/views/users/AddUserDialog.tsx
+++ b/packages/app/src/client/views/users/AddUserDialog.tsx
@@ -20,7 +20,6 @@ import { useDispatch } from "react-redux";
 import { usePickerService } from "client/services/Picker";
 import { useCommandService } from "client/services/Command";
 import { addUser } from "state/user/actions";
-import { useSimpleNotification } from "client/services/Notification";
 
 // eslint-disable-next-line no-useless-escape
 const emailValidator =
@@ -30,13 +29,18 @@ export const addUserCommandId = "add-user-picker";
 
 const AddUserPicker = () => {
   const dispatch = useDispatch();
-  const { registerNotification } = useSimpleNotification();
 
   const { activatePickerWithText } = usePickerService(
     {
       title: "Enter user's email",
       activationPrefix: "add user:",
       disableFilter: true,
+      textValidator: (email: string) => {
+        if (email.length < 1) return "Enter new user's email";
+        else if (!emailValidator.test(email))
+          return "It must be a valid email address";
+        else return true;
+      },
       options: [
         {
           id: "yes",
@@ -48,21 +52,7 @@ const AddUserPicker = () => {
         }
       ],
       onSelected: (option, email) => {
-        if (!email) {
-          return registerNotification({
-            state: "error" as const,
-            title: "Could not add user",
-            information: `Please enter a valid email address`
-          });
-        }
-        if (!emailValidator.test(email)) {
-          return registerNotification({
-            state: "error" as const,
-            title: "Could not add user",
-            information: `${email} is not a valid email address`
-          });
-        }
-        if (option.id === "yes") {
+        if (email && option.id === "yes") {
           dispatch(addUser(email));
         }
       }


### PR DESCRIPTION
Improving the user feedback from previously:
![130819521-38a6adad-218a-448f-a950-ddf05c656856](https://user-images.githubusercontent.com/64152453/131146826-42c74723-434c-4fa7-85b9-d09cc3eb7ef4.png)


To now:
![Screenshot 2021-08-27 at 16 53 02](https://user-images.githubusercontent.com/64152453/131146888-01bd2685-75fb-4f2c-acc1-2bbd6d3198cb.png)


# Have you...

* [x] Added an explanation of what your changes do?
* [x] Written new tests for your changes?
* [x] Thought about which docs need updating?
