### PR TITLE
ui(opstrace-config): fix

### DIFF
--- a/packages/app/src/client/views/cluster-config/opstrace.tsx
+++ b/packages/app/src/client/views/cluster-config/opstrace.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, { ReactNode } from "react";
 import { format, parseISO } from "date-fns";
 
 import useOpstraceConfig from "state/opstrace-config/hooks/useOpstraceConfig";
@@ -31,14 +31,15 @@ import {
 import { Card } from "client/components/Card";
 import { Typography } from "client/components/Typography";
 import { Box } from "client/components/Box";
+import { OpstraceBuildInfo } from "state/opstrace-config/types";
 
 type FieldType = {
-  key: string;
-  label: string;
-  formatter?: Function;
+  key: keyof OpstraceBuildInfo;
+  label: ReactNode;
+  formatter?: (value: string) => ReactNode;
 };
 
-const fields: FieldType[] = [
+const FIELDS: FieldType[] = [
   { key: "version", label: "Version" },
   { key: "commit", label: "Commit" },
   { key: "branch", label: "Branch" },
@@ -65,7 +66,7 @@ const OpstraceConfig = () => {
         <TableContainer component={Card}>
           <Table aria-label="tenants" data-test="tenant/list">
             <TableBody>
-              {fields.map(field => (
+              {FIELDS.map(field => (
                 <TableRow key={field.key}>
                   <TableCell component="th" scope="row">
                     {field.label}

--- a/packages/app/src/client/views/cluster-config/opstrace.tsx
+++ b/packages/app/src/client/views/cluster-config/opstrace.tsx
@@ -66,7 +66,7 @@ const OpstraceConfig = () => {
         <TableContainer component={Card}>
           <Table aria-label="tenants" data-test="tenant/list">
             <TableBody>
-              {FIELDS.map(field => (
+              {FIELDS.filter(field => !!buildInfo[field.key]).map(field => (
                 <TableRow key={field.key}>
                   <TableCell component="th" scope="row">
                     {field.label}

--- a/packages/app/src/state/opstrace-config/types.ts
+++ b/packages/app/src/state/opstrace-config/types.ts
@@ -19,9 +19,9 @@ export type OpstraceConfig = {
 };
 
 export type OpstraceBuildInfo = {
-  branch: string;
-  version: string;
-  commit: string;
-  buildTime: string;
-  buildHostname: string;
+  branch?: string;
+  version?: string;
+  commit?: string;
+  buildTime?: string;
+  buildHostname?: string;
 };


### PR DESCRIPTION
THIS PR IS NOT MEANT TO BE MERGED - JUST TO ILLUSTRATE THE PROBLEM. This is a superset of #1399. Relevant changes are [here](https://github.com/opstrace/opstrace/pull/1400/commits/db53036281a061eaf76d087cd828b096f7993bc1).

Right now, when developing, my `buildInfo` is an empty object:

![Screenshot 2021-09-16 at 18 07 39](https://user-images.githubusercontent.com/64152453/133647508-bf277f3f-c020-4830-be2d-5078987bf0af.png)

This breaks the opstrace config page on `/cluster/configuration/opstrace`. This is due to the fact that the code is [trying to pass `buildInfo.buildTime`, which is `undefined` to `parseISO`](https://github.com/opstrace/opstrace/blob/main/packages/app/src/client/views/cluster-config/opstrace.tsx#L48), which in turn throws.

![Screenshot 2021-09-16 at 18 15 30](https://user-images.githubusercontent.com/64152453/133648095-792e31ef-0e74-4152-b43a-7c0b8875cb28.png)

This might be a development problem only, but still relevant, as it prevents developing the opstrace config page. The changes proposed in this PR are merely meant to illustrate the issues. A more elegant solution might be, to have a development `buildInfo` with development values. 

But before tackling this, I would like to hear some input on what you guys think the best way is.

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
