### PR TITLE
ci: replace ci-shard-aaa with ci-shard-ddd

### DIFF
--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -69,7 +69,7 @@ source secrets/opstrace_dockerhub_creds.sh
 # https://stackoverflow.com/q/5189913/145400.
 #OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
 # remove ddd, eee and fff for now, see issue #293
-OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
+OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-bbb ci-shard-ccc)
 echo "--- random choice for GCP project ID: ${OPSTRACE_GCP_PROJECT_ID}"
 export GOOGLE_APPLICATION_CREDENTIALS=./secrets/gcp-svc-acc-${OPSTRACE_GCP_PROJECT_ID}.json
 

--- a/ci/test-upgrade/run.sh
+++ b/ci/test-upgrade/run.sh
@@ -24,7 +24,7 @@ case "${OPSTRACE_CLOUD_PROVIDER}" in
         # Shard across GCP CI projects.
         #export OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
         # see issue 293
-        export OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
+        export OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-bbb ci-shard-ccc)
         echo "--- random choice for GCP project ID: ${OPSTRACE_GCP_PROJECT_ID}"
         export GOOGLE_APPLICATION_CREDENTIALS=./secrets/gcp-svc-acc-${OPSTRACE_GCP_PROJECT_ID}.json
         ;;


### PR DESCRIPTION
Currently unable to create SQL databases in ci-shard-aaa (possibly related to #293). Cycling out ci-shard-aaa in favor of ci-shard-dd.

