### PR TITLE
ui(notifications): merge reducer into main store

### DIFF
--- a/packages/app/src/client/integrations/common/UninstallIntegrationBtn.test.tsx
+++ b/packages/app/src/client/integrations/common/UninstallIntegrationBtn.test.tsx
@@ -16,19 +16,14 @@
 
 import React, { ReactNode } from "react";
 import { UninstallBtn } from "./UninstallIntegrationBtn";
-import Services from "client/services";
-import light from "client/themes/light";
-import ThemeProvider from "client/themes/Provider";
-import { StoreProvider } from "state/provider";
-import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
-import { render, waitFor } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import { Integration } from "state/integration/types";
 import { createMemoryHistory } from "history";
 import { Tenant } from "state/tenant/types";
-import { Router } from "react-router-dom";
 import { graphql, rest } from "msw";
 import { setupServer } from "msw/node";
+import { renderWithEnv } from "client/utils/testutils";
 
 /* did not manage to get the picker service running with the tests
  * so I just mocked it, as I primarily want to test network interactions.
@@ -104,9 +99,9 @@ test("handles click", async () => {
   mockHasuraEndpoint();
   mockGrafanaEndpoint(tenant, integration);
 
-  const container = renderComponent(
+  const container = renderWithEnv(
     <UninstallBtn integration={integration} tenant={tenant} disabled={false} />,
-    history
+    { history }
   );
 
   userEvent.click(container.getByRole("button"));
@@ -136,9 +131,9 @@ test("shows error messages if hasura request fails", async () => {
   );
   mockGrafanaEndpoint(tenant, integration);
 
-  const container = renderComponent(
+  const container = renderWithEnv(
     <UninstallBtn integration={integration} tenant={tenant} disabled={false} />,
-    history
+    { history }
   );
 
   userEvent.click(container.getByRole("button"));
@@ -166,26 +161,12 @@ test("doesn't show error messages if grafana request fails", async () => {
     )
   );
 
-  const container = renderComponent(
+  const container = renderWithEnv(
     <UninstallBtn integration={integration} tenant={tenant} disabled={false} />,
-    history
+    { history }
   );
-
-  userEvent.click(container.getByRole("button"));
+  userEvent.click(
+    container.getByRole("button", { name: "Uninstall Integration" })
+  );
   expect(container.queryAllByText(errorMessage)).toHaveLength(0);
 });
-
-const renderComponent = (
-  children: React.ReactNode,
-  history = createMemoryHistory()
-) => {
-  return render(
-    <StoreProvider>
-      <ThemeProvider theme={light}>
-        <Services>
-          <Router history={history}>{children}</Router>
-        </Services>
-      </ThemeProvider>
-    </StoreProvider>
-  );
-};

--- a/packages/app/src/client/services/Notification/NotificationService.test.tsx
+++ b/packages/app/src/client/services/Notification/NotificationService.test.tsx
@@ -19,15 +19,13 @@ import {
   useSimpleNotification,
   NotificationService
 } from "client/services/Notification";
-import light from "client/themes/light";
-import ThemeProvider from "client/themes/Provider";
-import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
-import { render } from "@testing-library/react";
+import { renderWithEnv, screen, act, within } from "client/utils/testutils";
 
 test("useNotificationService", async () => {
-  const title = "my-title";
-  const information = "my-information";
+  const buttonName = "click me!";
+  const title = "my title";
+  const information = "my information";
   const state = "error";
   const TestComponent = () => {
     const { registerNotification } = useSimpleNotification();
@@ -40,22 +38,22 @@ test("useNotificationService", async () => {
             state
           })
         }
-      />
+      >
+        {buttonName}
+      </button>
     );
   };
 
-  const container = renderComponent(<TestComponent />);
+  renderComponent(<TestComponent />);
+  act(() => {
+    userEvent.click(screen.getByRole("button", { name: buttonName }));
+  });
 
-  userEvent.click(container.getByRole("button"));
-
-  expect(await container.findByText(title)).toBeInTheDocument();
-  expect(await container.findByText(information)).toBeInTheDocument();
+  const alert = within((await screen.findAllByRole("alert"))[0]);
+  expect(await alert.findByText(title)).toBeInTheDocument();
+  expect(await alert.findByText(information)).toBeInTheDocument();
 });
 
 const renderComponent = (children: React.ReactNode) => {
-  return render(
-    <ThemeProvider theme={light}>
-      <NotificationService>{children}</NotificationService>
-    </ThemeProvider>
-  );
+  return renderWithEnv(<NotificationService>{children}</NotificationService>);
 };

--- a/packages/app/src/client/services/Notification/NotificationService.tsx
+++ b/packages/app/src/client/services/Notification/NotificationService.tsx
@@ -21,30 +21,24 @@ import type {
   NotificationServiceState,
   Notification
 } from "./types";
-import { actions, notificationServiceReducer, initialState } from "./reducer";
-import { useTypesafeReducer } from "../../hooks/useTypesafeReducer";
+import { actions } from "./reducer";
 import NotificationsList from "../../components/NotificationsList/NotificationsList";
 import { random } from "lodash";
+import { useDispatch, useSelector } from "react-redux";
+import { State } from "state/reducer";
 
-const notificationServiceContext = React.createContext<NotificationServiceApi | null>(
-  null
-);
+const notificationServiceContext =
+  React.createContext<NotificationServiceApi | null>(null);
 
 function NotificationService({ children }: { children: React.ReactNode }) {
-  const [
-    state,
-    { register, unregister, unregisterAll, changeVisibility }
-  ] = useTypesafeReducer<NotificationServiceState, typeof actions>(
-    notificationServiceReducer,
-    initialState,
-    actions
-  );
+  const dispatch = useDispatch();
+  const { notifications, visibility } = useSelector<State, NotificationServiceState>(state => state.notifications);
 
   const notificationService: NotificationServiceApi = {
-    register,
-    unregister,
-    unregisterAll,
-    changeVisibility
+    register: (...args) => dispatch(actions.register(...args)),
+    unregister: (...args) => dispatch(actions.unregister(...args)),
+    unregisterAll: (...args) => dispatch(actions.unregisterAll(...args)),
+    changeVisibility: (...args) => dispatch(actions.changeVisibility(...args))
   };
 
   // Enable this when we have notifications to show
@@ -65,10 +59,10 @@ function NotificationService({ children }: { children: React.ReactNode }) {
         {children}
       </notificationServiceContext.Provider>
       <NotificationsList
-        isOpen={state.visibility}
-        items={state.notifications}
+        isOpen={visibility}
+        items={notifications}
         onDeleteAll={notificationService.unregisterAll}
-        onClose={changeVisibility}
+        onClose={notificationService.changeVisibility}
       />
     </>
   );
@@ -104,10 +98,8 @@ export function useNotificationService(
 }
 
 export function useSimpleNotification() {
-  const {
-    registerNotification,
-    unregisterNotification
-  } = useNotificationService();
+  const { registerNotification, unregisterNotification } =
+    useNotificationService();
 
   return {
     registerNotification: ({

--- a/packages/app/src/client/utils/testutils/testutils.tsx
+++ b/packages/app/src/client/utils/testutils/testutils.tsx
@@ -19,6 +19,12 @@ import { render as rtlRender, RenderResult } from "@testing-library/react";
 import { History, createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
 import UE from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import getStore from "state/store";
+import "@testing-library/jest-dom";
+import ThemeProvider from "client/themes/Provider";
+import light from "client/themes/light";
+import Services from "client/services";
 
 export type RenderOptions = {
   // optionally pass in a history object to control routes in the test
@@ -49,6 +55,21 @@ export function render(
 
   return rtlRender(<div>{ui}</div>, { wrapper: Wrapper, ...renderOptions });
 }
+
+export const renderWithEnv = (
+  children: React.ReactNode,
+  { store = getStore(), history = createMemoryHistory() } = {}
+) => {
+  return render(
+    <Provider store={store}>
+      <ThemeProvider theme={light}>
+        <Services>
+          <Router history={history}>{children}</Router>
+        </Services>
+      </ThemeProvider>
+    </Provider>
+  );
+};
 
 export function sleep(ms: number) {
   return new Promise((resolve) => {

--- a/packages/app/src/state/reducer.ts
+++ b/packages/app/src/state/reducer.ts
@@ -21,6 +21,7 @@ import { reducer as integrationReducer } from "./integration/reducer";
 import { reducer as cortexConfigReducer } from "./cortex-config/reducer";
 import { reducer as opstraceConfigReducer } from "./opstrace-config/reducer";
 import { reducer as formReducer } from "./form/reducer";
+import { notificationServiceReducer } from "client/services/Notification/reducer";
 
 export const mainReducers = {
   users: userReducer,
@@ -28,7 +29,8 @@ export const mainReducers = {
   integrations: integrationReducer,
   form: formReducer,
   cortex: cortexConfigReducer,
-  opstrace: opstraceConfigReducer
+  opstrace: opstraceConfigReducer,
+  notifications: notificationServiceReducer
 };
 
 export const mainReducer = combineReducers(mainReducers);


### PR DESCRIPTION
In order to be able to raise notifications from stores and sagas (e.g. request error handling), the notification state needs to live in the main store, not in a separate one (as was before the case). 

Perquisite for #1333


# Have you...

* [x] Added an explanation of what your changes do?
* [x] Thought about which docs need updating?
