### PR TITLE
ci: log cert/issuer content when checking LE certs

### DIFF
--- a/ci/utils.sh
+++ b/ci/utils.sh
@@ -51,10 +51,11 @@ check_certificate() {
     # also show all output on stderr via a tee shunt.
     # For the grep text, also see
     # https://github.com/opstrace/opstrace/issues/386
-    timeout --kill-after=10 10 \
-    openssl s_client -showcerts -connect "${1}"  </dev/null \
-    | openssl x509 -noout -issuer \
-    |& tee /dev/stderr | grep "O = (STAGING) Let's Encrypt, CN = (STAGING) Artificial Apricot"
+    # Setting the results to variables will result in printing them in CI via 'set -o xstrace'
+    # For example if the -showcerts command returns an error then the error should be logged
+    CERT="$(timeout --kill-after=10 10 openssl s_client -showcerts -connect $1 </dev/null 2>&1)"
+    ISSUER=$(echo "$CERT" | openssl x509 -noout -issuer 2>&1)
+    echo "$ISSUER" | grep "O = (STAGING) Let's Encrypt, CN = (STAGING) Artificial Apricot"
 }
 
 retry_check_certificate() {


### PR DESCRIPTION
Makes the output more verbose, hopefully showing the content of the certs.

Hopefully will help with tracking down #1388, where checks are getting generic "unable to load certificate" errors but we aren't seeing what content is failing to be loaded.

Signed-off-by: Nick Parker <nick@opstrace.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
