### PR TITLE
chore: misc typing fixes and a bump to TS 4.4.2 (latest)

### DIFF
--- a/lib/aws/src/vpc.ts
+++ b/lib/aws/src/vpc.ts
@@ -271,7 +271,7 @@ async function getELBsAssociatedWithVPC(
     return [];
   }
 
-  const elbs = [];
+  const elbs: ELBv2.LoadBalancers = [];
   for (const lb of data.LoadBalancers) {
     if (lb.VpcId === referenceVpcId) {
       log.info(

--- a/lib/kubernetes/package.json
+++ b/lib/kubernetes/package.json
@@ -33,6 +33,6 @@
     "@types/request": "^2.48.4",
     "jest": "^26.6.3",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.2"
+    "typescript": "4.4.2"
   }
 }

--- a/lib/kubernetes/package.json
+++ b/lib/kubernetes/package.json
@@ -32,7 +32,6 @@
     "@types/jest": "^26.0.16",
     "@types/request": "^2.48.4",
     "jest": "^26.6.3",
-    "ts-jest": "^26.4.4",
-    "typescript": "4.4.2"
+    "ts-jest": "^26.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^10.2.1",
-    "typescript": "4.3.5",
+    "typescript": "4.4.2",
     "wsrun": "^5.2.4"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,8 +26,7 @@
     "@types/argparse": "2.0.10",
     "@types/jest": "^26.0.23",
     "jest": "^26.6.3",
-    "ts-jest": "26.4.4",
-    "typescript": "4.4.2"
+    "ts-jest": "26.4.4"
   },
   "dependencies": {
     "@opstrace/config": "^0.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^26.0.23",
     "jest": "^26.6.3",
     "ts-jest": "26.4.4",
-    "typescript": "^4.3.4"
+    "typescript": "4.4.2"
   },
   "dependencies": {
     "@opstrace/config": "^0.0.0",

--- a/packages/cli/src/list.ts
+++ b/packages/cli/src/list.ts
@@ -118,7 +118,7 @@ export async function EKSgetOpstraceClustersAcrossManyRegions(): Promise<
   ];
 
   // Fetch, for all regions concurrently.
-  const actors = [];
+  const actors: Promise<EKSOpstraceClusterRegionRelation[]>[] = [];
   for (const region of regions) {
     actors.push(EKSgetOpstraceClustersInRegion(region));
   }

--- a/packages/cli/src/ucc.ts
+++ b/packages/cli/src/ucc.ts
@@ -99,7 +99,7 @@ async function readTextFromStdinUntilEOF() {
   // https://github.com/sindresorhus/get-stdin/issues/21
   // should be working in all relevant environments / on all relevant
   // platforms, but of course let's see; this is a very pragmatic approach.
-  const chunks = [];
+  const chunks: Uint8Array[] = [];
   for await (const chunk of process.stdin) chunks.push(chunk);
   return Buffer.concat(chunks).toString("utf8");
 }

--- a/packages/controller/src/resources/ingress/externalDns.ts
+++ b/packages/controller/src/resources/ingress/externalDns.ts
@@ -36,8 +36,8 @@ export function ExternalDnsResources(
 
   const domain = getDomain(state);
   const { target } = getControllerConfig(state);
-  let platformProvider = null;
 
+  let platformProvider: string | null = null;
   if (target === "gcp") {
     platformProvider = "google";
   }

--- a/packages/installer/src/aws.ts
+++ b/packages/installer/src/aws.ts
@@ -155,7 +155,7 @@ export function* ensureAWSInfraExists(): Generator<
   });
 
   // create s3 buckets and vpc concurrently
-  const tasks = [];
+  const tasks: any[] = [];
   tasks.push(
     yield fork([
       new S3BucketRes(

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -434,7 +434,7 @@ export async function waitUntilDataAPIEndpointsAreReachable(
     "waiting for expected HTTP responses at these URLs: %s",
     JSON.stringify(probeUrls, null, 2)
   );
-  const actors = [];
+  const actors: any[] = [];
   for (const [probeUrl, tenantName] of Object.entries(probeUrls)) {
     actors.push(waitForProbeURL(probeUrl, tenantName, 200, true));
   }
@@ -463,7 +463,7 @@ export async function waitUntilDDAPIEndpointsAreReachable(
     "waiting for expected HTTP responses at these URLs: %s",
     JSON.stringify(probeUrls, null, 2)
   );
-  const actors = [];
+  const actors: any[] = [];
   for (const [probeUrl, tenantName] of Object.entries(probeUrls)) {
     actors.push(waitForProbeURL(probeUrl, tenantName, 405, false, true, true));
   }
@@ -494,7 +494,7 @@ export async function waitUntilUIIsReachable(
     "waiting for expected HTTP responses at these URLs: %s",
     JSON.stringify(probeUrls, null, 2)
   );
-  const actors = [];
+  const actors: any[] = [];
   for (const [probeUrl, tenantName] of Object.entries(probeUrls)) {
     // Do not inspect JSON in response, do not enrich request with
     // authentication proof.

--- a/packages/uninstaller/src/aws.ts
+++ b/packages/uninstaller/src/aws.ts
@@ -99,7 +99,7 @@ export function* destroyAWSInfra(): Generator<
   // for some tasks / task groups explicitly every now and then for now to keep
   // things debuggable.
 
-  const taskGroup1 = [];
+  const taskGroup1: any[] = [];
 
   taskGroup1.push(
     yield fork(destroyAutoScalingGroup, destroyConfig.clusterName)
@@ -131,7 +131,7 @@ export function* destroyAWSInfra(): Generator<
 
   const eksDestroyTask = yield fork(destroyEKS, destroyConfig.clusterName);
 
-  const taskGroup2 = [];
+  const taskGroup2: any[] = [];
 
   taskGroup2.push(
     yield fork(
@@ -155,7 +155,7 @@ export function* destroyAWSInfra(): Generator<
     );
   }
 
-  const taskGroup3 = [];
+  const taskGroup3: any[] = [];
   for (const rtclass of [RouteTablePrivateRes, RouteTablePublicRes]) {
     taskGroup3.push(
       yield fork([new rtclass(destroyConfig.clusterName), "teardown"])
@@ -172,7 +172,7 @@ export function* destroyAWSInfra(): Generator<
     ])
   );
 
-  const taskGroup4 = [];
+  const taskGroup4: any[] = [];
 
   // Note(JP): do not delete any DNS-related infra when the Opstrace instance
   // was set up with a custom DNS name. TODO: when the Opstrace instance
@@ -212,7 +212,7 @@ export function* destroyAWSInfra(): Generator<
 
   // A task group that needs a better name, tasks will be joined late in the
   // game.
-  const taskGroupBob = [];
+  const taskGroupBob: any[] = [];
 
   taskGroupBob.push(
     yield fork([new RDSSubnetGroupRes(destroyConfig.clusterName), "teardown"])
@@ -439,7 +439,7 @@ function* detachPoliciesFromRoles(
 }
 
 function* getIamPoliciesByNames(polnames: string[]) {
-  const policies = [];
+  const policies: IAM.Policy[] = [];
   for (const pname of polnames) {
     const p: IAM.Policy = yield call(getPolicy, {
       PolicyName: pname

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -18,7 +18,7 @@
     "ramda": "^0.27.1",
     "ramda-adjunct": "^2.31.1",
     "ts-node": "^9.0.0",
-    "typescript": "^4.3.4",
+    "typescript": "4.4.2",
     "winston": "^3.3.3"
   },
   "scripts": {

--- a/test/test-remote/looker/package.json
+++ b/test/test-remote/looker/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^14.14.7",
     "@types/tmp": "^0.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "~4.3"
+    "typescript": "4.4.2"
   },
   "resolutions": {
     "boolean": "3.1.2"

--- a/test/test-remote/package.json
+++ b/test/test-remote/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^14.14.7",
     "@types/tmp": "^0.2.0",
     "ts-node": "^10.0.0",
-    "typescript": "~4.3",
+    "typescript": "4.4.2",
     "ws": "^8.2.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22743,20 +22743,10 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@4.3.5, typescript@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
-
-typescript@^4.1.2:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
-
-typescript@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
-  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
+typescript@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.24"


### PR DESCRIPTION
Plays it safe and pins to exactly 4.4.2 for now. Could go with 4.4.x instead?

The errors seen before in CI around catch types seems to indeed be a 4.4.x thing:
https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-rc/#use-unknown-catch-variables