### PR TITLE
chore: bump grafana to 8.1.6

### DIFF
--- a/packages/controller-config/src/docker-images.json
+++ b/packages/controller-config/src/docker-images.json
@@ -14,7 +14,7 @@
   "exporterStackdriver": "prometheuscommunity/stackdriver-exporter:v0.11.0",
   "externalDNS": "k8s.gcr.io/external-dns/external-dns:v0.7.4",
   "systemlogFluentd": "opstrace/systemlog-fluentd:4a532c5a-dev",
-  "grafana": "grafana/grafana:8.1.3-ubuntu",
+  "grafana": "grafana/grafana:8.1.6-ubuntu",
   "kubeRBACProxy": "quay.io/brancz/kube-rbac-proxy:v0.8.0",
   "kubeStateMetrics": "quay.io/coreos/kube-state-metrics:v1.7.2",
   "localVolumeProvisioner": "quay.io/external_storage/local-volume-provisioner:v2.2.0",


### PR DESCRIPTION
* Address CVE-2021-39226 Snapshot authentication bypass
* https://grafana.com/blog/2021/10/05/grafana-7.5.11-and-8.1.6-released-with-critical-security-fix/

Signed-off-by: ajayk <ajaykemparaj@gmail.com>

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [x] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
