### PR TITLE
chore: update hasura-cli/axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "**/**/lodash": "^4.17.19",
     "**/**/object-path": "^0.11.5",
     "**/**/serialize-javascript": "^3.1.0",
-    "**/**/yargs-parser": "^20.2.6"
+    "**/**/yargs-parser": "^20.2.6",
+    "**/app/hasura-cli/axios": "0.21.1"
   },
   "scripts": {
     "clean": "yarn wsrun -c clean && rimraf .cache tsconfig.tsbuildinfo",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6863,19 +6863,12 @@ axios-hooks@^2.6.3:
     dequal "2.0.2"
     lru-cache "6.0.0"
 
-axios@*, axios@^0.21.1:
+axios@*, axios@0.21.1, axios@^0.19.0, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
-
-axios@^0.19.0:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -9462,7 +9455,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -11636,13 +11629,6 @@ fn.name@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.2"


### PR DESCRIPTION
Forcing the `hasura-cli@1.3.3` dependency to use an updated `axios@0.21.1`, as it's required `axios@0.19.1` has the known vulnerability https://github.com/advisories/GHSA-4w2v-q235-vp99.

While this version of axios is technically out of [`hasura-cli@1.3.3` specified range](https://github.com/jjangga0214/hasura-cli/blob/v1.3.3/package.json#L94), this update should be safe, because:
1. The version bump [does NOT contain any breaking changes](https://github.com/axios/axios/blob/master/CHANGELOG.md).
1. [`axios` is NOT extensively used by `hasura-cli`](https://github.com/jjangga0214/hasura-cli/search?q=axios)

Though, this change should be seen as a hot fix. The proper way of achieving a safe version of `Hasura-cli/axios` would be to update `hasura-cli@1.3.3` to `hasura-cli@>2`, where this issue is fixed. Though there are [many breaking changes](https://github.com/hasura/graphql-engine/blob/master/CHANGELOG.md) to consider. See also https://github.com/opstrace/opstrace/issues/1302 regarding the update.

# Have you...

* [x] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
