### PR TITLE
cli: dns service http client: work around err handling regression #1323 (includes: trigger-login-upon-401)

### DIFF
--- a/lib/dns/src/opstrace.ts
+++ b/lib/dns/src/opstrace.ts
@@ -40,8 +40,8 @@ const ID_TOKEN_FILE_PATH = "./id.jwt";
 
 // Use e.g. https://httpbin.org/status/500
 // for testing behavior upon 5xx.
-//const DNS_SERVICE_URL = "https://dns-api.opstrace.net/dns/";
-const DNS_SERVICE_URL = "http://httpbin.org/status/404";
+const DNS_SERVICE_URL = "https://dns-api.opstrace.net/dns/";
+//const DNS_SERVICE_URL = "http://httpbin.org/status/401";
 
 const OIDC_ISSUER = "https://opstrace-dev.us.auth0.com";
 const OIDC_CLIENT_ID = "fT9EPILybLT44hQl2xE7hK0eTuH1sb21";
@@ -389,9 +389,14 @@ export class DNSClient {
           // It's actually unlikely that a high-level retry will heal something
           // at this point, but maybe it does. Let's see, maybe it's better UX to
           // `die()`, here, too.
+          log.info(
+            "dns api: not an expected http error response, throw HighLevelRetry"
+          );
+
           throw new HighLevelRetry(`${action} failed`);
         }
 
+        log.info(`http err handler, throw: ${e.name} -- ${e.message}`);
         // Re-throw all other errors, such as JSON.parse() errors.
         throw e;
       }

--- a/lib/dns/src/opstrace.ts
+++ b/lib/dns/src/opstrace.ts
@@ -40,7 +40,8 @@ const ID_TOKEN_FILE_PATH = "./id.jwt";
 
 // Use e.g. https://httpbin.org/status/500
 // for testing behavior upon 5xx.
-const DNS_SERVICE_URL = "https://dns-api.opstrace.net/dns/";
+//const DNS_SERVICE_URL = "https://dns-api.opstrace.net/dns/";
+const DNS_SERVICE_URL = "http://httpbin.org/status/404";
 
 const OIDC_ISSUER = "https://opstrace-dev.us.auth0.com";
 const OIDC_CLIENT_ID = "fT9EPILybLT44hQl2xE7hK0eTuH1sb21";
@@ -64,6 +65,7 @@ async function loginPollRequest(
     },
     // Some HTTP error responses are expected. Do this handling work manually.
     throwHttpErrors: false
+    //responseType: "text"
   };
 
   const url = `${OIDC_ISSUER}/oauth/token`;
@@ -336,7 +338,9 @@ export class DNSClient {
         // Good response, no data in response.
         return undefined;
       } catch (e: any) {
-        if (e instanceof got.RequestError) {
+        // got.RequestError does not always work, therefore also
+        // make the HTTPError name check -- see issue #1323
+        if (e instanceof got.RequestError || e.name === "HTTPError") {
           debugLogHTTPResponse(e.response);
 
           // In the future, a DELETE may result in a 404 when the cluster isn't

--- a/yarn.lock
+++ b/yarn.lock
@@ -4742,10 +4742,10 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/faker@5.5.3":
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.3.tgz#80978e52862e5df9e7a96befdfdd8fad882f6350"
-  integrity sha512-InxkM6sCFQTI6YQl29M/XGlO19ecv/EHH5X5zLEFdge2/qya8oIT0XkJUKTqheVYWJtGi+FBAfP7hbbunDiOmg==
+"@types/faker@5.5.7":
+  version "5.5.7"
+  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.7.tgz#52aa3ad6ead3642b7c54e1e87e9e3ff5b10b3873"
+  integrity sha512-ejzb61Q5zQTtS0ZIafgQ7ahO5ACzmGhG5PfX2hxWyth3k0/aysb4ZOxKQB8DbzwSPppA5jmFBwqnBxjv5hqI5Q==
 
 "@types/file-saver@^2.0.2":
   version "2.0.2"


### PR DESCRIPTION
Tested with mock service and in real world, trigger-login-upon-401 works again, tested during `opstrace create ...`:
```
2021-09-24T14:36:28.353Z info: setting up DNS
2021-09-24T14:36:29.258Z warning: DNS service client:GET failed: Response code 401 (Unauthorized)
2021-09-24T14:36:29.259Z info: perform another login to refresh authentication state
2021-09-24T14:36:29.259Z info: initiate device code login against https://opstrace-dev.us.auth0.com
```
This workaround should fix #1323. It is pretty sad that I do not understand the exact nature of this error handling problem.

It is unclear how the regression entered the system.