### PR TITLE
ci: remove ci-shard-iii from rotation

### DIFF
--- a/ci/deploy-testremote-teardown.sh
+++ b/ci/deploy-testremote-teardown.sh
@@ -68,9 +68,9 @@ source secrets/opstrace_dockerhub_creds.sh
 # https://github.com/opstrace/opstrace/pull/128#issuecomment-742519078 and
 # https://stackoverflow.com/q/5189913/145400.
 #OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
-# remove aaa, ddd, eee and fff for now, see issue #293
-# added ggg, hhh, iii due to #293, see issue opstrace/private#191
-OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-bbb ci-shard-ccc ci-shard-ggg ci-shard-hhh ci-shard-iii)
+# remove aaa, ddd, eee, fff, iii for now, see issue #293
+# added ggg, hhh due to #293, see issue opstrace/private#191
+OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-bbb ci-shard-ccc ci-shard-ggg ci-shard-hhh)
 echo "--- random choice for GCP project ID: ${OPSTRACE_GCP_PROJECT_ID}"
 export GOOGLE_APPLICATION_CREDENTIALS=./secrets/gcp-svc-acc-${OPSTRACE_GCP_PROJECT_ID}.json
 

--- a/ci/test-upgrade/run.sh
+++ b/ci/test-upgrade/run.sh
@@ -24,7 +24,7 @@ case "${OPSTRACE_CLOUD_PROVIDER}" in
         # Shard across GCP CI projects.
         #export OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-aaa ci-shard-bbb ci-shard-ccc)
         # see issues #293, opstrace/private#191
-        export OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-bbb ci-shard-ccc ci-shard-ggg ci-shard-hhh ci-shard-iii)
+        export OPSTRACE_GCP_PROJECT_ID=$(shuf -n1 -e ci-shard-bbb ci-shard-ccc ci-shard-ggg ci-shard-hhh)
         echo "--- random choice for GCP project ID: ${OPSTRACE_GCP_PROJECT_ID}"
         export GOOGLE_APPLICATION_CREDENTIALS=./secrets/gcp-svc-acc-${OPSTRACE_GCP_PROJECT_ID}.json
         ;;


### PR DESCRIPTION
This project seems to be hitting some hidden quota related to #1343. Remove it from rotation to get green CI again.