### PR TITLE
test-remote: log/retry query if loki returns a 500 error with error text

### DIFF
--- a/test/test-remote/looker/src/logs/dummystream.ts
+++ b/test/test-remote/looker/src/logs/dummystream.ts
@@ -497,6 +497,12 @@ Query parameters: ${JSON.stringify(
           `waitForLokiQueryResult() loop: http request failed: ${e.message} -- ignore, proceed with next iteration`
         );
         continue;
+      } else if (e instanceof SyntaxError) {
+        // JSON.parse() failed on loki response (e.g. 500 error)
+        log.warning(
+          `waitForLokiQueryResult() loop: http parse response failed: ${e.message} -- ignore, proceed with next iteration`
+        );
+        continue;
       } else {
         // Throw any other error, mainly programming error.
         throw e;

--- a/test/test-remote/testutils/logs.ts
+++ b/test/test-remote/testutils/logs.ts
@@ -139,6 +139,12 @@ Query parameters: ${JSON.stringify(
           `waitForLokiQueryResult() loop: http request failed: ${e.message} -- ignore, proceed with next iteration`
         );
         continue;
+      } else if (e instanceof SyntaxError) {
+        // JSON.parse() failed on loki response (e.g. 500 error)
+        log.warning(
+          `waitForLokiQueryResult() loop: http parse response failed: ${e.message} -- ignore, proceed with next iteration`
+        );
+        continue;
       } else {
         // Throw any other error, mainly programming error.
         throw e;


### PR DESCRIPTION
Note that the response containing the errant body is already being logged, this just adds a retry.

Seen in CI flake: https://buildkite.com/opstrace/scheduled-main-builds/builds/3086

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
