### PR TITLE
cortex: remap 'retryable' 5xx errors to non-retryable errors

### DIFF
--- a/go/cmd/cortex/main.go
+++ b/go/cmd/cortex/main.go
@@ -39,15 +39,95 @@ var (
 	cortexDistributorURL     string
 	tenantName               string
 	disableAPIAuthentication bool
+	allowPushRetries         bool
 )
 
+// The error code to use when replacing 429 errors with a consistently retryable error code.
+// Prometheus clients do not consistently honor retries with 429, but they do with 500 errors.
+// Therefore we remap 429 to 503.
+const retryableStatusCode = 503
+
+// The error code to use when replacing 5xx errors with non-retryable errors.
+// Any 400 code (other than 429 Too Many Requests) should theoretically work.
+// For now we use 409 Conflict, which is sufficiently ambiguous in meaning, while also not having
+// any additional baggage in terms of client handling.
+const nonRetryableStatusCode = 409
+
+// Remap default-not-retryable HTTP 429 errors to always-retryable 503 errors.
+// In this situation the server is acting healthy and is telling clients to back off/retry.
+// Unlike in the 5xx remap case this shouldn't present issues around server load.
+// Context: https://github.com/opstrace/opstrace/issues/464
+//
+// Remap "retryable" HTTP 500-599 errors to a different non-retryable error code.
+// This avoids indefinite retries by clients which can make server problems worse.
+// For example by default Prometheus retries 500 sample payloads every 50-100ms over 5s.
+// Context: https://github.com/opstrace/opstrace/issues/1409
+//
+// The proxy may return its own 502 errors if the distributor isn't reachable.
+// These are let through as-is with the assumption that the failure is temporary due to e.g.
+// a new version rollout and so will go away when the distributors are back.
+func replacePushErrors(resp *http.Response) error {
+	// start with quick int comparison to weed out (hopefully) common success cases
+	if resp.StatusCode != 429 && (resp.StatusCode < 500 || resp.StatusCode > 599) {
+		// not a remappable error, ignore
+		return nil
+	}
+	if !strings.Contains(resp.Request.URL.Path, "/api/v1/push") {
+		// not a push request, ignore
+		return nil
+	}
+
+	var origCode = resp.StatusCode
+	if resp.StatusCode == 429 {
+		// Server is healthy and telling a client to retry later.
+		// Use 503 error to ensure the retry happens. See context above.
+		resp.StatusCode = retryableStatusCode
+	} else {
+		// Server is not healthy with a 5xx error.
+		// Use 409 error to ensure the client doesn't retry. See other context above.
+		resp.StatusCode = nonRetryableStatusCode
+	}
+
+	// Try to update body to reflect the mapping.
+	origBodyBytes, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		// Treat body update as best-effort - proceed without update
+		log.Warnf("CortexPushRewrite: could not read %d resp body: %s", origCode, readErr)
+	} else {
+		bodybytes := []byte(fmt.Sprintf("%d-to-%d: %s", origCode, resp.StatusCode, string(origBodyBytes)))
+		resp.Body = ioutil.NopCloser(bytes.NewReader(bodybytes))
+		resp.ContentLength = int64(len(bodybytes))
+		resp.Header.Set("Content-Length", strconv.Itoa(len(bodybytes)))
+	}
+	return nil
+}
+
 func main() {
-	flag.StringVar(&listenAddress, "listen", "", "")
-	flag.StringVar(&cortexQuerierURL, "cortex-querier-url", "", "")
-	flag.StringVar(&cortexDistributorURL, "cortex-distributor-url", "", "")
-	flag.StringVar(&tenantName, "tenantname", "", "")
+	flag.StringVar(&listenAddress, "listen", "", "Endpoint for listening to incoming requests from the Internet")
+	flag.StringVar(&cortexQuerierURL, "cortex-querier-url", "", "Endpoint for reaching the cortex querier for reads")
+	flag.StringVar(
+		&cortexDistributorURL,
+		"cortex-distributor-url",
+		"",
+		"Endpoint for reaching the cortex distributor for writes",
+	)
+	flag.StringVar(&tenantName, "tenantname", "", "Name of the tenant that the API is serving")
 	flag.StringVar(&loglevel, "loglevel", "info", "error|info|debug")
-	flag.BoolVar(&disableAPIAuthentication, "disable-api-authn", false, "")
+	flag.BoolVar(
+		&disableAPIAuthentication,
+		"disable-api-authn",
+		false,
+		"Whether to skip validation of Authentication headers in requests, for testing only",
+	)
+	// By default we remap 500 and 429 errors to a 409 Conflict error, treated by clients as non-retryable.
+	// This avoids problems with brief outages causing stock Prometheus clients to overload the server without progress.
+	// See also: https://github.com/opstrace/opstrace/issues/1409
+	flag.BoolVar(
+		&allowPushRetries,
+		"allow-push-retries",
+		false,
+		"Whether to allow write clients to receive retryable 429/500 errors on push requests",
+	)
 
 	flag.Parse()
 
@@ -72,6 +152,7 @@ func main() {
 	log.Infof("listen address: %s", listenAddress)
 	log.Infof("tenant name: %s", tenantName)
 	log.Infof("API authentication enabled: %v", !disableAPIAuthentication)
+	log.Infof("Remapping retryable distributor errors: %v", !allowPushRetries)
 
 	if !disableAPIAuthentication {
 		authenticator.ReadConfigFromEnvOrCrash()
@@ -91,7 +172,9 @@ func main() {
 		cortexdurl,
 		disableAPIAuthentication,
 	)
-
+	if !allowPushRetries {
+		distributorProxy.ReplaceResponses(replacePushErrors)
+	}
 	// mux matches based on registration order, not prefix length.
 	router := mux.NewRouter()
 
@@ -121,35 +204,5 @@ func main() {
 	router.Handle("/metrics", promhttp.Handler())
 	router.Use(middleware.PrometheusMetrics("cortex_api_proxy"))
 
-	// Hook into reverse proxy for flexible treatment of responses to requests
-	// to `/api/v1/push`.
-	distributorProxy.Revproxy.ModifyResponse = CortexPushRewrite429
-
 	log.Fatalf("terminated: %s", http.ListenAndServe(listenAddress, router))
-}
-
-/*
-Context: https://github.com/opstrace/opstrace/issues/464
-*/
-func CortexPushRewrite429(resp *http.Response) (err error) {
-	if strings.Contains(resp.Request.URL.Path, "/api/v1/push") {
-		if resp.StatusCode == 429 {
-			// Read original error message from (original) response body.
-			origBodyBytes, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				log.Warnf("CortexPushRewrite429: could not read resp body: %s", err)
-			}
-
-			// Now set new response status code, and tweak the error message.
-			// Note(JP): does the old resp.Body need to be close()d?
-			resp.StatusCode = 503
-			errmsg := fmt.Sprintf("429-to-503: %s", string(origBodyBytes))
-			bodybytes := []byte(errmsg)
-			resp.Body = ioutil.NopCloser(bytes.NewReader(bodybytes))
-			resp.ContentLength = int64(len(bodybytes))
-			resp.Header.Set("Content-Length", strconv.Itoa(len(bodybytes)))
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
When cortex is backing up (e.g. full distributor queues) it can return 500 errors.
If clients retry-loop on these errors, it can lead to nobody being able to catch up.

Note that this is separate from the existing 429->503 mapping, which stays as-is.

See also https://github.com/opstrace/opstrace/issues/1409

Signed-off-by: Nick Parker <nick@opstrace.com>