### PR TITLE
cli: aws infra setup: set ec2 instance metadata (wip)

### DIFF
--- a/lib/aws/src/autoScalingGroup.ts
+++ b/lib/aws/src/autoScalingGroup.ts
@@ -270,11 +270,13 @@ class EC2InstanceMetadata extends AWSResource<boolean> {
           if (result.Reservations[0].Instances.length === 1) {
             const instance = result.Reservations[0].Instances[0];
             if (instance.MetadataOptions?.HttpPutResponseHopLimit === 2) {
-              log.info(`${this}: HttpPutResponseHopLimit is 2`);
+              log.info(`${this.rname}: HttpPutResponseHopLimit is 2`);
               return true;
             } else {
               const s = JSON.stringify(instance.MetadataOptions, null, 2);
-              log.info(`${this}: HttpPutResponseHopLimit is not 2:\n${s}`);
+              log.info(
+                `${this.rname}: HttpPutResponseHopLimit is not 2:\n${s}`
+              );
               return false;
             }
           }
@@ -283,7 +285,7 @@ class EC2InstanceMetadata extends AWSResource<boolean> {
     }
 
     log.info(
-      `${this}: unexpected describeInstances result: :\n${JSON.stringify(
+      `${this.rname}: unexpected describeInstances result: :\n${JSON.stringify(
         result,
         null,
         2


### PR DESCRIPTION
This is executed as part of an upgrade, in particular
as part of the 'infrastructure upgrade'.

When this runs, EC2 instance metadata is mutated
so that HttpPutResponseHopLimit is set from 1 (the
default to 2). This is a pragmatic first step
#1383.

Note that this per-instance mutation is not
persistent: goes away when an intance goes away
in an auto-scaling group.

To persist this kind of configuration change
the underlying launch configuration needs to
be mutated (more context in #1383).
