### PR TITLE
ui: fix missing dependency

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -65,6 +65,7 @@
     "deep-diff": "^1.0.2",
     "deepmerge": "^4.2.2",
     "delay": "^4.4.0",
+    "dotenv-expand": "5.1.0",
     "dot-object": "^2.1.4",
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8317,6 +8317,11 @@ dot-prop@^5.1.0, dot-prop@^5.1.1, dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv-expand@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
 dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"


### PR DESCRIPTION
Signed-off-by: Mo Sattler <hi@mosattler.com>

We do rely on "dotenv-expand", e.g. [here](https://github.com/opstrace/opstrace/blame/f0fd22918137b6eb351d4b15113a9911270ce5e6/packages/app/config/webpack.server.config.js#L58).

Though, we never have added it to the dependency lists, and it merely worked because storybook was coincidently shipping with this dependency. So [removing storybook](https://github.com/opstrace/opstrace/pull/1432) broke this code. 

This PR adds `dotenv-expand` explicitly to the dependency lists and fixes the issue above.

# Have you...

* [x] Added an explanation of what your changes do?
