### PR TITLE
loki|cortex: tweak grpc settings

### DIFF
--- a/packages/controller/src/resources/cortex/index.ts
+++ b/packages/controller/src/resources/cortex/index.ts
@@ -405,7 +405,10 @@ export function CortexResources(
           config: {
             server: {
               grpc_server_max_recv_msg_size: 41943040, // default (4 MB) * 10
-              grpc_server_max_send_msg_size: 41943040 // default (4 MB) * 10
+              grpc_server_max_send_msg_size: 41943040, // default (4 MB) * 10
+              // https://github.com/grafana/cortex-jsonnet/pull/233
+              grpc_server_ping_without_stream_allowed: true,
+              grpc_server_min_time_between_pings: "10s"
             },
             memberlist: {
               max_join_backoff: "1m",

--- a/packages/controller/src/resources/loki/index.ts
+++ b/packages/controller/src/resources/loki/index.ts
@@ -200,7 +200,11 @@ export function LokiResources(
     server: {
       http_listen_port: 1080,
       grpc_server_max_recv_msg_size: grpc_server_max_msg_size,
-      grpc_server_max_send_msg_size: grpc_server_max_msg_size
+      grpc_server_max_send_msg_size: grpc_server_max_msg_size,
+      // https://github.com/grafana/loki/pull/4182/files
+      grpc_server_max_concurrent_streams: 1000,
+      grpc_server_ping_without_stream_allowed: true,
+      grpc_server_min_time_between_pings: "10s"
     },
     auth_enabled: true,
     chunk_store_config: {


### PR DESCRIPTION
While triaging for #1226 I saw the following error printed by loki querier:

```
msg="error processing requests" address=X.X.X.X:9095 err="rpc error: code = Unknown desc = closing transport due to: connection error: desc = \"error reading from server: EOF\", received prior goaway: code: ENHANCE_YOUR_CALM, debug data: too_many_pings"
```

Some googling later and I found the following PRs to tweak the grpc keepalive config:

https://github.com/grafana/cortex-jsonnet/pull/233
https://github.com/grafana/loki/pull/4182/files