### PR TITLE
go authenticator: migrate to jwt lib v4

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,4 +1,14 @@
 
+# Run unit tests
+
+The unit tests manage Docker containers, i.e. the Docker daemon needs to be running.
+
+
+```
+cd go
+make unit-tests
+```
+
 # Cortex
 
 ## Test Cortex locally
@@ -50,11 +60,4 @@ Build and push container images with the following script:
 ```
 
 `packages/controller-config/src/docker-images.json` will be updated to refer to newly built images.
-
-
-Build the controller to use the new configuration:
-
-```bash
-make dependencies
-```
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/Microsoft/hcsshim v0.8.22 // indirect
 	github.com/containerd/containerd v1.5.6 // indirect
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docker/docker v20.10.8+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.2
 	github.com/google/uuid v1.3.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -254,7 +254,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
@@ -346,6 +345,8 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.1.0 h1:XUgk2Ex5veyVFVeLm0xhusUTQybEbexJXrvPNOKkSY0=
+github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/go/pkg/authenticator/jwt.go
+++ b/go/pkg/authenticator/jwt.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/go/pkg/authenticator/jwt.go
+++ b/go/pkg/authenticator/jwt.go
@@ -33,7 +33,7 @@ func validateAuthTokenGetTenantName(authTokenUnverified string) (string, error) 
 	// set of standard claims to be present (`sub`, `iss` and the likes), and
 	// custom claims to not be present.
 	tokenstruct, veriferr := jwt.ParseWithClaims(
-		authTokenUnverified, &jwt.StandardClaims{}, keyLookupCallback)
+		authTokenUnverified, &jwt.RegisteredClaims{}, keyLookupCallback)
 
 	if veriferr != nil {
 		log.Infof("jwt verification failed: %s", veriferr)
@@ -52,8 +52,8 @@ func validateAuthTokenGetTenantName(authTokenUnverified string) (string, error) 
 		return "", fmt.Errorf("bad authentication token")
 	}
 
-	// https://godoc.org/github.com/dgrijalva/jwt-go#StandardClaims
-	claims := tokenstruct.Claims.(*jwt.StandardClaims)
+	// https://pkg.go.dev/github.com/golang-jwt/jwt/v4#RegisteredClaims
+	claims := tokenstruct.Claims.(*jwt.RegisteredClaims)
 	// log.Infof("claims: %+v", claims)
 
 	// Custom convention: encode Opstrace tenant name in subject, expect

--- a/go/pkg/authenticator/keyset_test.go
+++ b/go/pkg/authenticator/keyset_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestKeysetFromEnv_TwoKeys(t *testing.T) {
-	os.Setenv("API_AUTHTOKEN_VERIFICATION_PUBKEY_SET", TestKeysetEnvValTwoPubkeys)
+	os.Setenv("API_AUTHTOKEN_VERIFICATION_PUBKEY_SET", TestKeysetEnvValThreePubkeys)
 
 	log.Infof("keyset map:\n%v", authtokenVerificationPubKeys)
 	log.Infof("fallback key:\n%v", authtokenVerificationPubKeyFallback)

--- a/go/pkg/authenticator/testresources.go
+++ b/go/pkg/authenticator/testresources.go
@@ -14,12 +14,22 @@
 
 package authenticator
 
+// Note that the private key corresponding to the third public key
+// (with ID 624bd0...) was used to sign the token stored as
+// `TenantAPITokenForKey624` below.
 //nolint:lll // ignore long lines
-const TestKeysetEnvValTwoPubkeys = `
+const TestKeysetEnvValThreePubkeys = `
 {
 	"0773cd2a09713115bca465a5b12171cab7aecfe5": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytbw9TvWedKzygbivO8t\n/6ZNT6uZxPAhNGITamwdgppvyf+7aHECHHAYgiqdI2bBRe8m+0+cHUceOwziewr7\nEClawdC61qGLp6Lw17nf8yM08ALSyAR976NCgCDFZ9Zxl5AAlfiyez88MFyjzXWC\nLmHWH02f9rs52PkYteXdhHe2nMvPNVKgWm1UUhEf80lFrFB51p7EkPmT8TW2lZ9p\nq2SnXQLi555ffaxOMos5tLx/Dji79q1Js5RzYCqrv0l+Wnr4IkSqYKSLrFnC/1ek\nAgM0R6DMFYRHGNnwGhNELPhd4DQKRUdNhEu0SLy0qSPpoTDpwgvXpcmOjUIUmRZU\nrwIDAQAB\n-----END PUBLIC KEY-----",
-	"df99d68cf04b53c2697e4b537d6236a7a1ee79e9": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtJRlJmDqKfCO513D3pwV\n39VZh00MidESK0IQr6NQrG4DgL5H67VHuGZb4utdygQqqLxE6+cJfTi79Tlr7dmH\nWlgOxJ0swQLmjOgVAV4rowoYHj/L6dpFZzIseqwcqi5Rt4fyQm3FyMOCHX+mIRp6\ns1yV6/TfCe1OTz8ueS9WaSOROhtfv4Lh+DH2jwclT6PEEQtQjdBqxdlhFhptyWZf\nUldIEIwX1Cf8PrJpbUXNC7Vyr+iWC765hXwMq5w33jAS+s6E2QBs0UDUSp4Hgo1n\n53h7nGazgse5s6lCBddeclvOhEIWYRn4CXAbZsNntwOwveehou1l4RykMN34lNip\nDwIDAQAB\n-----END PUBLIC KEY-----"
+	"df99d68cf04b53c2697e4b537d6236a7a1ee79e9": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtJRlJmDqKfCO513D3pwV\n39VZh00MidESK0IQr6NQrG4DgL5H67VHuGZb4utdygQqqLxE6+cJfTi79Tlr7dmH\nWlgOxJ0swQLmjOgVAV4rowoYHj/L6dpFZzIseqwcqi5Rt4fyQm3FyMOCHX+mIRp6\ns1yV6/TfCe1OTz8ueS9WaSOROhtfv4Lh+DH2jwclT6PEEQtQjdBqxdlhFhptyWZf\nUldIEIwX1Cf8PrJpbUXNC7Vyr+iWC765hXwMq5w33jAS+s6E2QBs0UDUSp4Hgo1n\n53h7nGazgse5s6lCBddeclvOhEIWYRn4CXAbZsNntwOwveehou1l4RykMN34lNip\nDwIDAQAB\n-----END PUBLIC KEY-----",
+	"624bd05d77efb13d9d1ed923baef5483b5e07933": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvdiYGI2880F3leaGWMw1\nhaXKL7kMA1JJn5zylkQeMK1pmy/DzcX+WyPDlgFJTJVDCt+geEIqMQg1TKdu+uYF\nAdt5Lsya6SuWLbGJQS5V8Hd6t9eFILvbI5gyR22Jbd3khtuLkkVVpFJVq5Qyh/6W\ngHaTyzfYRKrMK2OZNw3GtXj9VOXNYOclO38F5/hd3wroILGyBD9/SSs0EMujNE56\nKZF4IEFrXGxXbqM9x47q/JNFR2/ABD+A49ahVH7YHNXdzdtNanJ6eWOJhGPCDpgv\n4gO+zilBMdZtY1HmhUMAOwU0slrj9jCd/gYwwR5E1TkLzvuu8ssPX3U31okMuEnC\nUwIDAQAB\n-----END PUBLIC KEY-----"
 }`
 
 //nolint:lll // ignore long lines
 const TestPubKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtJRlJmDqKfCO513D3pwV\n39VZh00MidESK0IQr6NQrG4DgL5H67VHuGZb4utdygQqqLxE6+cJfTi79Tlr7dmH\nWlgOxJ0swQLmjOgVAV4rowoYHj/L6dpFZzIseqwcqi5Rt4fyQm3FyMOCHX+mIRp6\ns1yV6/TfCe1OTz8ueS9WaSOROhtfv4Lh+DH2jwclT6PEEQtQjdBqxdlhFhptyWZf\nUldIEIwX1Cf8PrJpbUXNC7Vyr+iWC765hXwMq5w33jAS+s6E2QBs0UDUSp4Hgo1n\n53h7nGazgse5s6lCBddeclvOhEIWYRn4CXAbZsNntwOwveehou1l4RykMN34lNip\nDwIDAQAB\n-----END PUBLIC KEY-----"
+
+// Tenant API token created with
+//	./build/bin/opstrace ta-create-token instancename tenantfoo keypair.pem
+// Expires Oct 02, 2031
+//nolint:lll,gosec // ignore long lines
+const TenantAPITokenForKey624 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjYyNGJkMDVkNzdlZmIxM2Q5ZDFlZDkyM2JhZWY1NDgzYjVlMDc5MzMifQ.eyJpYXQiOjE2MzMwODg0NTEsImV4cCI6MTk0ODY2NDQ1MSwiYXVkIjoib3BzdHJhY2UtY2x1c3Rlci1pbnN0YW5jZW5hbWUiLCJpc3MiOiJvcHN0cmFjZS1jbGkiLCJzdWIiOiJ0ZW5hbnQtdGVuYW50Zm9vIn0.vKHxvp_W_0HdZ6dxE6zJsrdFp8XdZrNprjyaAONOXmjps635CH3YQdv3vy6oPg7leGgjXEg0THRlmmn9pABRpeK71Yi_5ooU11-mbLKsKdPsu7ffvIGqhMhu_2fVXMOqTt4E_6zNlwkc2mwxRD4o4uH0o7RIErAPEaIUVnmp3LcvHKVU83yxamz8OXbFI1SfvxXYrPVGnUFFhxtRLwROgfts7cPO69hrn3mVHSUgrPuNbiSTa2UlLZas7Od1nfbguFXQTu880oo_72DgK1yEwMnCHb6IUJF8VNVGjv_j049gBBRpRCLSUXcZfJR7CVF-Lk_aKCRKFH4sZy_xyjUXtw"


### PR DESCRIPTION
from https://github.com/dgrijalva/jwt-go to https://github.com/golang-jwt/jwt
https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md

Added tests for more confidence that this does not introduce an embarrassing security regression.