### PR TITLE
ui(error-view): fix wrong reload call

### DIFF
--- a/packages/app/src/client/components/Error/View.tsx
+++ b/packages/app/src/client/components/Error/View.tsx
@@ -76,7 +76,7 @@ const ErrorView = (props: ErrorViewProps) => {
       >
         Open Github Issue
       </Button>
-      <Button variant="outlined" onClick={() => window.location.reload(true)}>
+      <Button variant="outlined" onClick={() => window.location.reload()}>
         Refresh
       </Button>
     </CardActions>


### PR DESCRIPTION
It's a common misconception that `window.location.reload()` has a `boolean` parameter. This is not the case according to the spec. In fact, this flag is ignored by all browsers but firefox. [Read more about this on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location/reload#location.reload_has_no_parameter).

In firefox, the flag is to bypass its cache and force-reload the current document. If in fact this is something we want to do, we should look for a way that achieves this across all browsers. 

While `reload(boolean)` was [marked as deprecated](https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.location.html#reload) for a long time, it seems like that TS compilation entirely fails now if it's used (see #1358). 

Closes #1358

# Have you...

* [x] Added an explanation of what your changes do?
* [x] Thought about which docs need updating?
