### PR TITLE
fix: increase hop limit to access AWS instance metadata endpoint

### DIFF
--- a/lib/aws/src/launchConfiguration.ts
+++ b/lib/aws/src/launchConfiguration.ts
@@ -127,6 +127,12 @@ set -o xtrace
     SecurityGroups: [securityGroupId],
     ImageId: imageId,
     InstanceType: instanceType,
+    MetadataOptions: {
+      // Increase allowed network hops to allow containers to that access the
+      // AWS instance metadata endpoint. Check
+      // https://github.com/opstrace/opstrace/issues/1226 for more details.
+      HttpPutResponseHopLimit: 2
+    },
     UserData
   };
 

--- a/packages/controller/src/resources/loki/index.ts
+++ b/packages/controller/src/resources/loki/index.ts
@@ -1368,47 +1368,6 @@ export function LokiResources(
                     successThreshold: 1,
                     failureThreshold: 3
                   },
-                  //
-                  // From https://github.com/grafana/loki/issues/3085. The
-                  // queriers initialize the storage credentials in the query
-                  // evaluation code path. To ensure the querier is initialized
-                  // before being marked ready to receive requests we query the
-                  // labels endpoint in the system tenant until we get a 200 OK.
-                  // The system tenant is created by default. This means the
-                  // queriers startupProbe waits for the ingesters to receive
-                  // some data.
-                  //
-                  // The startupProbe indicates whether the application within
-                  // the container is started. All other probes are disabled if
-                  // a startup probe is provided, until it succeeds. The
-                  // readinessProbe indicates whether the container is ready to
-                  // respond to requests. If the readiness probe fails, teh
-                  // endpoints controller removes the Pod's IP address from the
-                  // endpoints of all Services that match the Pod.
-                  //
-                  // https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
-                  // https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
-                  //
-                  startupProbe: {
-                    httpGet: {
-                      path: "/loki/api/v1/labels",
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      port: 1080 as any,
-                      httpHeaders: [
-                        {
-                          name: "X-Scope-OrgID",
-                          value: "system"
-                        }
-                      ]
-                    },
-                    // We are being liberal with these settings to cover a worst
-                    // case startup time.
-                    initialDelaySeconds: 90,
-                    timeoutSeconds: 30,
-                    periodSeconds: 10,
-                    successThreshold: 1,
-                    failureThreshold: 10
-                  },
                   resources: deploymentConfig.querier.resources,
                   volumeMounts: [
                     {


### PR DESCRIPTION
Back in https://github.com/opstrace/opstrace/issues/1226#issuecomment-915346058, we saw that the S3 bucket list request was stalling for 2+ minutes. It turns out it was one of the requests, an `ec2metadata/GetToken` that makes a `PUT /latest/api/token HTTP/1.1`, that was hanging. This led me to find https://github.com/aws/aws-sdk-go/issues/2972, which mentions that containers running on EC2 instances have issues accessing the AWS instance metadata endpoint due to a network knob not being configured properly.

I've ran a build in the draft PR #1351 with this fix applied and the stalling AWS instance metada requests seems to be fixed.

A few notes from that [build](https://buildkite.com/opstrace/prs/builds/5774#21a0e0fe-ed01-4710-8f9c-4fb1fd6bcfa7/5538-7453):

1) The installer no longer times out checking the Loki and Cortex endoints when the instance is created, indicating the querier initialized properly. Previously, requests to the `default` tenant would time out because the `startupProbe` we added could only check one tenant.
```
[2021-09-09T12:00:54Z] 2021-09-09T12:00:54.668Z info: waiting for expected HTTP responses at these URLs: {
[2021-09-09T12:00:54Z]   "https://cortex.default.prs-bk-5774-06a-a.opstrace.io/api/v1/labels": "default",
[2021-09-09T12:00:54Z]   "https://loki.default.prs-bk-5774-06a-a.opstrace.io/loki/api/v1/labels": "default",
[2021-09-09T12:00:54Z]   "https://cortex.system.prs-bk-5774-06a-a.opstrace.io/api/v1/labels": "system",
[2021-09-09T12:00:54Z]   "https://loki.system.prs-bk-5774-06a-a.opstrace.io/loki/api/v1/labels": "system"
[2021-09-09T12:00:54Z] }
[2021-09-09T12:00:54Z] 2021-09-09T12:00:54.810Z info: https://cortex.default.prs-bk-5774-06a-a.opstrace.io/api/v1/labels: got expected HTTP response
[2021-09-09T12:00:54Z] 2021-09-09T12:00:54.895Z info: https://loki.default.prs-bk-5774-06a-a.opstrace.io/loki/api/v1/labels: got expected HTTP response
[2021-09-09T12:00:54Z] 2021-09-09T12:00:54.932Z info: https://loki.system.prs-bk-5774-06a-a.opstrace.io/loki/api/v1/labels: got expected HTTP response
[2021-09-09T12:00:54Z] 2021-09-09T12:00:54.935Z info: https://cortex.system.prs-bk-5774-06a-a.opstrace.io/api/v1/labels: got expected HTTP response
[2021-09-09T12:00:54Z] 2021-09-09T12:00:54.936Z info: wait for data API endpoints: all probe URLs returned expected HTTP responses, continue
[2021-09-09T12:00:54Z] 2021-09-09T12:00:54.936Z info: waiting for expected HTTP responses at these URLs: {
[2021-09-09T12:00:54Z]   "https://dd.default.prs-bk-5774-06a-a.opstrace.io/api/v1/series": "default"
[2021-09-09T12:00:54Z] }
[2021-09-09T12:00:54Z] 2021-09-09T12:00:54.985Z info: wait for DD API endpoints: all probe URLs returned expected HTTP responses, continue
[2021-09-09T12:00:54Z] 2021-09-09T12:00:54.985Z info: waiting for expected HTTP responses at these URLs: {
[2021-09-09T12:00:54Z]   "https://default.prs-bk-5774-06a-a.opstrace.io/": "default",
[2021-09-09T12:00:54Z]   "https://system.prs-bk-5774-06a-a.opstrace.io/": "system"
[2021-09-09T12:00:54Z] }
[2021-09-09T12:00:55Z] 2021-09-09T12:00:55.267Z info: wait for grafana endpoints: all probe URLs returned expected HTTP responses, continue
```

2) More important, the ec2metadata/GetToken request returned [instantly](https://builds.collection.opstrace.io/grafana/explore?orgId=1&left=%5B%221631188200000%22,%221631188919000%22,%22logs%22,%7B%22expr%22:%22%7B%5Cn%20%20opstrace_cluster_name%3D%5C%22prs-bk-5774-06a-a%5C%22,%20%5Cn%20%20k8s_namespace_name%3D%5C%22loki%5C%22,%5Cn%20%20k8s_pod_name%3D%5C%22querier-0%5C%22%5Cn%7D%22,%22maxLines%22:1000%7D%5D)

```
2021-09-09 11:56:50	
stdout
2021/09/09 11:56:50 DEBUG: Request ec2metadata/GetToken Details:
2021-09-09 11:56:50	
stdout
---[ REQUEST POST-SIGN ]-----------------------------
PUT /latest/api/token HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go/1.38.68 (go1.16.2; linux; amd64)
Content-Length: 0
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 21600
Accept-Encoding: gzip


-----------------------------------------------------
2021/09/09 11:56:50 DEBUG: Response ec2metadata/GetToken Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Content-Length: 56
Content-Type: text/plain
Date: Thu, 09 Sep 2021 11:56:50 GMT
Server: EC2ws
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 21600


-----------------------------------------------------
2021/09/09 11:56:50 DEBUG: Request ec2metadata/GetMetadata Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /latest/meta-data/iam/security-credentials/ HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go/1.38.68 (go1.16.2; linux; amd64)
X-Aws-Ec2-Metadata-Token: AQAEABMbM1-ukdJYiBzyjIgAGJDjb43gVMld-FSnGehziQ-T1GFXLA==
Accept-Encoding: gzip


-----------------------------------------------------
2021/09/09 11:56:50 DEBUG: Response ec2metadata/GetMetadata Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Content-Length: 27
Accept-Ranges: none
Content-Type: text/plain
Date: Thu, 09 Sep 2021 11:56:50 GMT
Last-Modified: Thu, 09 Sep 2021 11:55:43 GMT
Server: EC2ws
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 21600


-----------------------------------------------------
2021/09/09 11:56:50 DEBUG: Request ec2metadata/GetMetadata Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /latest/meta-data/iam/security-credentials/prs-bk-5774-06a-a-eks-nodes HTTP/1.1
Host: 169.254.169.254
User-Agent: aws-sdk-go/1.38.68 (go1.16.2; linux; amd64)
X-Aws-Ec2-Metadata-Token: AQAEABMbM1-ukdJYiBzyjIgAGJDjb43gVMld-FSnGehziQ-T1GFXLA==
Accept-Encoding: gzip


-----------------------------------------------------
2021/09/09 11:56:50 DEBUG: Response ec2metadata/GetMetadata Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Content-Length: 1310
Accept-Ranges: none
Content-Type: text/plain
Date: Thu, 09 Sep 2021 11:56:50 GMT
Last-Modified: Thu, 09 Sep 2021 11:55:43 GMT
Server: EC2ws
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 21600


-----------------------------------------------------
2021/09/09 11:56:50 DEBUG: Request s3/ListObjectsV2 Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /?delimiter=%2F&list-type=2&prefix=index%2Fprs-bk-5774-06a-a_loki_index_18879%2F HTTP/1.1
Host: prs-bk-5774-06a-a-loki.s3.us-west-2.amazonaws.com
User-Agent: aws-sdk-go/1.38.68 (go1.16.2; linux; amd64)
Authorization: AWS4-HMAC-SHA256 Credential=ASIA56XCAEKWIX44AW54/20210909/us-west-2/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=64305ff35bb804a4902ae78ce11677ce153ac6dac11b2cddc9114c78d6afbda8
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20210909T115650Z
X-Amz-Security-Token: XXX
Accept-Encoding: gzip


-----------------------------------------------------
2021/09/09 11:56:50 DEBUG: Response s3/ListObjectsV2 Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Thu, 09 Sep 2021 11:56:51 GMT
Server: AmazonS3
X-Amz-Bucket-Region: us-west-2
X-Amz-Id-2: erE+/vaDOksG6K/pTPS3aAb9ADyfT1m8/oSIZXovpi8z1iEkdi0Emwia2BIclFd3FFwvrD2CMZA=
X-Amz-Request-Id: ZVCJJPS5JHQNC9KH


-----------------------------------------------------
ts=2021-09-09T11:56:50.702201018Z caller=spanlogger.go:87 traceID=587f6ee85d3aed3f method=S3ObjectClient.List level=debug msg="ListObjectsV2WithContext returned" bucketName=prs-bk-5774-06a-a-loki length=0
```

It's most likely we started seeing an increased error rate in #1226 due to a recent loki bump that includes https://github.com/grafana/loki/pull/4188, which bumped the aws-go-sdk from 1.38.60 to 1.38.68. This particular PR https://github.com/aws/aws-sdk-go/pull/3962/files might have led to this time out.

Fix #1226 

* Removes Loki querier workaround introduced in #918 since we identified the root cause.