### PR TITLE
chore: skip flaky loki tail endpoint test

### DIFF
--- a/test/test-remote/test_loki_tail_endpoint.ts
+++ b/test/test-remote/test_loki_tail_endpoint.ts
@@ -40,7 +40,7 @@ suite("Loki tail API test suite", function () {
     log.info("suite teardown");
   });
 
-  test("connect and stream cortex ingester pod logs from /loki/api/v1/tail", async function () {
+  test.skip("connect and stream cortex ingester pod logs from /loki/api/v1/tail", async function () {
     // encode query string
     const query = querystring.stringify({
       query: `{k8s_namespace_name="cortex",k8s_container_name="ingester"}`


### PR DESCRIPTION
Working on a fix in PR opstrace/opstrace#1340 but let's skip this one flaky test to reduce noise in the meantime.
