### PR TITLE
chore: AWS custom DNS name

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,27 +70,27 @@ steps:
       - bash ci/check-if-docs-pr.sh || make ci-deploy-testremote-teardown
     artifact_paths:
       - "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-a/bk-artifacts/**/*"
-  - label: "🔨 test upgrades (GCP)"
-    key: "testupgrades-gcp"
-    depends_on:
-      - "unit-tests"
-    env:
-      # Fetch the latest Opstrace CLI release artifact and use that as the
-      # initial cluster version.
-      OPSTRACE_CLI_VERSION_FROM: https://go.otr.dev/cli-latest-release-linux
-      # Use the Opstrace CLI artifact built from the PR branch to upgrade the
-      # cluster.
-      OPSTRACE_CLI_VERSION_TO: ${OPSTRACE_PREBUILD_DIR}/build/bin/opstrace
-      OPSTRACE_CLUSTER_NAME: "${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug"
-      OPSTRACE_BUILD_DIR: "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug"
-      OPSTRACE_ARTIFACT_DIR: "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug/bk-artifacts"
-      OPSTRACE_CLOUD_PROVIDER: "gcp"
-      GCLOUD_CLI_REGION: "us-west2"
-      GCLOUD_CLI_ZONE: "us-west2-a"
-    command:
-      - bash ci/check-if-docs-pr.sh || make ci-test-upgrade-run-sh
-    artifact_paths:
-      - "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug/bk-artifacts/**/*"
+  # - label: "🔨 test upgrades (GCP)"
+  #   key: "testupgrades-gcp"
+  #   depends_on:
+  #     - "unit-tests"
+  #   env:
+  #     # Fetch the latest Opstrace CLI release artifact and use that as the
+  #     # initial cluster version.
+  #     OPSTRACE_CLI_VERSION_FROM: https://go.otr.dev/cli-latest-release-linux
+  #     # Use the Opstrace CLI artifact built from the PR branch to upgrade the
+  #     # cluster.
+  #     OPSTRACE_CLI_VERSION_TO: ${OPSTRACE_PREBUILD_DIR}/build/bin/opstrace
+  #     OPSTRACE_CLUSTER_NAME: "${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug"
+  #     OPSTRACE_BUILD_DIR: "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug"
+  #     OPSTRACE_ARTIFACT_DIR: "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug/bk-artifacts"
+  #     OPSTRACE_CLOUD_PROVIDER: "gcp"
+  #     GCLOUD_CLI_REGION: "us-west2"
+  #     GCLOUD_CLI_ZONE: "us-west2-a"
+  #   command:
+  #     - bash ci/check-if-docs-pr.sh || make ci-test-upgrade-run-sh
+  #   artifact_paths:
+  #     - "/tmp/builddir-${BUILDKITE_PIPELINE_SLUG:0:7}-bk-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:3}-ug/bk-artifacts/**/*"
   - label: "🔨 cleanup /tmp"
     key: "cleanup-tmp"
     depends_on:

--- a/packages/cli/src/schemas.ts
+++ b/packages/cli/src/schemas.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import {
-  LatestAWSInfraConfigType,
-  LatestGCPInfraConfigType
-} from "@opstrace/config";
-import { die, log } from "@opstrace/utils";
+// import {
+//   LatestAWSInfraConfigType,
+//   LatestGCPInfraConfigType
+// } from "@opstrace/config";
+// import { die, log } from "@opstrace/utils";
 
-import {
-  ClusterConfigFileSchemaTypeV1,
-  ClusterConfigFileSchemaV1
-} from "./schemasv1";
+// import {
+//   ClusterConfigFileSchemaTypeV1,
+//   ClusterConfigFileSchemaV1
+// } from "./schemasv1";
 
 import {
   AWSInfraConfigSchemaV2,
@@ -44,93 +44,3 @@ export const LatestRenderedClusterConfigSchema = RenderedClusterConfigSchemaV2;
 export type LatestRenderedClusterConfigSchemaType =
   RenderedClusterConfigSchemaTypeV2;
 export type LatestClusterConfigFileSchemaType = ClusterConfigFileSchemaTypeV2;
-
-// upgrade function
-function V1toV2(
-  ucc: ClusterConfigFileSchemaTypeV1
-): ClusterConfigFileSchemaTypeV2 {
-  const { log_retention, metric_retention, ...restConfig } = ucc;
-  return {
-    ...restConfig,
-    log_retention_days: log_retention,
-    metric_retention_days: metric_retention
-  };
-}
-
-// function that takes any user cluster config and upgrades it to the latest
-// version if necessary.
-export function upgradeToLatest(
-  ucc: any,
-  cloudProvider: string
-): [
-  LatestClusterConfigFileSchemaType,
-  LatestAWSInfraConfigType | undefined,
-  LatestGCPInfraConfigType | undefined
-] {
-  // handle user cluster config
-  const uccWithDefaults = upgradeClusterConfigSchemaToLatest(ucc);
-
-  // handle user cloud provider config
-  let infraConfigAWS: LatestAWSInfraConfigType | undefined;
-  let infraConfigGCP: LatestGCPInfraConfigType | undefined;
-
-  switch (cloudProvider) {
-    case "aws": {
-      infraConfigAWS = upgradeAWSInfraConfigToLatest(uccWithDefaults.aws);
-      break;
-    }
-    case "gcp": {
-      infraConfigGCP = upgradeGCPInfraConfigToLatest(uccWithDefaults.gcp);
-      break;
-    }
-
-    default: {
-      die(`cloud provider not supported: ${cloudProvider}`);
-    }
-  }
-
-  // provider-specific infra config has been extracted, remove all traces
-  // from ucc
-  delete uccWithDefaults.aws;
-  delete uccWithDefaults.gcp;
-
-  return [uccWithDefaults, infraConfigAWS, infraConfigGCP];
-}
-
-function upgradeClusterConfigSchemaToLatest(
-  ucc: any
-): LatestClusterConfigFileSchemaType {
-  if (LatestClusterConfigFileSchema.isValidSync(ucc, { strict: true })) {
-    // validate again, this time "only" to interpolate with defaults, see
-    // https://github.com/jquense/yup/pull/961
-    log.debug("got latest cluster config file version");
-    return LatestClusterConfigFileSchema.validateSync(ucc);
-  }
-
-  if (ClusterConfigFileSchemaV1.isValidSync(ucc, { strict: true })) {
-    log.debug("got v1 cluster config file, upgrading...");
-    return V1toV2(ClusterConfigFileSchemaV1.validateSync(ucc));
-  }
-
-  // Possible user error. Parse again and it'll throw a meaningful error
-  // message.
-  return LatestClusterConfigFileSchema.validateSync(ucc, { strict: true });
-}
-
-// throws an error when parsing invalid data
-function upgradeAWSInfraConfigToLatest(uic: any): LatestAWSInfraConfigType {
-  // AWSInfraConfigTypeV1 matches AWSInfraConfigTypeV2 so we don't need to do
-  // any validation
-
-  log.debug("ucc.aws: %s", JSON.stringify(uic, null, 2));
-  return LatestAWSInfraConfigSchema.validateSync(uic);
-}
-
-// throws an error when parsing invalid data
-function upgradeGCPInfraConfigToLatest(uic: any): LatestGCPInfraConfigType {
-  // GCPInfraConfigTypeV1 matches GCPInfraConfigTypeV2 so we don't need to do
-  // any validation
-
-  log.debug("ucc.gcp: %s", JSON.stringify(uic, null, 2));
-  return LatestGCPInfraConfigSchema.validateSync(uic);
-}

--- a/packages/cli/src/schemasv2.test.ts
+++ b/packages/cli/src/schemasv2.test.ts
@@ -27,6 +27,9 @@ describe("ClusterConfigFileSchemaV2", () => {
     metric_retention_days: 7,
     data_api_authentication_disabled: true,
     data_api_authorized_ip_ranges: ["0.0.0.0/0"],
+    custom_dns_name: "foo",
+    custom_auth0_domain: "bar",
+    custom_auth0_client_id: "foobar",
     aws: {},
     gcp: {},
     ...overwrite

--- a/packages/cli/src/schemasv2.ts
+++ b/packages/cli/src/schemasv2.ts
@@ -81,10 +81,14 @@ export const ClusterConfigFileSchemaV2 = yup
     env_label: yup.string(),
 
     // Added later to V2, but is an optional parameter, therefore not strictly
-    // justifying a new schema version. Content and name need to be iterated on.
-    custom_dns_name: yup.string().notRequired(),
-    custom_auth0_client_id: yup.string().notRequired(),
-    custom_auth0_domain: yup.string().notRequired(),
+    // justifying a new schema version. Content and name need to be iterated
+    // on.
+    // Note(JP, Nov 2021): these are now required. This certainly requires
+    // user interaction, an automatic migration is not possible. Therefore
+    // adding this pragmatically to V2.
+    custom_dns_name: yup.string().required().min(1),
+    custom_auth0_client_id: yup.string().required().min(1),
+    custom_auth0_domain: yup.string().required().min(1),
 
     cert_issuer: yup
       .string()

--- a/packages/config/src/clusterconfigv2.ts
+++ b/packages/config/src/clusterconfigv2.ts
@@ -45,7 +45,7 @@ export interface ClusterConfigTypeV2 {
   node_count: number; // bigint to force this to integer?
   aws: AWSInfraConfigTypeV2 | undefined;
   gcp: GCPInfraConfigTypeV2 | undefined;
-  custom_dns_name?: string;
-  custom_auth0_client_id?: string;
-  custom_auth0_domain?: string;
+  custom_dns_name: string;
+  custom_auth0_client_id: string;
+  custom_auth0_domain: string;
 }

--- a/packages/controller/src/resources/app/app.ts
+++ b/packages/controller/src/resources/app/app.ts
@@ -49,15 +49,10 @@ export function OpstraceApplicationResources(
   // issue? Well, have a read. And maybe keep this
   // comment here :-).
 
-  // This is the Auth0 client ID corresponding to opstrace-dev.us.auth0.com,
-  // preconfigured for the Opstrace DNS infrastructure behind *.opstrace.io.
-  let auth0_client_id = "vs6bgTunbVK4dvdLRj02DptWjOmAVWVM";
-  let auth0_domain = "opstrace-dev.us.auth0.com";
-  if (custom_auth0_client_id !== undefined) {
-    assert(custom_auth0_domain);
-    auth0_client_id = custom_auth0_client_id;
-    auth0_domain = custom_auth0_domain;
-  }
+  assert(custom_auth0_domain);
+  assert(custom_auth0_client_id);
+  const auth0_client_id = custom_auth0_client_id;
+  const auth0_domain = custom_auth0_domain;
 
   collection.add(
     new Namespace(

--- a/packages/installer/src/gcp.ts
+++ b/packages/installer/src/gcp.ts
@@ -32,14 +32,9 @@ import {
   setCortexServiceAccount,
   setLokiServiceAccount
 } from "@opstrace/gcp";
-import { ensureDNSExists } from "@opstrace/dns";
-import {
-  getGKEClusterConfig,
-  getDnsConfig,
-  getCloudSQLConfig
-} from "@opstrace/config";
+import { getGKEClusterConfig, getCloudSQLConfig } from "@opstrace/config";
 import { GCPAuthOptions } from "@opstrace/gcp";
-import { getBucketName, log, SECOND } from "@opstrace/utils";
+import { die, getBucketName, log, SECOND } from "@opstrace/utils";
 import {
   getClusterConfig,
   //RenderedClusterConfigSchemaType
@@ -58,18 +53,12 @@ export function* ensureGCPInfraExists(
     throw Error("`gcp` property expected");
   }
 
-  if (ccfg.custom_dns_name === undefined) {
-    const dnsConf = getDnsConfig(ccfg.cloud_provider);
-    const dnsname = yield call(ensureDNSExists, {
-      opstraceClusterName: ccfg.cluster_name,
-      dnsName: dnsConf.dnsName,
-      target: ccfg.cloud_provider,
-      dnsProvider: ccfg.cloud_provider
-    });
+  if (!ccfg.custom_dns_name) {
+    die("custom_dns_name is not set");
+  }
 
-    log.info("DNS name has been set up: %s", dnsname);
-  } else {
-    log.info("skip DNS setup, custom DNS name set");
+  if (!ccfg.custom_auth0_client_id || !ccfg.custom_auth0_domain) {
+    die("custom_dns_name and custom_auth0_domain are not set");
   }
 
   const gkeConf = getGKEClusterConfig(ccfg, gcpAuthOptions);

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -366,7 +366,7 @@ function* createClusterCore() {
   //   );
   // }
 
-  const opstraceInstanceDNSname = instanceDNSNameFromClusterConfig(ccfg);
+  const opstraceInstanceDNSname = ccfg.custom_dns_name;
   log.info(
     "expected DNS name for this Opstrace instance: %s",
     opstraceInstanceDNSname
@@ -382,7 +382,7 @@ function* createClusterCore() {
 
 export function instanceDNSNameFromClusterConfig(
   ccfg: LatestClusterConfigType
-) {
+): string {
   let opstraceInstanceDNSname = `${ccfg.cluster_name}.opstrace.io`;
   if (ccfg.custom_dns_name !== undefined) {
     opstraceInstanceDNSname = ccfg.custom_dns_name;

--- a/packages/uninstaller/src/index.ts
+++ b/packages/uninstaller/src/index.ts
@@ -37,8 +37,6 @@ import { setAWSRegion, getEKSKubeconfig } from "@opstrace/aws";
 
 import { log, SECOND, retryUponAnyError, sleep } from "@opstrace/utils";
 
-import { DNSClient } from "@opstrace/dns";
-
 import {
   CONTROLLER_NAME,
   set as saveControllerConfig,
@@ -118,21 +116,6 @@ function* destroyClusterCore(): Generator<Effect, void, any> {
 
   if (kubeconfig) {
     yield call(triggerk8sTeardown, kubeconfig);
-  }
-
-  // First, try to determine if the  DNS name <instance_name>.opstrace.io
-  // exists for this Opstrace instance name (it may not when it was set up with
-  // a custom DNS name, which we are trying to find out here); and then attempt
-  // DNS service entry deletion (which may fail after login, when it turns out
-  // that <instance_name>.opstrace.io belongs to someone else, see #861 for
-  // trade-off discussion). Note(JP): for manually preventing false positives,
-  // maybe add a flag --skip-dns-service-login
-  if (yield call(doesOpstraceIoDNSNameExist, destroyConfig.clusterName)) {
-    const opstraceClient = yield call([DNSClient, DNSClient.getInstance]);
-    yield call(
-      [opstraceClient, opstraceClient.delete],
-      destroyConfig.clusterName
-    );
   }
 
   if (destroyConfig.cloudProvider === "gcp") {

--- a/packages/upgrader/src/upgrade.ts
+++ b/packages/upgrader/src/upgrade.ts
@@ -219,6 +219,14 @@ export function* upgradeControllerConfigMap(
     cfg.custom_auth0_client_id = ucc.custom_auth0_client_id;
     cfg.custom_auth0_domain = ucc.custom_auth0_domain;
   }
+  // custom_dns_name was introduced to be able to move instances to a new domain
+  // name
+  if (ucc.custom_dns_name) {
+    log.info(
+      `new controller config: set custom_dns_name to ${ucc.custom_dns_name}`
+    );
+    cfg.custom_dns_name = ucc.custom_dns_name;
+  }
 
   log.info(`upgraded controller config:\n${JSON.stringify(cfg, null, 2)}`);
 


### PR DESCRIPTION
Changelog of changes in the branch:

* Require the `custom_dns_name`, `custom_auth0_client_id`, and `custom_auth0_domain` parameters to be set when creating/upgrading an instance.
* Change AWS CI job to use a custom DNS name in the `opstraceaws.com` root domain.
* Create a hosted zone in Route53 for the new instance.
* Add an NS entry in the opstraceaws.com root zone for the new instance hosted zone.
* On teardown, delete the instance hosted zone and remove the NS entry in the `opstraceaws.com` root zone.
* Disables upgrade tests in CI PR pipeline because it does not support running with a custom domain name. 

**NOTE**
*After merging the PR, we need to disable the scheduled upgrade tests because that pipeline does not support custom domain names.* 