### PR TITLE
instance config: add custom_auth0_domain parameter

### DIFF
--- a/ci/cluster-config.yaml
+++ b/ci/cluster-config.yaml
@@ -6,3 +6,4 @@ aws:
   eks_admin_roles:
     - AWSReservedSSO_AdministratorAccess_8488c3da2f880f06
 custom_auth0_client_id: 5MoCYfPXPuEzceBLRUr6T6SAklT2GDys
+custom_auth0_domain: opstrace-dev.us.auth0.com

--- a/ci/test-upgrade/initial-cluster-config.yaml
+++ b/ci/test-upgrade/initial-cluster-config.yaml
@@ -6,4 +6,4 @@ aws:
   eks_admin_roles:
     - AWSReservedSSO_AdministratorAccess_8488c3da2f880f06
 custom_auth0_client_id: 5MoCYfPXPuEzceBLRUr6T6SAklT2GDys
-
+custom_auth0_domain: opstrace-dev.us.auth0.com

--- a/ci/test-upgrade/initial-cluster-config.yaml
+++ b/ci/test-upgrade/initial-cluster-config.yaml
@@ -6,4 +6,4 @@ aws:
   eks_admin_roles:
     - AWSReservedSSO_AdministratorAccess_8488c3da2f880f06
 custom_auth0_client_id: 5MoCYfPXPuEzceBLRUr6T6SAklT2GDys
-custom_auth0_domain: opstrace-dev.us.auth0.com
+#custom_auth0_domain: opstrace-dev.us.auth0.com

--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -206,9 +206,9 @@ Note:
 * `letsencrypt-prod` results in browser-trusted certificates, but is subject to quota/limits: [https://letsencrypt.org/docs/rate-limits/](https://letsencrypt.org/docs/rate-limits).
 
 
-### `custom_auth0_client_id`
+### `custom_auth0_client_id` and `custom_auth0_domain`
 
-Use this when you want to log in to the web UI of your Opstrace instance via your custom Auth0 'application'.
+Use these two parameters when you want to log in to the web UI of your Opstrace instance via your custom Auth0 'application'.
 
 This makes sense especially when you would like to connect to a special identity provider, and is obligatory when using a `custom_dns_name` (see above).
 
@@ -222,9 +222,10 @@ This makes sense especially when you would like to connect to a special identity
 
 ```yaml
 custom_auth0_client_id: 1333337
+custom_auth0_domain: barfoo.us.auth0.com
 ```
 
-<!-- TODO -->
+These two parameters must be provided together.
 
 ### `controller_image`
 

--- a/packages/cli/src/schemas.ts
+++ b/packages/cli/src/schemas.ts
@@ -59,16 +59,14 @@ function V1toV2(
 
 // function that takes any user cluster config and upgrades it to the latest
 // version if necessary.
-export async function upgradeToLatest(
+export function upgradeToLatest(
   ucc: any,
   cloudProvider: string
-): Promise<
-  [
-    LatestClusterConfigFileSchemaType,
-    LatestAWSInfraConfigType | undefined,
-    LatestGCPInfraConfigType | undefined
-  ]
-> {
+): [
+  LatestClusterConfigFileSchemaType,
+  LatestAWSInfraConfigType | undefined,
+  LatestGCPInfraConfigType | undefined
+] {
   // handle user cluster config
   const uccWithDefaults = upgradeClusterConfigSchemaToLatest(ucc);
 

--- a/packages/cli/src/schemasv2.ts
+++ b/packages/cli/src/schemasv2.ts
@@ -83,8 +83,8 @@ export const ClusterConfigFileSchemaV2 = yup
     // Added later to V2, but is an optional parameter, therefore not strictly
     // justifying a new schema version. Content and name need to be iterated on.
     custom_dns_name: yup.string().notRequired(),
-
     custom_auth0_client_id: yup.string().notRequired(),
+    custom_auth0_domain: yup.string().notRequired(),
 
     cert_issuer: yup
       .string()

--- a/packages/cli/src/ucc.spec.ts
+++ b/packages/cli/src/ucc.spec.ts
@@ -148,7 +148,7 @@ random string
   fs.writeFileSync(filename, configFile);
 
   const expectedErr = new Error(
-    'invalid cluster config document: this must be a `object` type, but the final value was: `"random string"`.'
+    'invalid config document: this must be a `object` type, but the final value was: `"random string"`.'
   );
 
   try {

--- a/packages/cli/src/ucc.ts
+++ b/packages/cli/src/ucc.ts
@@ -73,7 +73,7 @@ export async function uccGetAndValidate(
       ucc,
       cloudProvider
     );
-  } catch (err) {
+  } catch (err: any) {
     die(`invalid config document: ${err.message}`);
   }
 

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -32,7 +32,7 @@ import { logDockerHubCredentialsMessage } from "@opstrace/controller-config";
 
 export async function upgrade(): Promise<void> {
   log.info(
-    `About to upgrade cluster ${cli.CLIARGS.instanceName} (${cli.CLIARGS.cloudProvider}).`
+    `About to upgrade Opstrace instance '${cli.CLIARGS.instanceName}' (${cli.CLIARGS.cloudProvider}).`
   );
 
   const [userClusterConfig, infraConfigAWS, infraConfigGCP]: [

--- a/packages/config/src/clusterconfigv2.ts
+++ b/packages/config/src/clusterconfigv2.ts
@@ -47,4 +47,5 @@ export interface ClusterConfigTypeV2 {
   gcp: GCPInfraConfigTypeV2 | undefined;
   custom_dns_name?: string;
   custom_auth0_client_id?: string;
+  custom_auth0_domain?: string;
 }

--- a/packages/controller-config/src/schemav2.ts
+++ b/packages/controller-config/src/schemav2.ts
@@ -38,6 +38,7 @@ export const ControllerConfigSchemaV2 = yup
     // justifying a new schema version. Content and name need to be iterated on.
     custom_dns_name: yup.string().notRequired(),
     custom_auth0_client_id: yup.string().notRequired(),
+    custom_auth0_domain: yup.string().notRequired(),
 
     terminate: yup.bool().default(false),
     // https://stackoverflow.com/a/63944333/145400 `data_api_authn_pubkey_pem`

--- a/packages/controller-config/src/schemav3.ts
+++ b/packages/controller-config/src/schemav3.ts
@@ -74,6 +74,7 @@ export const ControllerConfigSchemaV3 = yup
 
     custom_dns_name: yup.string().notRequired(),
     custom_auth0_client_id: yup.string().notRequired(),
+    custom_auth0_domain: yup.string().notRequired(),
 
     terminate: yup.bool().default(false),
     // https://stackoverflow.com/a/63944333/145400 `data_api_authn_pubkey_pem`

--- a/packages/controller/src/resources/app/app.ts
+++ b/packages/controller/src/resources/app/app.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { strict as assert } from "assert";
+
 import { urlJoin } from "url-join-ts";
 import {
   ResourceCollection,
@@ -38,7 +40,8 @@ export function OpstraceApplicationResources(
 ): ResourceCollection {
   const collection = new ResourceCollection();
 
-  const { custom_auth0_client_id } = getControllerConfig(state);
+  const { custom_auth0_client_id, custom_auth0_domain } =
+    getControllerConfig(state);
 
   // This comment here is both solution and homage to
   // https://github.com/opstrace/opstrace/issues/1274.
@@ -49,8 +52,11 @@ export function OpstraceApplicationResources(
   // This is the Auth0 client ID corresponding to opstrace-dev.us.auth0.com,
   // preconfigured for the Opstrace DNS infrastructure behind *.opstrace.io.
   let auth0_client_id = "vs6bgTunbVK4dvdLRj02DptWjOmAVWVM";
+  let auth0_domain = "opstrace-dev.us.auth0.com";
   if (custom_auth0_client_id !== undefined) {
+    assert(custom_auth0_domain);
     auth0_client_id = custom_auth0_client_id;
+    auth0_domain = custom_auth0_domain;
   }
 
   collection.add(
@@ -277,7 +283,7 @@ export function OpstraceApplicationResources(
                     },
                     {
                       name: "AUTH0_DOMAIN",
-                      value: "opstrace-dev.us.auth0.com"
+                      value: auth0_domain
                     },
                     { name: "DOMAIN", value: `https://${domain}` },
                     { name: "UI_DOMAIN", value: `https://${domain}` },

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -181,6 +181,7 @@ function* createClusterCore() {
     disable_data_api_authentication: ccfg.data_api_authentication_disabled,
     custom_dns_name: ccfg.custom_dns_name,
     custom_auth0_client_id: ccfg.custom_auth0_client_id,
+    custom_auth0_domain: ccfg.custom_auth0_domain,
     cliMetadata: {
       allCLIVersions: [
         {

--- a/packages/upgrader/src/index.ts
+++ b/packages/upgrader/src/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { strict as assert } from "assert";
+
 import fs from "fs";
 import { fork, call, race, delay, cancel } from "redux-saga/effects";
 import { createStore, applyMiddleware } from "redux";
@@ -116,9 +118,8 @@ async function getKubecfgIfk8sClusterExists(
 // buckets, required to run Opstrace. Checks if Kubernetes cluster is available
 // before starting the upgrade.
 function* triggerInfraUpgrade() {
-  if (upgradeConfig === undefined) {
-    throw new Error("call setUpgradeConfig() first");
-  }
+  // catch programmer's error (call setUpgradeConfig() first)
+  assert(upgradeConfig);
 
   const kubeConfig: KubeConfig | undefined = yield call(
     getKubecfgIfk8sClusterExists,

--- a/packages/upgrader/src/upgrade.ts
+++ b/packages/upgrader/src/upgrade.ts
@@ -163,6 +163,9 @@ export function* upgradeControllerConfigMap(
   kubeConfig: KubeConfig
 ): Generator<Effect, void, State> {
   const state: State = yield select();
+
+  log.info("controller upgrade: obtain current controller config");
+
   const cm = state.kubernetes.cluster.ConfigMaps.resources.find(
     cm => cm.name === CONFIGMAP_NAME
   );
@@ -175,6 +178,7 @@ export function* upgradeControllerConfigMap(
     die(`invalid Opstrace controller config map`);
   }
 
+  log.info("got current controller config map");
   log.debug(`controller config: ${JSON.stringify(cfgJSON, null, 2)}`);
 
   let cfg: LatestControllerConfigType;
@@ -202,9 +206,10 @@ export function* upgradeControllerConfigMap(
   // client id. CI uses it to automate the login flow using email and password.
   cfg.custom_auth0_client_id = ucc.custom_auth0_client_id;
 
-  log.debug(`upgraded controller config ${JSON.stringify(cfg, null, 2)}`);
+  log.info(`upgraded controller config:\n${JSON.stringify(cfg, null, 2)}`);
 
   yield call(updateControllerConfig, cfg, kubeConfig);
+  log.info("controller config upgrade done");
 }
 
 export function* upgradeInfra(cloudProvider: string) {

--- a/packages/upgrader/src/upgrade.ts
+++ b/packages/upgrader/src/upgrade.ts
@@ -184,19 +184,19 @@ export function* upgradeControllerConfigMap(
   let cfg: LatestControllerConfigType;
   try {
     cfg = upgradeControllerConfigMapToLatest(cfgJSON);
-    cfg.cliMetadata.allCLIVersions.push({
-      version: BUILD_INFO.VERSION_STRING,
-      // Current time in UTC using RFC3339 string representation (w/o
-      // fractional seconds, with Z tz specififer), e.g.
-      // '2021-07-28T15:43:07Z'
-      timestamp: ZonedDateTime.now(ZoneOffset.UTC).format(
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
-      )
-    });
   } catch (e: any) {
-    die(`failed to upgrade controller configuration: ${e.message}`);
+    die(`failed to migrate controller config: ${e.message}`);
   }
 
+  cfg.cliMetadata.allCLIVersions.push({
+    version: BUILD_INFO.VERSION_STRING,
+    // Current time in UTC using RFC3339 string representation (w/o
+    // fractional seconds, with Z tz specififer), e.g.
+    // '2021-07-28T15:43:07Z'
+    timestamp: ZonedDateTime.now(ZoneOffset.UTC).format(
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+    )
+  });
   //
   // At this point, override any new fields that require reading from the user
   // cluster config.


### PR DESCRIPTION
The `custom_auth0_domain` parameter logically accompanies `custom_auth0_client_id`.

`custom_auth0_client_id` was not generally functional w/o the domain parameter.

Also see https://github.com/opstrace/opstrace/issues/1175

Tested config validation with an intentionally bad config:

```
± node packages/cli/build/index.js create aws rofl -c cluster-config.yaml 
2021-09-08T14:42:30.744Z info: logging to file: opstrace_cli_create_20210908-144230Z.log
2021-09-08T14:42:30.746Z info: Discovered AWS credentials. Access key: AKIA...AOGY
2021-09-08T14:42:30.763Z error: invalid config document: 'custom_auth0_client_id' requires 'custom_auth0_domain' and vice versa
```
